### PR TITLE
feat(shared): add cross-package types and zod schemas

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,14 +16,15 @@
   "packageManager": "pnpm@10.0.0",
   "scripts": {
     "dev": "pnpm --filter @opentrad/desktop dev",
-    "build": "pnpm -r build",
+    "build": "pnpm -r --if-present build",
     "lint": "biome check .",
     "format": "biome format --write .",
-    "typecheck": "pnpm -r typecheck",
-    "test": "pnpm -r test"
+    "typecheck": "pnpm -r --if-present typecheck",
+    "test": "pnpm -r --if-present test"
   },
   "devDependencies": {
     "@biomejs/biome": "^2.0.0",
-    "typescript": "^5.5.0"
+    "typescript": "^5.5.0",
+    "vitest": "^4.1.5"
   }
 }

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -6,6 +6,10 @@
   "main": "./src/index.ts",
   "types": "./src/index.ts",
   "scripts": {
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run"
+  },
+  "dependencies": {
+    "zod": "^4.3.6"
   }
 }

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -1,2 +1,8 @@
-// 占位，共享类型与常量在 Issue #3 填充
-export {};
+// @opentrad/shared 入口：统一 re-export 所有跨包共享的类型与 zod schema。
+// 消费方示例：`import { CCEvent, SkillManifest } from '@opentrad/shared';`
+
+export * from "./types/cc-event";
+export * from "./types/cc-task";
+export * from "./types/ipc";
+export * from "./types/risk-gate";
+export * from "./types/skill";

--- a/packages/shared/src/types/cc-event.ts
+++ b/packages/shared/src/types/cc-event.ts
@@ -1,0 +1,79 @@
+// CC stream-json 事件的 discriminated union。
+// 对应 03-architecture.md §4.2：StreamParser 输出、UI 消费的标准事件形态。
+
+import { z } from "zod";
+
+// MCP server 在 system/init 事件里的信息。字段结构随 CC 版本可能差异，用 passthrough 容错。
+export const McpServerInfoSchema = z
+  .object({
+    name: z.string(),
+  })
+  .passthrough();
+
+export type McpServerInfo = z.infer<typeof McpServerInfoSchema>;
+
+// system/init 事件携带的完整会话上下文。
+export const SystemInitDataSchema = z.object({
+  sessionId: z.string(),
+  tools: z.array(z.string()),
+  mcpServers: z.array(McpServerInfoSchema),
+  model: z.string(),
+  permissionMode: z.string(),
+  claudeCodeVersion: z.string(),
+  apiKeySource: z.enum(["subscription", "api_key", "bedrock", "vertex"]),
+});
+
+export type SystemInitData = z.infer<typeof SystemInitDataSchema>;
+
+// assistant 事件内部的文本块或思考块。
+export const AssistantContentSchema = z.discriminatedUnion("type", [
+  z.object({ type: z.literal("text"), text: z.string() }),
+  z.object({ type: z.literal("thinking"), thinking: z.string() }),
+]);
+
+export type AssistantContent = z.infer<typeof AssistantContentSchema>;
+
+// result 事件的 data。字段细节待 Issue #4（stream-parser）结合真实样本细化。
+export const ResultDataSchema = z.object({}).passthrough();
+
+export type ResultData = z.infer<typeof ResultDataSchema>;
+
+// rate_limit_event 的 rateLimitInfo。字段同样待 Issue #4 细化。
+export const RateLimitInfoSchema = z.object({}).passthrough();
+
+export type RateLimitInfo = z.infer<typeof RateLimitInfoSchema>;
+
+// CC stream-json 全部事件的 discriminated union。
+// unknown 变体用于吸收未知 type 的事件（避免因 CC 版本差异而丢数据）。
+export const CCEventSchema = z.discriminatedUnion("type", [
+  z.object({
+    type: z.literal("system"),
+    subtype: z.literal("init"),
+    data: SystemInitDataSchema,
+  }),
+  z.object({ type: z.literal("assistant"), content: AssistantContentSchema }),
+  z.object({
+    type: z.literal("tool_use"),
+    toolUseId: z.string(),
+    name: z.string(),
+    input: z.unknown(),
+  }),
+  z.object({
+    type: z.literal("tool_result"),
+    toolUseId: z.string(),
+    content: z.unknown(),
+    isError: z.boolean().optional(),
+  }),
+  z.object({
+    type: z.literal("result"),
+    subtype: z.enum(["success", "error"]),
+    data: ResultDataSchema,
+  }),
+  z.object({
+    type: z.literal("rate_limit_event"),
+    rateLimitInfo: RateLimitInfoSchema,
+  }),
+  z.object({ type: z.literal("unknown"), raw: z.unknown() }),
+]);
+
+export type CCEvent = z.infer<typeof CCEventSchema>;

--- a/packages/shared/src/types/cc-event.ts
+++ b/packages/shared/src/types/cc-event.ts
@@ -4,6 +4,7 @@
 import { z } from "zod";
 
 // MCP server 在 system/init 事件里的信息。字段结构随 CC 版本可能差异，用 passthrough 容错。
+// TODO(issue-4): tighten schema after real sample
 export const McpServerInfoSchema = z
   .object({
     name: z.string(),
@@ -34,11 +35,13 @@ export const AssistantContentSchema = z.discriminatedUnion("type", [
 export type AssistantContent = z.infer<typeof AssistantContentSchema>;
 
 // result 事件的 data。字段细节待 Issue #4（stream-parser）结合真实样本细化。
+// TODO(issue-4): tighten schema after real sample
 export const ResultDataSchema = z.object({}).passthrough();
 
 export type ResultData = z.infer<typeof ResultDataSchema>;
 
 // rate_limit_event 的 rateLimitInfo。字段同样待 Issue #4 细化。
+// TODO(issue-4): tighten schema after real sample
 export const RateLimitInfoSchema = z.object({}).passthrough();
 
 export type RateLimitInfo = z.infer<typeof RateLimitInfoSchema>;

--- a/packages/shared/src/types/cc-task.ts
+++ b/packages/shared/src/types/cc-task.ts
@@ -29,11 +29,11 @@ export interface CCTaskHandle {
 }
 
 // 任务最终结果。架构文档未直列字段，这里按 result 事件 + 元信息合理补全：
-// 以 sessionId 关联、status 区分成功失败、data 透传 result 事件原 payload、
-// exitCode 记录子进程退出码（便于上层判断是否异常退出）。
+// 以 sessionId 关联、status 三值 union（success/error/cancelled）便于上层做类型保护、
+// data 透传 result 事件原 payload、exitCode 记录子进程退出码（便于判断异常退出）。
 export const CCResultSchema = z.object({
   sessionId: z.string(),
-  status: z.enum(["success", "error"]),
+  status: z.enum(["success", "error", "cancelled"]),
   data: ResultDataSchema,
   exitCode: z.number().int(),
 });

--- a/packages/shared/src/types/cc-task.ts
+++ b/packages/shared/src/types/cc-task.ts
@@ -1,0 +1,41 @@
+// CC 子进程任务的选项、handle、结果。对应 03-architecture.md §4.1。
+
+import { z } from "zod";
+import type { CCEvent } from "./cc-event";
+import { ResultDataSchema } from "./cc-event";
+
+// spawn 一个 CC 子进程所需的参数。
+export const CCTaskOptionsSchema = z.object({
+  sessionId: z.string(),
+  prompt: z.string(),
+  mcpConfigPath: z.string(),
+  allowedTools: z.array(z.string()),
+  cwd: z.string().optional(),
+  model: z.enum(["default", "haiku", "sonnet", "opus"]).optional(),
+  permissionMode: z.enum(["default", "acceptEdits", "bypassPermissions"]).optional(),
+  resume: z.boolean().optional(),
+});
+
+export type CCTaskOptions = z.infer<typeof CCTaskOptionsSchema>;
+
+// CCManager.startTask() 返回的运行时 handle。
+// 包含流式事件和控制方法——函数签名无法用 zod 校验，保留纯 TS interface。
+export interface CCTaskHandle {
+  sessionId: string;
+  pid: number;
+  events: AsyncIterable<CCEvent>;
+  cancel(): Promise<void>;
+  result(): Promise<CCResult>;
+}
+
+// 任务最终结果。架构文档未直列字段，这里按 result 事件 + 元信息合理补全：
+// 以 sessionId 关联、status 区分成功失败、data 透传 result 事件原 payload、
+// exitCode 记录子进程退出码（便于上层判断是否异常退出）。
+export const CCResultSchema = z.object({
+  sessionId: z.string(),
+  status: z.enum(["success", "error"]),
+  data: ResultDataSchema,
+  exitCode: z.number().int(),
+});
+
+export type CCResult = z.infer<typeof CCResultSchema>;

--- a/packages/shared/src/types/ipc.ts
+++ b/packages/shared/src/types/ipc.ts
@@ -51,6 +51,8 @@ export type CCCancelTaskRequest = z.infer<typeof CCCancelTaskRequestSchema>;
 
 // -------- cc:status（双向） --------
 // email 是脱敏后的字符串（如 "u***@example.com"），按 03-architecture.md §4.1 F1.3 规定。
+// error 用于 CC 检测失败时告诉 Renderer 出了什么事（如"claude binary not found"
+// 或"auth status command timeout"），UI 层可直接展示给用户。
 
 export const CCStatusSchema = z.object({
   installed: z.boolean(),
@@ -58,6 +60,7 @@ export const CCStatusSchema = z.object({
   loggedIn: z.boolean().optional(),
   email: z.string().optional(),
   authMethod: z.enum(["subscription", "api_key"]).optional(),
+  error: z.string().optional(),
 });
 
 export type CCStatus = z.infer<typeof CCStatusSchema>;

--- a/packages/shared/src/types/ipc.ts
+++ b/packages/shared/src/types/ipc.ts
@@ -1,0 +1,119 @@
+// Electron Main ↔ Renderer IPC 协议。对应 03-architecture.md §3。
+// 原则：Renderer 永不直接 spawn CC，只通过 IPC 请求；Main 负责全部子进程管理。
+
+import { z } from "zod";
+
+// -------- Channel 名常量（避免字符串硬编码） --------
+
+export const IpcChannels = {
+  CCStartTask: "cc:start-task",
+  CCCancelTask: "cc:cancel-task",
+  CCEvent: "cc:event",
+  CCStatus: "cc:status",
+  SkillList: "skill:list",
+  SkillInstall: "skill:install",
+  SessionList: "session:list",
+  SessionResume: "session:resume",
+  RiskGateConfirm: "risk-gate:confirm",
+  RiskGateResponse: "risk-gate:response",
+  SettingsGet: "settings:get",
+  SettingsSet: "settings:set",
+} as const;
+
+export type IpcChannel = (typeof IpcChannels)[keyof typeof IpcChannels];
+
+// -------- cc:start-task（Renderer → Main） --------
+// Renderer 提供 skillId 和表单填值，Main 内部 compose prompt / 生成 mcp-config / 派 sessionId。
+
+export const CCStartTaskRequestSchema = z.object({
+  skillId: z.string(),
+  inputs: z.record(z.string(), z.unknown()),
+});
+
+export type CCStartTaskRequest = z.infer<typeof CCStartTaskRequestSchema>;
+
+export const CCStartTaskResponseSchema = z.object({
+  sessionId: z.string(),
+});
+
+export type CCStartTaskResponse = z.infer<typeof CCStartTaskResponseSchema>;
+
+// -------- cc:cancel-task（Renderer → Main） --------
+
+export const CCCancelTaskRequestSchema = z.object({
+  sessionId: z.string(),
+});
+
+export type CCCancelTaskRequest = z.infer<typeof CCCancelTaskRequestSchema>;
+
+// -------- cc:event（Main → Renderer push） --------
+// payload 直接是 CCEvent（见 cc-event.ts），这里不重复 schema。
+
+// -------- cc:status（双向） --------
+// email 是脱敏后的字符串（如 "u***@example.com"），按 03-architecture.md §4.1 F1.3 规定。
+
+export const CCStatusSchema = z.object({
+  installed: z.boolean(),
+  version: z.string().optional(),
+  loggedIn: z.boolean().optional(),
+  email: z.string().optional(),
+  authMethod: z.enum(["subscription", "api_key"]).optional(),
+});
+
+export type CCStatus = z.infer<typeof CCStatusSchema>;
+
+// -------- skill:list（Renderer → Main） --------
+// 返回 SkillManifest[]（见 skill.ts）。请求无 payload。
+
+// -------- skill:install（Renderer → Main） --------
+// source 可以是本地路径、zip 文件路径或 URL，由 Main 判断。
+
+export const SkillInstallRequestSchema = z.object({
+  source: z.string(),
+});
+
+export type SkillInstallRequest = z.infer<typeof SkillInstallRequestSchema>;
+
+// -------- session:list（Renderer → Main） --------
+// 返回 SessionMeta[]。SessionMeta 是 sessions 表的精简视图（UI 列表需要的字段）。
+
+export const SessionMetaSchema = z.object({
+  id: z.string(),
+  title: z.string(),
+  skillId: z.string().nullable(),
+  createdAt: z.number().int(), // epoch ms
+  updatedAt: z.number().int(),
+  status: z.enum(["active", "completed", "cancelled", "error"]),
+});
+
+export type SessionMeta = z.infer<typeof SessionMetaSchema>;
+
+// -------- session:resume（Renderer → Main） --------
+
+export const SessionResumeRequestSchema = z.object({
+  sessionId: z.string(),
+});
+
+export type SessionResumeRequest = z.infer<typeof SessionResumeRequestSchema>;
+
+// -------- risk-gate:confirm（Main → Renderer push） --------
+// payload 是 RiskGateRequest（见 risk-gate.ts）。
+
+// -------- risk-gate:response（Renderer → Main） --------
+// payload 是 RiskGateDecision（见 risk-gate.ts）。
+
+// -------- settings:get / settings:set（双向） --------
+// value 用 unknown，具体结构由具体设置项决定（SQLite settings 表按 key-value JSON 存）。
+
+export const SettingsGetRequestSchema = z.object({
+  key: z.string(),
+});
+
+export type SettingsGetRequest = z.infer<typeof SettingsGetRequestSchema>;
+
+export const SettingsSetRequestSchema = z.object({
+  key: z.string(),
+  value: z.unknown(),
+});
+
+export type SettingsSetRequest = z.infer<typeof SettingsSetRequestSchema>;

--- a/packages/shared/src/types/risk-gate.ts
+++ b/packages/shared/src/types/risk-gate.ts
@@ -1,0 +1,24 @@
+// Risk Gate 请求/决策数据结构。对应 03-architecture.md §4.5。
+
+import { z } from "zod";
+
+// Risk Gate 拦截时生成的请求（由 OpenTrad MCP server 的 middleware 发起）。
+export const RiskGateRequestSchema = z.object({
+  skillId: z.string(),
+  toolName: z.string(),
+  params: z.unknown(),
+  riskLevel: z.enum(["safe", "review", "blocked"]),
+  businessAction: z.string().optional(), // 命中 skill manifest 的 stop_before 条目
+});
+
+export type RiskGateRequest = z.infer<typeof RiskGateRequestSchema>;
+
+// Risk Gate 决策结果（由用户在 UI 弹窗或历史规则产生）。
+// timestamp 用 epoch ms，方便写 JSONL 审计日志和按时间查询。
+export const RiskGateDecisionSchema = z.object({
+  decision: z.enum(["allow", "deny", "allow_once", "allow_always"]),
+  reason: z.string().optional(),
+  timestamp: z.number().int(),
+});
+
+export type RiskGateDecision = z.infer<typeof RiskGateDecisionSchema>;

--- a/packages/shared/src/types/skill.ts
+++ b/packages/shared/src/types/skill.ts
@@ -1,0 +1,34 @@
+// Skill manifest 与输入字段定义。对应 03-architecture.md §4.3。
+
+import { z } from "zod";
+
+// skill manifest 里的一个输入字段定义（用于 UI 生成表单）。
+export const SkillInputSchema = z.object({
+  name: z.string(),
+  type: z.enum(["text", "textarea", "select", "url", "file"]),
+  label: z.string(),
+  placeholder: z.string().optional(),
+  required: z.boolean().optional(),
+  options: z.array(z.string()).optional(), // 仅 type=select 时使用
+  default: z.string().optional(),
+});
+
+export type SkillInput = z.infer<typeof SkillInputSchema>;
+
+// skill 的完整 manifest（对应 skill.yml 文件解析后的结构）。
+export const SkillManifestSchema = z.object({
+  id: z.string(),
+  title: z.string(),
+  version: z.string(),
+  description: z.string(),
+  category: z.enum(["sourcing", "communication", "listing", "compliance", "other"]),
+  riskLevel: z.enum(["draft_only", "read_only", "interactive"]),
+  allowedTools: z.array(z.string()),
+  disallowedTools: z.array(z.string()).optional(),
+  stopBefore: z.array(z.string()).optional(), // 业务级停止动作，Risk Gate 依赖
+  inputs: z.array(SkillInputSchema),
+  outputs: z.array(z.string()),
+  promptTemplate: z.string(), // 相对 skill 目录的 markdown 文件路径
+});
+
+export type SkillManifest = z.infer<typeof SkillManifestSchema>;

--- a/packages/shared/tests/cc-event.test.ts
+++ b/packages/shared/tests/cc-event.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it } from "vitest";
+import { AssistantContentSchema, CCEventSchema, McpServerInfoSchema } from "../src";
+
+describe("CCEvent schema", () => {
+  it("parses a valid system/init event", () => {
+    const raw = {
+      type: "system",
+      subtype: "init",
+      data: {
+        sessionId: "abc-123",
+        tools: ["Read", "Write"],
+        mcpServers: [{ name: "opentrad" }],
+        model: "claude-opus-4-7",
+        permissionMode: "default",
+        claudeCodeVersion: "2.1.119",
+        apiKeySource: "subscription",
+      },
+    };
+    const parsed = CCEventSchema.parse(raw);
+    expect(parsed.type).toBe("system");
+    if (parsed.type === "system") {
+      expect(parsed.subtype).toBe("init");
+      expect(parsed.data.sessionId).toBe("abc-123");
+    }
+  });
+
+  it("parses an assistant text event", () => {
+    const raw = { type: "assistant", content: { type: "text", text: "你好" } };
+    expect(CCEventSchema.safeParse(raw).success).toBe(true);
+  });
+
+  it("parses an assistant thinking event", () => {
+    const raw = {
+      type: "assistant",
+      content: { type: "thinking", thinking: "..." },
+    };
+    expect(CCEventSchema.safeParse(raw).success).toBe(true);
+  });
+
+  it("parses a tool_use event with arbitrary input", () => {
+    const raw = {
+      type: "tool_use",
+      toolUseId: "t1",
+      name: "Read",
+      input: { path: "/etc/hosts" },
+    };
+    expect(CCEventSchema.safeParse(raw).success).toBe(true);
+  });
+
+  it("parses a result event (data fields passthrough)", () => {
+    const raw = {
+      type: "result",
+      subtype: "success",
+      data: { totalCostUsd: 0.01, durationMs: 1500 },
+    };
+    expect(CCEventSchema.safeParse(raw).success).toBe(true);
+  });
+
+  it("parses an unknown event (fallback variant for forward-compat)", () => {
+    const raw = { type: "unknown", raw: "something weird" };
+    expect(CCEventSchema.safeParse(raw).success).toBe(true);
+  });
+
+  it("rejects system/init with invalid apiKeySource", () => {
+    const raw = {
+      type: "system",
+      subtype: "init",
+      data: {
+        sessionId: "abc",
+        tools: [],
+        mcpServers: [],
+        model: "x",
+        permissionMode: "y",
+        claudeCodeVersion: "2.1.119",
+        apiKeySource: "invalid_source",
+      },
+    };
+    expect(CCEventSchema.safeParse(raw).success).toBe(false);
+  });
+
+  it("rejects event with missing type discriminator", () => {
+    const raw = { content: { type: "text", text: "..." } };
+    expect(CCEventSchema.safeParse(raw).success).toBe(false);
+  });
+
+  it("McpServerInfo allows unknown extra fields (passthrough)", () => {
+    const raw = { name: "opentrad", status: "connected", extra: 42 };
+    const parsed = McpServerInfoSchema.parse(raw);
+    expect(parsed.name).toBe("opentrad");
+  });
+});
+
+describe("AssistantContent schema", () => {
+  it("distinguishes text vs thinking by discriminator", () => {
+    expect(AssistantContentSchema.safeParse({ type: "text", text: "a" }).success).toBe(true);
+    expect(AssistantContentSchema.safeParse({ type: "thinking", thinking: "b" }).success).toBe(
+      true,
+    );
+    expect(AssistantContentSchema.safeParse({ type: "text" }).success).toBe(false);
+  });
+});

--- a/packages/shared/tests/cc-task.test.ts
+++ b/packages/shared/tests/cc-task.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from "vitest";
+import { CCResultSchema, CCTaskOptionsSchema } from "../src";
+
+describe("CCTaskOptions schema", () => {
+  it("accepts minimum required fields", () => {
+    const raw = {
+      sessionId: "abc",
+      prompt: "Say hi",
+      mcpConfigPath: "/tmp/x.json",
+      allowedTools: ["Read"],
+    };
+    expect(CCTaskOptionsSchema.safeParse(raw).success).toBe(true);
+  });
+
+  it("accepts all optional fields populated", () => {
+    const raw = {
+      sessionId: "abc",
+      prompt: "Say hi",
+      mcpConfigPath: "/tmp/x.json",
+      allowedTools: ["Read"],
+      cwd: "/home/user",
+      model: "sonnet",
+      permissionMode: "acceptEdits",
+      resume: true,
+    };
+    expect(CCTaskOptionsSchema.safeParse(raw).success).toBe(true);
+  });
+
+  it("rejects unknown model name", () => {
+    const raw = {
+      sessionId: "abc",
+      prompt: "Say hi",
+      mcpConfigPath: "/tmp/x.json",
+      allowedTools: [],
+      model: "gpt-5",
+    };
+    expect(CCTaskOptionsSchema.safeParse(raw).success).toBe(false);
+  });
+
+  it("rejects missing required field (prompt only)", () => {
+    const raw = { prompt: "x" };
+    expect(CCTaskOptionsSchema.safeParse(raw).success).toBe(false);
+  });
+});
+
+describe("CCResult schema", () => {
+  it("parses a valid success result", () => {
+    const raw = {
+      sessionId: "abc",
+      status: "success",
+      data: { costUsd: 0.01 },
+      exitCode: 0,
+    };
+    expect(CCResultSchema.safeParse(raw).success).toBe(true);
+  });
+
+  it("rejects non-integer exitCode", () => {
+    const raw = {
+      sessionId: "abc",
+      status: "error",
+      data: {},
+      exitCode: 1.5,
+    };
+    expect(CCResultSchema.safeParse(raw).success).toBe(false);
+  });
+});

--- a/packages/shared/tests/cc-task.test.ts
+++ b/packages/shared/tests/cc-task.test.ts
@@ -54,6 +54,26 @@ describe("CCResult schema", () => {
     expect(CCResultSchema.safeParse(raw).success).toBe(true);
   });
 
+  it("accepts cancelled status (user-initiated kill)", () => {
+    const raw = {
+      sessionId: "abc",
+      status: "cancelled",
+      data: {},
+      exitCode: 130,
+    };
+    expect(CCResultSchema.safeParse(raw).success).toBe(true);
+  });
+
+  it("rejects unknown status value", () => {
+    const raw = {
+      sessionId: "abc",
+      status: "timeout",
+      data: {},
+      exitCode: 1,
+    };
+    expect(CCResultSchema.safeParse(raw).success).toBe(false);
+  });
+
   it("rejects non-integer exitCode", () => {
     const raw = {
       sessionId: "abc",

--- a/packages/shared/tests/ipc.test.ts
+++ b/packages/shared/tests/ipc.test.ts
@@ -60,6 +60,15 @@ describe("CCStatus schema", () => {
       }).success,
     ).toBe(false);
   });
+
+  it("accepts error message for CC detection failures", () => {
+    expect(
+      CCStatusSchema.safeParse({
+        installed: false,
+        error: "claude binary not found in PATH",
+      }).success,
+    ).toBe(true);
+  });
 });
 
 describe("SessionMeta schema", () => {

--- a/packages/shared/tests/ipc.test.ts
+++ b/packages/shared/tests/ipc.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it } from "vitest";
+import {
+  CCStartTaskRequestSchema,
+  CCStatusSchema,
+  IpcChannels,
+  SessionMetaSchema,
+  SettingsSetRequestSchema,
+} from "../src";
+
+describe("IpcChannels constants", () => {
+  it("matches canonical channel names from 03-architecture.md §3", () => {
+    expect(IpcChannels.CCStartTask).toBe("cc:start-task");
+    expect(IpcChannels.CCEvent).toBe("cc:event");
+    expect(IpcChannels.RiskGateConfirm).toBe("risk-gate:confirm");
+    expect(IpcChannels.SettingsSet).toBe("settings:set");
+  });
+});
+
+describe("CCStartTask schema", () => {
+  it("accepts skillId with arbitrary inputs map", () => {
+    const raw = {
+      skillId: "trade-email-writer",
+      inputs: { context: "报价信", tone: "formal" },
+    };
+    expect(CCStartTaskRequestSchema.safeParse(raw).success).toBe(true);
+  });
+
+  it("accepts empty inputs object", () => {
+    expect(
+      CCStartTaskRequestSchema.safeParse({
+        skillId: "x",
+        inputs: {},
+      }).success,
+    ).toBe(true);
+  });
+});
+
+describe("CCStatus schema", () => {
+  it("allows installed=false without other fields", () => {
+    expect(CCStatusSchema.safeParse({ installed: false }).success).toBe(true);
+  });
+
+  it("accepts fully-populated status", () => {
+    expect(
+      CCStatusSchema.safeParse({
+        installed: true,
+        version: "2.1.119",
+        loggedIn: true,
+        email: "u***@example.com",
+        authMethod: "subscription",
+      }).success,
+    ).toBe(true);
+  });
+
+  it("rejects invalid authMethod", () => {
+    expect(
+      CCStatusSchema.safeParse({
+        installed: true,
+        authMethod: "oauth",
+      }).success,
+    ).toBe(false);
+  });
+});
+
+describe("SessionMeta schema", () => {
+  it("parses typical completed session", () => {
+    const raw = {
+      id: "abc",
+      title: "报价邮件",
+      skillId: "trade-email-writer",
+      createdAt: Date.now(),
+      updatedAt: Date.now(),
+      status: "completed",
+    };
+    expect(SessionMetaSchema.safeParse(raw).success).toBe(true);
+  });
+
+  it("allows null skillId (ad-hoc session without skill)", () => {
+    const raw = {
+      id: "abc",
+      title: "x",
+      skillId: null,
+      createdAt: 1,
+      updatedAt: 1,
+      status: "active",
+    };
+    expect(SessionMetaSchema.safeParse(raw).success).toBe(true);
+  });
+});
+
+describe("SettingsSet schema", () => {
+  it("accepts arbitrary value types (unknown)", () => {
+    expect(SettingsSetRequestSchema.safeParse({ key: "theme", value: "dark" }).success).toBe(true);
+    expect(SettingsSetRequestSchema.safeParse({ key: "n", value: 42 }).success).toBe(true);
+    expect(SettingsSetRequestSchema.safeParse({ key: "o", value: { x: 1 } }).success).toBe(true);
+  });
+});

--- a/packages/shared/tests/risk-gate.test.ts
+++ b/packages/shared/tests/risk-gate.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from "vitest";
+import { RiskGateDecisionSchema, RiskGateRequestSchema } from "../src";
+
+describe("RiskGateRequest schema", () => {
+  it("parses a minimal review-level request", () => {
+    const raw = {
+      skillId: "supplier-rfq-draft",
+      toolName: "browser_open",
+      params: { url: "https://1688.com" },
+      riskLevel: "review",
+    };
+    expect(RiskGateRequestSchema.safeParse(raw).success).toBe(true);
+  });
+
+  it("parses a business-level request with stopBefore action", () => {
+    const raw = {
+      skillId: "supplier-rfq-draft",
+      toolName: "send_rfq",
+      params: { to: "abc@supplier.com" },
+      riskLevel: "review",
+      businessAction: "send_rfq",
+    };
+    expect(RiskGateRequestSchema.safeParse(raw).success).toBe(true);
+  });
+
+  it("rejects invalid riskLevel", () => {
+    const raw = {
+      skillId: "x",
+      toolName: "x",
+      params: {},
+      riskLevel: "medium",
+    };
+    expect(RiskGateRequestSchema.safeParse(raw).success).toBe(false);
+  });
+});
+
+describe("RiskGateDecision schema", () => {
+  it("accepts all four decision values", () => {
+    for (const decision of ["allow", "deny", "allow_once", "allow_always"] as const) {
+      expect(
+        RiskGateDecisionSchema.safeParse({
+          decision,
+          timestamp: Date.now(),
+        }).success,
+      ).toBe(true);
+    }
+  });
+
+  it("rejects non-integer timestamp", () => {
+    expect(
+      RiskGateDecisionSchema.safeParse({
+        decision: "allow",
+        timestamp: 1.5,
+      }).success,
+    ).toBe(false);
+  });
+});

--- a/packages/shared/tests/skill.test.ts
+++ b/packages/shared/tests/skill.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from "vitest";
+import { SkillInputSchema, SkillManifestSchema } from "../src";
+
+describe("SkillInput schema", () => {
+  it("accepts a text input", () => {
+    expect(
+      SkillInputSchema.safeParse({
+        name: "context",
+        type: "text",
+        label: "邮件场景描述",
+      }).success,
+    ).toBe(true);
+  });
+
+  it("accepts a select input with options", () => {
+    expect(
+      SkillInputSchema.safeParse({
+        name: "tone",
+        type: "select",
+        label: "语气",
+        options: ["formal", "friendly"],
+      }).success,
+    ).toBe(true);
+  });
+
+  it("rejects unknown input type", () => {
+    expect(
+      SkillInputSchema.safeParse({
+        name: "x",
+        type: "checkbox",
+        label: "x",
+      }).success,
+    ).toBe(false);
+  });
+});
+
+describe("SkillManifest schema", () => {
+  it("parses a full manifest for trade-email-writer", () => {
+    const raw = {
+      id: "trade-email-writer",
+      title: "外贸邮件写作",
+      version: "1.0.0",
+      description: "生成各类外贸邮件草稿",
+      category: "communication",
+      riskLevel: "draft_only",
+      allowedTools: ["Read", "Write", "WebSearch"],
+      disallowedTools: ["Bash(*)"],
+      stopBefore: ["send_email"],
+      inputs: [{ name: "context", type: "text", label: "场景", required: true }],
+      outputs: ["draft_email", "subject_line"],
+      promptTemplate: "prompt.md",
+    };
+    expect(SkillManifestSchema.safeParse(raw).success).toBe(true);
+  });
+
+  it("rejects invalid category", () => {
+    const raw = {
+      id: "x",
+      title: "x",
+      version: "1.0",
+      description: "x",
+      category: "cooking",
+      riskLevel: "draft_only",
+      allowedTools: [],
+      inputs: [],
+      outputs: [],
+      promptTemplate: "p.md",
+    };
+    expect(SkillManifestSchema.safeParse(raw).success).toBe(false);
+  });
+
+  it("rejects invalid riskLevel", () => {
+    const raw = {
+      id: "x",
+      title: "x",
+      version: "1.0",
+      description: "x",
+      category: "other",
+      riskLevel: "dangerous",
+      allowedTools: [],
+      inputs: [],
+      outputs: [],
+      promptTemplate: "p.md",
+    };
+    expect(SkillManifestSchema.safeParse(raw).success).toBe(false);
+  });
+});

--- a/packages/shared/tsconfig.json
+++ b/packages/shared/tsconfig.json
@@ -1,9 +1,9 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "rootDir": "./src",
     "outDir": "./dist",
     "noEmit": true
   },
-  "include": ["src/**/*"]
+  "include": ["src/**/*", "tests/**/*", "vitest.config.ts"],
+  "exclude": ["node_modules", "dist"]
 }

--- a/packages/shared/vitest.config.ts
+++ b/packages/shared/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    include: ["tests/**/*.test.ts"],
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,9 @@ importers:
       typescript:
         specifier: ^5.5.0
         version: 5.9.3
+      vitest:
+        specifier: ^4.1.5
+        version: 4.1.5(vite@8.0.10)
 
   apps/desktop: {}
 
@@ -25,7 +28,11 @@ importers:
 
   packages/risk-gate: {}
 
-  packages/shared: {}
+  packages/shared:
+    dependencies:
+      zod:
+        specifier: ^4.3.6
+        version: 4.3.6
 
   packages/skill-runtime: {}
 
@@ -86,10 +93,429 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@emnapi/core@1.10.0':
+    resolution: {integrity: sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==}
+
+  '@emnapi/runtime@1.10.0':
+    resolution: {integrity: sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==}
+
+  '@emnapi/wasi-threads@1.2.1':
+    resolution: {integrity: sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==}
+
+  '@jridgewell/sourcemap-codec@1.5.5':
+    resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
+
+  '@napi-rs/wasm-runtime@1.1.4':
+    resolution: {integrity: sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==}
+    peerDependencies:
+      '@emnapi/core': ^1.7.1
+      '@emnapi/runtime': ^1.7.1
+
+  '@oxc-project/types@0.127.0':
+    resolution: {integrity: sha512-aIYXQBo4lCbO4z0R3FHeucQHpF46l2LbMdxRvqvuRuW2OxdnSkcng5B8+K12spgLDj93rtN3+J2Vac/TIO+ciQ==}
+
+  '@rolldown/binding-android-arm64@1.0.0-rc.17':
+    resolution: {integrity: sha512-s70pVGhw4zqGeFnXWvAzJDlvxhlRollagdCCKRgOsgUOH3N1l0LIxf83AtGzmb5SiVM4Hjl5HyarMRfdfj3DaQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [android]
+
+  '@rolldown/binding-darwin-arm64@1.0.0-rc.17':
+    resolution: {integrity: sha512-4ksWc9n0mhlZpZ9PMZgTGjeOPRu8MB1Z3Tz0Mo02eWfWCHMW1zN82Qz/pL/rC+yQa+8ZnutMF0JjJe7PjwasYw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@rolldown/binding-darwin-x64@1.0.0-rc.17':
+    resolution: {integrity: sha512-SUSDOI6WwUVNcWxd02QEBjLdY1VPHvlEkw6T/8nYG322iYWCTxRb1vzk4E+mWWYehTp7ERibq54LSJGjmouOsw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [darwin]
+
+  '@rolldown/binding-freebsd-x64@1.0.0-rc.17':
+    resolution: {integrity: sha512-hwnz3nw9dbJ05EDO/PvcjaaewqqDy7Y1rn1UO81l8iIK1GjenME75dl16ajbvSSMfv66WXSRCYKIqfgq2KCfxw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.17':
+    resolution: {integrity: sha512-IS+W7epTcwANmFSQFrS1SivEXHtl1JtuQA9wlxrZTcNi6mx+FDOYrakGevvvTwgj2JvWiK8B29/qD9BELZPyXQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
+  '@rolldown/binding-linux-arm64-gnu@1.0.0-rc.17':
+    resolution: {integrity: sha512-e6usGaHKW5BMNZOymS1UcEYGowQMWcgZ71Z17Sl/h2+ZziNJ1a9n3Zvcz6LdRyIW5572wBCTH/Z+bKuZouGk9Q==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+
+  '@rolldown/binding-linux-arm64-musl@1.0.0-rc.17':
+    resolution: {integrity: sha512-b/CgbwAJpmrRLp02RPfhbudf5tZnN9nsPWK82znefso832etkem8H7FSZwxrOI9djcdTP7U6YfNhbRnh7djErg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+
+  '@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.17':
+    resolution: {integrity: sha512-4EII1iNGRUN5WwGbF/kOh/EIkoDN9HsupgLQoXfY+D1oyJm7/F4t5PYU5n8SWZgG0FEwakyM8pGgwcBYruGTlA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@rolldown/binding-linux-s390x-gnu@1.0.0-rc.17':
+    resolution: {integrity: sha512-AH8oq3XqQo4IibpVXvPeLDI5pzkpYn0WiZAfT05kFzoJ6tQNzwRdDYQ45M8I/gslbodRZwW8uxLhbSBbkv96rA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [s390x]
+    os: [linux]
+
+  '@rolldown/binding-linux-x64-gnu@1.0.0-rc.17':
+    resolution: {integrity: sha512-cLnjV3xfo7KslbU41Z7z8BH/E1y5mzUYzAqih1d1MDaIGZRCMqTijqLv76/P7fyHuvUcfGsIpqCdddbxLLK9rA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+
+  '@rolldown/binding-linux-x64-musl@1.0.0-rc.17':
+    resolution: {integrity: sha512-0phclDw1spsL7dUB37sIARuis2tAgomCJXAHZlpt8PXZ4Ba0dRP1e+66lsRqrfhISeN9bEGNjQs+T/Fbd7oYGw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+
+  '@rolldown/binding-openharmony-arm64@1.0.0-rc.17':
+    resolution: {integrity: sha512-0ag/hEgXOwgw4t8QyQvUCxvEg+V0KBcA6YuOx9g0r02MprutRF5dyljgm3EmR02O292UX7UeS6HzWHAl6KgyhA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@rolldown/binding-wasm32-wasi@1.0.0-rc.17':
+    resolution: {integrity: sha512-LEXei6vo0E5wTGwpkJ4KoT3OZJRnglwldt5ziLzOlc6qqb55z4tWNq2A+PFqCJuvWWdP53CVhG1Z9NtToDPJrA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [wasm32]
+
+  '@rolldown/binding-win32-arm64-msvc@1.0.0-rc.17':
+    resolution: {integrity: sha512-gUmyzBl3SPMa6hrqFUth9sVfcLBlYsbMzBx5PlexMroZStgzGqlZ26pYG89rBb45Mnia+oil6YAIFeEWGWhoZA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [win32]
+
+  '@rolldown/binding-win32-x64-msvc@1.0.0-rc.17':
+    resolution: {integrity: sha512-3hkiolcUAvPB9FLb3UZdfjVVNWherN1f/skkGWJP/fgSQhYUZpSIRr0/I8ZK9TkF3F7kxvJAk0+IcKvPHk9qQg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [win32]
+
+  '@rolldown/pluginutils@1.0.0-rc.17':
+    resolution: {integrity: sha512-n8iosDOt6Ig1UhJ2AYqoIhHWh/isz0xpicHTzpKBeotdVsTEcxsSA/i3EVM7gQAj0rU27OLAxCjzlj15IWY7bg==}
+
+  '@standard-schema/spec@1.1.0':
+    resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
+
+  '@tybys/wasm-util@0.10.1':
+    resolution: {integrity: sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==}
+
+  '@types/chai@5.2.3':
+    resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
+
+  '@types/deep-eql@4.0.2':
+    resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
+
+  '@types/estree@1.0.8':
+    resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
+
+  '@vitest/expect@4.1.5':
+    resolution: {integrity: sha512-PWBaRY5JoKuRnHlUHfpV/KohFylaDZTupcXN1H9vYryNLOnitSw60Mw9IAE2r67NbwwzBw/Cc/8q9BK3kIX8Kw==}
+
+  '@vitest/mocker@4.1.5':
+    resolution: {integrity: sha512-/x2EmFC4mT4NNzqvC3fmesuV97w5FC903KPmey4gsnJiMQ3Be1IlDKVaDaG8iqaLFHqJ2FVEkxZk5VmeLjIItw==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
+  '@vitest/pretty-format@4.1.5':
+    resolution: {integrity: sha512-7I3q6l5qr03dVfMX2wCo9FxwSJbPdwKjy2uu/YPpU3wfHvIL4QHwVRp57OfGrDFeUJ8/8QdfBKIV12FTtLn00g==}
+
+  '@vitest/runner@4.1.5':
+    resolution: {integrity: sha512-2D+o7Pr82IEO46YPpoA/YU0neeyr6FTerQb5Ro7BUnBuv6NQtT/kmVnczngiMEBhzgqz2UZYl5gArejsyERDSQ==}
+
+  '@vitest/snapshot@4.1.5':
+    resolution: {integrity: sha512-zypXEt4KH/XgKGPUz4eC2AvErYx0My5hfL8oDb1HzGFpEk1P62bxSohdyOmvz+d9UJwanI68MKwr2EquOaOgMQ==}
+
+  '@vitest/spy@4.1.5':
+    resolution: {integrity: sha512-2lNOsh6+R2Idnf1TCZqSwYlKN2E/iDlD8sgU59kYVl+OMDmvldO1VDk39smRfpUNwYpNRVn3w4YfuC7KfbBnkQ==}
+
+  '@vitest/utils@4.1.5':
+    resolution: {integrity: sha512-76wdkrmfXfqGjueGgnb45ITPyUi1ycZ4IHgC2bhPDUfWHklY/q3MdLOAB+TF1e6xfl8NxNY0ZYaPCFNWSsw3Ug==}
+
+  assertion-error@2.0.1:
+    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
+    engines: {node: '>=12'}
+
+  chai@6.2.2:
+    resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
+    engines: {node: '>=18'}
+
+  convert-source-map@2.0.0:
+    resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
+
+  detect-libc@2.1.2:
+    resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
+    engines: {node: '>=8'}
+
+  es-module-lexer@2.0.0:
+    resolution: {integrity: sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==}
+
+  estree-walker@3.0.3:
+    resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
+
+  expect-type@1.3.0:
+    resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
+    engines: {node: '>=12.0.0'}
+
+  fdir@6.5.0:
+    resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
+    engines: {node: '>=12.0.0'}
+    peerDependencies:
+      picomatch: ^3 || ^4
+    peerDependenciesMeta:
+      picomatch:
+        optional: true
+
+  fsevents@2.3.3:
+    resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
+  lightningcss-android-arm64@1.32.0:
+    resolution: {integrity: sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [android]
+
+  lightningcss-darwin-arm64@1.32.0:
+    resolution: {integrity: sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [darwin]
+
+  lightningcss-darwin-x64@1.32.0:
+    resolution: {integrity: sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [darwin]
+
+  lightningcss-freebsd-x64@1.32.0:
+    resolution: {integrity: sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [freebsd]
+
+  lightningcss-linux-arm-gnueabihf@1.32.0:
+    resolution: {integrity: sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm]
+    os: [linux]
+
+  lightningcss-linux-arm64-gnu@1.32.0:
+    resolution: {integrity: sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [linux]
+
+  lightningcss-linux-arm64-musl@1.32.0:
+    resolution: {integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [linux]
+
+  lightningcss-linux-x64-gnu@1.32.0:
+    resolution: {integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [linux]
+
+  lightningcss-linux-x64-musl@1.32.0:
+    resolution: {integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [linux]
+
+  lightningcss-win32-arm64-msvc@1.32.0:
+    resolution: {integrity: sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [win32]
+
+  lightningcss-win32-x64-msvc@1.32.0:
+    resolution: {integrity: sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [win32]
+
+  lightningcss@1.32.0:
+    resolution: {integrity: sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==}
+    engines: {node: '>= 12.0.0'}
+
+  magic-string@0.30.21:
+    resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
+
+  nanoid@3.3.11:
+    resolution: {integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==}
+    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
+    hasBin: true
+
+  obug@2.1.1:
+    resolution: {integrity: sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==}
+
+  pathe@2.0.3:
+    resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
+
+  picocolors@1.1.1:
+    resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
+
+  picomatch@4.0.4:
+    resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
+    engines: {node: '>=12'}
+
+  postcss@8.5.10:
+    resolution: {integrity: sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==}
+    engines: {node: ^10 || ^12 || >=14}
+
+  rolldown@1.0.0-rc.17:
+    resolution: {integrity: sha512-ZrT53oAKrtA4+YtBWPQbtPOxIbVDbxT0orcYERKd63VJTF13zPcgXTvD4843L8pcsI7M6MErt8QtON6lrB9tyA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+
+  siginfo@2.0.0:
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
+  source-map-js@1.2.1:
+    resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
+    engines: {node: '>=0.10.0'}
+
+  stackback@0.0.2:
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
+  std-env@4.1.0:
+    resolution: {integrity: sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==}
+
+  tinybench@2.9.0:
+    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+
+  tinyexec@1.1.1:
+    resolution: {integrity: sha512-VKS/ZaQhhkKFMANmAOhhXVoIfBXblQxGX1myCQ2faQrfmobMftXeJPcZGp0gS07ocvGJWDLZGyOZDadDBqYIJg==}
+    engines: {node: '>=18'}
+
+  tinyglobby@0.2.16:
+    resolution: {integrity: sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==}
+    engines: {node: '>=12.0.0'}
+
+  tinyrainbow@3.1.0:
+    resolution: {integrity: sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==}
+    engines: {node: '>=14.0.0'}
+
+  tslib@2.8.1:
+    resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
+
   typescript@5.9.3:
     resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
     engines: {node: '>=14.17'}
     hasBin: true
+
+  vite@8.0.10:
+    resolution: {integrity: sha512-rZuUu9j6J5uotLDs+cAA4O5H4K1SfPliUlQwqa6YEwSrWDZzP4rhm00oJR5snMewjxF5V/K3D4kctsUTsIU9Mw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^20.19.0 || >=22.12.0
+      '@vitejs/devtools': ^0.1.0
+      esbuild: ^0.27.0 || ^0.28.0
+      jiti: '>=1.21.0'
+      less: ^4.0.0
+      sass: ^1.70.0
+      sass-embedded: ^1.70.0
+      stylus: '>=0.54.8'
+      sugarss: ^5.0.0
+      terser: ^5.16.0
+      tsx: ^4.8.1
+      yaml: ^2.4.2
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      '@vitejs/devtools':
+        optional: true
+      esbuild:
+        optional: true
+      jiti:
+        optional: true
+      less:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+      tsx:
+        optional: true
+      yaml:
+        optional: true
+
+  vitest@4.1.5:
+    resolution: {integrity: sha512-9Xx1v3/ih3m9hN+SbfkUyy0JAs72ap3r7joc87XL6jwF0jGg6mFBvQ1SrwaX+h8BlkX6Hz9shdd1uo6AF+ZGpg==}
+    engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@opentelemetry/api': ^1.9.0
+      '@types/node': ^20.0.0 || ^22.0.0 || >=24.0.0
+      '@vitest/browser-playwright': 4.1.5
+      '@vitest/browser-preview': 4.1.5
+      '@vitest/browser-webdriverio': 4.1.5
+      '@vitest/coverage-istanbul': 4.1.5
+      '@vitest/coverage-v8': 4.1.5
+      '@vitest/ui': 4.1.5
+      happy-dom: '*'
+      jsdom: '*'
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@opentelemetry/api':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser-playwright':
+        optional: true
+      '@vitest/browser-preview':
+        optional: true
+      '@vitest/browser-webdriverio':
+        optional: true
+      '@vitest/coverage-istanbul':
+        optional: true
+      '@vitest/coverage-v8':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
+  why-is-node-running@2.3.0:
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
+    engines: {node: '>=8'}
+    hasBin: true
+
+  zod@4.3.6:
+    resolution: {integrity: sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==}
 
 snapshots:
 
@@ -128,4 +554,316 @@ snapshots:
   '@biomejs/cli-win32-x64@2.4.13':
     optional: true
 
+  '@emnapi/core@1.10.0':
+    dependencies:
+      '@emnapi/wasi-threads': 1.2.1
+      tslib: 2.8.1
+    optional: true
+
+  '@emnapi/runtime@1.10.0':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  '@emnapi/wasi-threads@1.2.1':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  '@jridgewell/sourcemap-codec@1.5.5': {}
+
+  '@napi-rs/wasm-runtime@1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)':
+    dependencies:
+      '@emnapi/core': 1.10.0
+      '@emnapi/runtime': 1.10.0
+      '@tybys/wasm-util': 0.10.1
+    optional: true
+
+  '@oxc-project/types@0.127.0': {}
+
+  '@rolldown/binding-android-arm64@1.0.0-rc.17':
+    optional: true
+
+  '@rolldown/binding-darwin-arm64@1.0.0-rc.17':
+    optional: true
+
+  '@rolldown/binding-darwin-x64@1.0.0-rc.17':
+    optional: true
+
+  '@rolldown/binding-freebsd-x64@1.0.0-rc.17':
+    optional: true
+
+  '@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.17':
+    optional: true
+
+  '@rolldown/binding-linux-arm64-gnu@1.0.0-rc.17':
+    optional: true
+
+  '@rolldown/binding-linux-arm64-musl@1.0.0-rc.17':
+    optional: true
+
+  '@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.17':
+    optional: true
+
+  '@rolldown/binding-linux-s390x-gnu@1.0.0-rc.17':
+    optional: true
+
+  '@rolldown/binding-linux-x64-gnu@1.0.0-rc.17':
+    optional: true
+
+  '@rolldown/binding-linux-x64-musl@1.0.0-rc.17':
+    optional: true
+
+  '@rolldown/binding-openharmony-arm64@1.0.0-rc.17':
+    optional: true
+
+  '@rolldown/binding-wasm32-wasi@1.0.0-rc.17':
+    dependencies:
+      '@emnapi/core': 1.10.0
+      '@emnapi/runtime': 1.10.0
+      '@napi-rs/wasm-runtime': 1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
+    optional: true
+
+  '@rolldown/binding-win32-arm64-msvc@1.0.0-rc.17':
+    optional: true
+
+  '@rolldown/binding-win32-x64-msvc@1.0.0-rc.17':
+    optional: true
+
+  '@rolldown/pluginutils@1.0.0-rc.17': {}
+
+  '@standard-schema/spec@1.1.0': {}
+
+  '@tybys/wasm-util@0.10.1':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  '@types/chai@5.2.3':
+    dependencies:
+      '@types/deep-eql': 4.0.2
+      assertion-error: 2.0.1
+
+  '@types/deep-eql@4.0.2': {}
+
+  '@types/estree@1.0.8': {}
+
+  '@vitest/expect@4.1.5':
+    dependencies:
+      '@standard-schema/spec': 1.1.0
+      '@types/chai': 5.2.3
+      '@vitest/spy': 4.1.5
+      '@vitest/utils': 4.1.5
+      chai: 6.2.2
+      tinyrainbow: 3.1.0
+
+  '@vitest/mocker@4.1.5(vite@8.0.10)':
+    dependencies:
+      '@vitest/spy': 4.1.5
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 8.0.10
+
+  '@vitest/pretty-format@4.1.5':
+    dependencies:
+      tinyrainbow: 3.1.0
+
+  '@vitest/runner@4.1.5':
+    dependencies:
+      '@vitest/utils': 4.1.5
+      pathe: 2.0.3
+
+  '@vitest/snapshot@4.1.5':
+    dependencies:
+      '@vitest/pretty-format': 4.1.5
+      '@vitest/utils': 4.1.5
+      magic-string: 0.30.21
+      pathe: 2.0.3
+
+  '@vitest/spy@4.1.5': {}
+
+  '@vitest/utils@4.1.5':
+    dependencies:
+      '@vitest/pretty-format': 4.1.5
+      convert-source-map: 2.0.0
+      tinyrainbow: 3.1.0
+
+  assertion-error@2.0.1: {}
+
+  chai@6.2.2: {}
+
+  convert-source-map@2.0.0: {}
+
+  detect-libc@2.1.2: {}
+
+  es-module-lexer@2.0.0: {}
+
+  estree-walker@3.0.3:
+    dependencies:
+      '@types/estree': 1.0.8
+
+  expect-type@1.3.0: {}
+
+  fdir@6.5.0(picomatch@4.0.4):
+    optionalDependencies:
+      picomatch: 4.0.4
+
+  fsevents@2.3.3:
+    optional: true
+
+  lightningcss-android-arm64@1.32.0:
+    optional: true
+
+  lightningcss-darwin-arm64@1.32.0:
+    optional: true
+
+  lightningcss-darwin-x64@1.32.0:
+    optional: true
+
+  lightningcss-freebsd-x64@1.32.0:
+    optional: true
+
+  lightningcss-linux-arm-gnueabihf@1.32.0:
+    optional: true
+
+  lightningcss-linux-arm64-gnu@1.32.0:
+    optional: true
+
+  lightningcss-linux-arm64-musl@1.32.0:
+    optional: true
+
+  lightningcss-linux-x64-gnu@1.32.0:
+    optional: true
+
+  lightningcss-linux-x64-musl@1.32.0:
+    optional: true
+
+  lightningcss-win32-arm64-msvc@1.32.0:
+    optional: true
+
+  lightningcss-win32-x64-msvc@1.32.0:
+    optional: true
+
+  lightningcss@1.32.0:
+    dependencies:
+      detect-libc: 2.1.2
+    optionalDependencies:
+      lightningcss-android-arm64: 1.32.0
+      lightningcss-darwin-arm64: 1.32.0
+      lightningcss-darwin-x64: 1.32.0
+      lightningcss-freebsd-x64: 1.32.0
+      lightningcss-linux-arm-gnueabihf: 1.32.0
+      lightningcss-linux-arm64-gnu: 1.32.0
+      lightningcss-linux-arm64-musl: 1.32.0
+      lightningcss-linux-x64-gnu: 1.32.0
+      lightningcss-linux-x64-musl: 1.32.0
+      lightningcss-win32-arm64-msvc: 1.32.0
+      lightningcss-win32-x64-msvc: 1.32.0
+
+  magic-string@0.30.21:
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
+
+  nanoid@3.3.11: {}
+
+  obug@2.1.1: {}
+
+  pathe@2.0.3: {}
+
+  picocolors@1.1.1: {}
+
+  picomatch@4.0.4: {}
+
+  postcss@8.5.10:
+    dependencies:
+      nanoid: 3.3.11
+      picocolors: 1.1.1
+      source-map-js: 1.2.1
+
+  rolldown@1.0.0-rc.17:
+    dependencies:
+      '@oxc-project/types': 0.127.0
+      '@rolldown/pluginutils': 1.0.0-rc.17
+    optionalDependencies:
+      '@rolldown/binding-android-arm64': 1.0.0-rc.17
+      '@rolldown/binding-darwin-arm64': 1.0.0-rc.17
+      '@rolldown/binding-darwin-x64': 1.0.0-rc.17
+      '@rolldown/binding-freebsd-x64': 1.0.0-rc.17
+      '@rolldown/binding-linux-arm-gnueabihf': 1.0.0-rc.17
+      '@rolldown/binding-linux-arm64-gnu': 1.0.0-rc.17
+      '@rolldown/binding-linux-arm64-musl': 1.0.0-rc.17
+      '@rolldown/binding-linux-ppc64-gnu': 1.0.0-rc.17
+      '@rolldown/binding-linux-s390x-gnu': 1.0.0-rc.17
+      '@rolldown/binding-linux-x64-gnu': 1.0.0-rc.17
+      '@rolldown/binding-linux-x64-musl': 1.0.0-rc.17
+      '@rolldown/binding-openharmony-arm64': 1.0.0-rc.17
+      '@rolldown/binding-wasm32-wasi': 1.0.0-rc.17
+      '@rolldown/binding-win32-arm64-msvc': 1.0.0-rc.17
+      '@rolldown/binding-win32-x64-msvc': 1.0.0-rc.17
+
+  siginfo@2.0.0: {}
+
+  source-map-js@1.2.1: {}
+
+  stackback@0.0.2: {}
+
+  std-env@4.1.0: {}
+
+  tinybench@2.9.0: {}
+
+  tinyexec@1.1.1: {}
+
+  tinyglobby@0.2.16:
+    dependencies:
+      fdir: 6.5.0(picomatch@4.0.4)
+      picomatch: 4.0.4
+
+  tinyrainbow@3.1.0: {}
+
+  tslib@2.8.1:
+    optional: true
+
   typescript@5.9.3: {}
+
+  vite@8.0.10:
+    dependencies:
+      lightningcss: 1.32.0
+      picomatch: 4.0.4
+      postcss: 8.5.10
+      rolldown: 1.0.0-rc.17
+      tinyglobby: 0.2.16
+    optionalDependencies:
+      fsevents: 2.3.3
+
+  vitest@4.1.5(vite@8.0.10):
+    dependencies:
+      '@vitest/expect': 4.1.5
+      '@vitest/mocker': 4.1.5(vite@8.0.10)
+      '@vitest/pretty-format': 4.1.5
+      '@vitest/runner': 4.1.5
+      '@vitest/snapshot': 4.1.5
+      '@vitest/spy': 4.1.5
+      '@vitest/utils': 4.1.5
+      es-module-lexer: 2.0.0
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      obug: 2.1.1
+      pathe: 2.0.3
+      picomatch: 4.0.4
+      std-env: 4.1.0
+      tinybench: 2.9.0
+      tinyexec: 1.1.1
+      tinyglobby: 0.2.16
+      tinyrainbow: 3.1.0
+      vite: 8.0.10
+      why-is-node-running: 2.3.0
+    transitivePeerDependencies:
+      - msw
+
+  why-is-node-running@2.3.0:
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2
+
+  zod@4.3.6: {}


### PR DESCRIPTION
Closes #3

## 改了什么

按 `03-architecture.md` §4 + §3 实现 `@opentrad/shared` 的类型地基：

**types/** 5 个文件（每类一个，zod schema 与 TS 类型同源）：
- `cc-event.ts` — `CCEvent` 7 种变体的 discriminatedUnion（§4.2）
- `cc-task.ts` — `CCTaskOptions` / `CCTaskHandle` / `CCResult`（§4.1）
- `skill.ts` — `SkillManifest` / `SkillInput`（§4.3）
- `risk-gate.ts` — `RiskGateRequest` / `RiskGateDecision`（§4.5）
- `ipc.ts` — 12 个 channel 常量 + 8 组 Request/Response schema（§3）

**tests/** 5 个 vitest 文件，共 **36 个测试用例**，都用 `safeParse` 做正/反向校验。

**基建**：`vitest` 4.1.5（workspace-root）、`zod` 4.3.6（shared runtime），`vitest.config.ts`，根脚本加 `--if-present`。

## 小偏离（透明告知）

1. **zod 4.3.6 / vitest 4.1.5**：初选最新 major（非升级），pnpm 默认行为，与项目"最新主流"（Biome 2 / Tailwind 4 / Electron 34 / pnpm 10）一致。如希望固定到更低 major 告知我回退。
2. **`CCResult` 字段**：架构文档未直列字段。按 result 事件 + 元信息合理补全 `sessionId` / `status` / `data` / `exitCode`。
3. **`McpServerInfo` / `ResultData` / `RateLimitInfo`**：架构文档只提名字。用 zod `.passthrough()` 占位容错，字段细节留到 Issue #4 结合 `acciowork-research/07-raw-evidence/cc-local-cli-probe.redacted.md` 真实样本再收紧。
4. **`CCStatus` 字段**：架构无明确定义，按 §4.1 F1.3 + Issue #7 验收推断：`{ installed, version?, loggedIn?, email?, authMethod? }`。
5. **`CCStartTaskRequest` 字段**：架构只说"启动新任务"。按 §7.2 流程推断 Renderer 只传 `{ skillId, inputs }`，Main 内部 compose prompt / 生成 mcp-config / 派 sessionId。
6. **根 `package.json` 加 `--if-present`**：允许 package 可选实现 test/build/typecheck 脚本，避免 `pnpm -r` 对无脚本 package 报错。
7. **`packages/shared/tsconfig.json` 扩展 include**：添加 `tests/**/*` 和 `vitest.config.ts`，让测试代码也被 typecheck。删掉 `rootDir` 让 tsc 自动推断。

## 为什么

Issue #3（文档 Issue #2）是"整个 monorepo 的类型地基"，后面 6 个 issue（#4 stream-parser、#5 cc-adapter、#6 desktop、#7 IPC、#8 Hello World、#9 CI）都依赖它。zod schema 同时提供 compile-time 类型和 runtime 校验，防止 CC 版本升级后因未知字段而 crash。

## 怎么测试

```
$ pnpm --filter @opentrad/shared test
 Test Files  5 passed (5)
      Tests  36 passed (36)

$ pnpm -r --if-present typecheck
packages/shared typecheck: Done
... 8 packages all Done

$ pnpm lint
Checked 39 files in 5ms. No fixes applied.
```

## 已知歧义（PR 描述标注，待发起人拍板）

按发起人指令"有歧义的地方先按文档实现，完成后在 PR 描述里标一下"，本 PR 的歧义点都在"小偏离"列出，具体是第 2-5 项（CCResult 字段补全、三个占位 schema、CCStatus 字段、CCStartTaskRequest 字段）。这些都是架构文档未显式定义的工程补全，需要 review 时确认命名和字段集合可接受。

## Checklist

- [x] `pnpm -r --if-present typecheck` 通过（8/8 包）
- [x] `pnpm lint` 通过（39 文件，No fixes applied）
- [x] `pnpm --filter @opentrad/shared test` 通过（5 files / 36 tests）
- [x] 对应 issue：#3
- [x] PR 摘要标注了所有小偏离和歧义

🤖 Generated with [Claude Code](https://claude.com/claude-code)