### PR TITLE
feat(desktop): IPC cc:status end-to-end (main → preload → renderer)

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -10,6 +10,7 @@
     "start": "electron-vite preview"
   },
   "dependencies": {
+    "@opentrad/cc-adapter": "workspace:^",
     "electron": "^41.3.0",
     "react": "^19.2.5",
     "react-dom": "^19.2.5"

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -1,12 +1,17 @@
 // Electron 主进程入口。对应 03-architecture.md §2 apps/desktop/src/main/index.ts。
-// M0 范围：创建 BrowserWindow、加载 renderer、退出时清理。
-// 不在本 issue 内：IPC handlers（#7）、CC 集成（#8）、托盘/菜单（后续里程碑）。
+// M0 范围：BrowserWindow、CCManager 单例、IPC handlers 注册、退出时清理。
+// 不在本 issue 内：session 持久化（M2）、托盘/菜单、自动更新。
 
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
+import { CCManager } from "@opentrad/cc-adapter";
 import { app, BrowserWindow } from "electron";
+import { registerIpcHandlers } from "./ipc";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
+
+// 全局 CCManager 单例：所有 IPC handler 共享同一个 manager 以维持 activeTasks map。
+const ccManager = new CCManager();
 
 // contextIsolation + sandbox 按 03-architecture.md §9「沙箱和权限」开启。
 function createMainWindow(): BrowserWindow {
@@ -27,7 +32,6 @@ function createMainWindow(): BrowserWindow {
     win.show();
   });
 
-  // 开发模式 electron-vite 注入 ELECTRON_RENDERER_URL；生产模式读打包后的 HTML 文件。
   const devUrl = process.env.ELECTRON_RENDERER_URL;
   if (devUrl) {
     void win.loadURL(devUrl);
@@ -39,6 +43,7 @@ function createMainWindow(): BrowserWindow {
 }
 
 app.whenReady().then(() => {
+  registerIpcHandlers(ccManager);
   createMainWindow();
 
   // macOS 点 dock icon 重启窗口（Electron 推荐行为）
@@ -54,4 +59,13 @@ app.on("window-all-closed", () => {
   if (process.platform !== "darwin") {
     app.quit();
   }
+});
+
+// 应用退出前清理 CC 子进程（避免 claude 残留）。
+// CCManager 内部也注册了 SIGINT/SIGTERM/exit handler，这里是业务层再加一道保险。
+app.on("before-quit", async (event) => {
+  if (ccManager.activeTasks.size === 0) return;
+  event.preventDefault();
+  await ccManager.cleanup();
+  app.quit();
 });

--- a/apps/desktop/src/main/ipc/cc.ts
+++ b/apps/desktop/src/main/ipc/cc.ts
@@ -1,0 +1,56 @@
+// cc:* IPC handlers。对应 03-architecture.md §3 IPC channels + §4.1 Process Manager。
+// M0 范围：只实现 cc:status（Issue #7 验收要求）。
+// 后续里程碑：cc:start-task / cc:cancel-task / cc:event（Issue #8 + M1）。
+
+import { type CCManager, redactEmail } from "@opentrad/cc-adapter";
+import { type CCStatus, IpcChannels } from "@opentrad/shared";
+import { ipcMain } from "electron";
+
+export function registerCcHandlers(manager: CCManager): void {
+  ipcMain.handle(IpcChannels.CCStatus, async (): Promise<CCStatus> => {
+    return buildCcStatus(manager);
+  });
+}
+
+// 合成 CCStatus：detectInstallation + getAuthStatus 两步的合并视图。
+// 任一失败时把原因塞到 error 字段返回（不 throw，IPC 永远成功）。
+export async function buildCcStatus(manager: CCManager): Promise<CCStatus> {
+  try {
+    const detected = await manager.detectInstallation();
+    if (!detected.installed) {
+      return {
+        installed: false,
+        error: detected.error,
+      };
+    }
+
+    let loggedIn = false;
+    let email: string | undefined;
+    let authMethod: "subscription" | "api_key" | undefined;
+    let authError: string | undefined;
+
+    try {
+      const auth = await manager.getAuthStatus();
+      loggedIn = auth.loggedIn;
+      authMethod = auth.method;
+      email = auth.email ? redactEmail(auth.email) : undefined;
+      authError = auth.error;
+    } catch (err) {
+      authError = err instanceof Error ? err.message : String(err);
+    }
+
+    return {
+      installed: true,
+      version: detected.version,
+      loggedIn,
+      email,
+      authMethod,
+      error: authError,
+    };
+  } catch (err) {
+    return {
+      installed: false,
+      error: err instanceof Error ? err.message : String(err),
+    };
+  }
+}

--- a/apps/desktop/src/main/ipc/index.ts
+++ b/apps/desktop/src/main/ipc/index.ts
@@ -1,0 +1,10 @@
+// IPC handler 统一注册入口。启动时在 app.whenReady 里调一次。
+// 新增 domain 时在此 register 进来。
+
+import type { CCManager } from "@opentrad/cc-adapter";
+import { registerCcHandlers } from "./cc";
+
+export function registerIpcHandlers(manager: CCManager): void {
+  registerCcHandlers(manager);
+  // 后续 domain：skill / session / settings / risk-gate 在此注册
+}

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -1,15 +1,26 @@
 // Preload 脚本：contextBridge 暴露 typed IPC API 给 renderer。
-// 对应 03-architecture.md §2 apps/desktop/src/main/preload.ts。
+// 对应 03-architecture.md §2 apps/desktop/src/main/preload.ts + §3 IPC 协议。
 //
-// M0 范围：框架占位，暴露一个空 api 对象让 renderer 能 import 不报错。
-// Issue #7（IPC 通信）里补全实际 channel（cc/skill/session/settings）。
+// sandbox:true 下 preload 的能力受限：
+// - 可用：contextBridge、ipcRenderer（Electron 白名单）
+// - 不可用：任意 require、fs、child_process 等 Node API
+// 这是 03-architecture.md §9 安全边界的一部分。
 
-import { contextBridge } from "electron";
+import type { CCStatus } from "@opentrad/shared";
+import { IpcChannels } from "@opentrad/shared";
+import { contextBridge, ipcRenderer } from "electron";
 
-// M0 占位 API。Issue #7 会把各 channel 的 invoke 方法填进来。
+// 对 renderer 暴露的 API。每个 domain 对应一个子对象。
 const api = {
-  // IPC 方法待 Issue #7 实现
-};
+  cc: {
+    status(): Promise<CCStatus> {
+      return ipcRenderer.invoke(IpcChannels.CCStatus);
+    },
+  },
+  // skill / session / settings / risk-gate 后续补
+} as const;
+
+export type OpenTradApi = typeof api;
 
 if (process.contextIsolated) {
   try {
@@ -19,8 +30,5 @@ if (process.contextIsolated) {
   }
 } else {
   // contextIsolation 被关闭时的降级（生产不走这里）
-  // @ts-expect-error — 直接挂 window 的非标准用法仅限开发降级
   window.api = api;
 }
-
-export type OpenTradApi = typeof api;

--- a/apps/desktop/src/renderer/App.tsx
+++ b/apps/desktop/src/renderer/App.tsx
@@ -1,9 +1,36 @@
-// App 组件 — M0 占位：验证 Electron 窗口能渲染 React。
-// 三栏布局、SkillPicker、Chat 等留到 Issue #7-#8 和后续里程碑。
+// App 组件 — M0 阶段：通过 IPC 拿 CC 状态并展示。
+// Issue #7 验收点：window.api.cc.status() 能拿到 typed CCStatus，
+// 未装/未登录场景 UI 友好提示。
 
+import type { CCStatus } from "@opentrad/shared";
 import type { ReactElement } from "react";
+import { useEffect, useState } from "react";
+
+type LoadState =
+  | { kind: "loading" }
+  | { kind: "ready"; data: CCStatus }
+  | { kind: "error"; message: string };
 
 export function App(): ReactElement {
+  const [state, setState] = useState<LoadState>({ kind: "loading" });
+
+  useEffect(() => {
+    let cancelled = false;
+    window.api.cc
+      .status()
+      .then((data) => {
+        if (!cancelled) setState({ kind: "ready", data });
+      })
+      .catch((err: unknown) => {
+        if (cancelled) return;
+        const message = err instanceof Error ? err.message : String(err);
+        setState({ kind: "error", message });
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
   return (
     <div
       style={{
@@ -16,11 +43,73 @@ export function App(): ReactElement {
         color: "#333",
       }}
     >
-      <h1 style={{ fontSize: "2rem", marginBottom: "0.5rem" }}>Hello OpenTrad</h1>
-      <p style={{ color: "#666", fontSize: "0.95rem" }}>
-        Electron 主进程已启动，React renderer 已挂载。
+      <h1 style={{ fontSize: "2rem", marginBottom: "0.5rem" }}>OpenTrad</h1>
+      <CcStatusPanel state={state} />
+      <p style={{ color: "#999", fontSize: "0.85rem", marginTop: "2rem" }}>
+        M0 骨架 — Issue #7 IPC 通信
       </p>
-      <p style={{ color: "#999", fontSize: "0.85rem", marginTop: "1rem" }}>M0 骨架 — Issue #6</p>
+    </div>
+  );
+}
+
+function CcStatusPanel({ state }: { state: LoadState }): ReactElement {
+  if (state.kind === "loading") {
+    return <p style={{ color: "#999" }}>检测 Claude Code...</p>;
+  }
+  if (state.kind === "error") {
+    return (
+      <div
+        style={{
+          color: "#b91c1c",
+          background: "#fee2e2",
+          padding: "0.75rem 1rem",
+          borderRadius: 6,
+          maxWidth: 420,
+          textAlign: "center",
+        }}
+      >
+        <strong>IPC 调用失败：</strong>
+        {state.message}
+      </div>
+    );
+  }
+  const s = state.data;
+  if (!s.installed) {
+    return (
+      <div
+        style={{
+          color: "#92400e",
+          background: "#fef3c7",
+          padding: "0.75rem 1rem",
+          borderRadius: 6,
+          maxWidth: 420,
+          textAlign: "center",
+        }}
+      >
+        未检测到 Claude Code
+        {s.error ? (
+          <div style={{ fontSize: "0.85rem", marginTop: "0.25rem" }}>{s.error}</div>
+        ) : null}
+      </div>
+    );
+  }
+  if (!s.loggedIn) {
+    return (
+      <div style={{ color: "#666", textAlign: "center" }}>
+        <div>Claude Code 已安装（v{s.version}）</div>
+        <div style={{ color: "#92400e", marginTop: "0.25rem" }}>尚未登录</div>
+      </div>
+    );
+  }
+  const methodLabel = s.authMethod === "subscription" ? "Claude 订阅" : "API key";
+  return (
+    <div style={{ color: "#166534", textAlign: "center" }}>
+      <div>
+        已登录 <code>{s.email ?? "(unknown)"}</code>（{methodLabel}）
+      </div>
+      <div style={{ color: "#666", fontSize: "0.85rem", marginTop: "0.25rem" }}>
+        Claude Code v{s.version}
+      </div>
     </div>
   );
 }

--- a/apps/desktop/src/renderer/lib/api.d.ts
+++ b/apps/desktop/src/renderer/lib/api.d.ts
@@ -1,0 +1,10 @@
+// Renderer 侧的 window.api 类型声明。
+// preload 通过 contextBridge 挂 api 到 window；此处声明类型让 renderer 代码有完整类型提示。
+
+import type { OpenTradApi } from "../../preload";
+
+declare global {
+  interface Window {
+    api: OpenTradApi;
+  }
+}

--- a/docs/tech-debt.md
+++ b/docs/tech-debt.md
@@ -39,3 +39,27 @@
 **倾向**：M1 开始做 browser_open 工具时再实测体积，按真实数据选方案 A 或 B。方案 C 运维成本高不推荐。
 
 **不要在 M0 阶段解决**：M0 连 Playwright 都不引入，过早决策没依据。
+
+## TD-002 preload bundle 含 zod（138KB）
+
+**来源**：Issue #7 IPC 实现时观察（2026-04-24）
+
+**触发时机**：**M1 性能打磨时决策**（可延后）
+
+**状态**：`open`
+
+**详情**：
+
+preload 脚本 `import { IpcChannels } from '@opentrad/shared'` 会把整个 `@opentrad/shared` 模块图 bundle 进来——包括所有 zod schema（`WireCCEventSchema` / `CCEventSchema` 等），导致 preload 产出 138KB（其中 100KB+ 是 zod）。
+
+问题：preload 每次 BrowserWindow 启动都加载，体积直接影响窗口首次渲染速度。M0 性能目标里"UI 响应（点击 → 反馈）≤ 100ms"对此敏感。
+
+**选项**：
+
+1. **A. `src/common/ipc-channels.ts` 本地定义 IpcChannels**（架构文档 §2 就是这么设计的），preload 不 import `@opentrad/shared`。优点：preload bundle 降到 <10KB；缺点：IpcChannels 常量要在两处维护（shared 和 common，但 shared 是源头 common 抄）。
+2. **B. 改 `@opentrad/shared` 拆两个 entry**：`@opentrad/shared/ipc` 只导出 IPC 常量（纯数据），`@opentrad/shared` 原路径含 zod schema。
+3. **C. 配 vite `build.rollupOptions.output.manualChunks` 手工分离 zod**：让 preload 只打包用到的代码。vite 7+ 的 tree-shake 对 re-export chain 处理不完美，可能需要 explicit 配置。
+
+**倾向**：**A**，和架构文档 §2 目录结构一致（`src/common/ipc-channels.ts` 本就规划存在）。M1 实现。
+
+**不要在 M0 阶段解决**：功能正确优先；preload 138KB 对 dev/build 流程无影响，只是 window 启动多耗 ~10ms。

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -35,6 +35,9 @@ importers:
 
   apps/desktop:
     dependencies:
+      '@opentrad/cc-adapter':
+        specifier: workspace:^
+        version: link:../../packages/cc-adapter
       electron:
         specifier: ^41.3.0
         version: 41.3.0


### PR DESCRIPTION
Closes #7

## 一句话改动

按 \`03-architecture.md\` §3 实现 \`cc:status\` channel 的完整链路：renderer 调用 \`window.api.cc.status()\` → preload \`ipcRenderer.invoke\` → main \`ipcMain.handle\` → \`CCManager\` 的 detect/auth → 脱敏后返回 typed \`CCStatus\`。

## 文件改动

| 文件 | 作用 |
|---|---|
| \`src/main/ipc/cc.ts\` | \`cc:status\` handler，\`buildCcStatus(manager)\` 合成 detect + auth + redactEmail；永不 throw（走 \`error\` 字段） |
| \`src/main/ipc/index.ts\` | 所有 domain handler 的统一注册入口 |
| \`src/main/index.ts\` | \`CCManager\` 单例 + \`registerIpcHandlers\` + before-quit 清理 |
| \`src/preload/index.ts\` | \`contextBridge.exposeInMainWorld("api", {cc:{status()}})\` |
| \`src/renderer/lib/api.d.ts\` | \`declare global Window.api: OpenTradApi\` |
| \`src/renderer/App.tsx\` | LoadState 状态机；4 种 UI 分支 |

## UI 分支展示

| 状态 | 视觉 |
|---|---|
| loading | 灰色 "检测 Claude Code..." |
| IPC 失败 | 红色警告 + 错误信息 |
| CC 未装 | 黄色警告 "未检测到 Claude Code" + \`error\` 细节 |
| 未登录 | "已安装 vX.Y.Z / 尚未登录" |
| 已登录 | 绿色 "已登录 T***@gmx.es（Claude 订阅）" + CC 版本 |

## 类型一路到底

```
renderer App.tsx
  → window.api.cc.status(): Promise<CCStatus>    ← api.d.ts declare global
    → preload ipcRenderer.invoke(CCStatus)       ← IpcChannels.CCStatus 字符串常量
      → main ipcMain.handle(CCStatus, async (): Promise<CCStatus> => ...)
        → CCManager.detectInstallation() + getAuthStatus() + redactEmail()
```

CCStatus 类型从 \`@opentrad/shared\` import，compile-time 保证三层一致。

## 新增技术债（TD-002）

preload bundle 138KB（大头 zod，transitive from \`import { IpcChannels } from '@opentrad/shared'\`）。M1 优化方案：按架构 §2 目录结构在 \`src/common/ipc-channels.ts\` 本地定义 IpcChannels，降到 <10KB。详见 \`docs/tech-debt.md\` TD-002。

## 小偏离

- **@opentrad/cc-adapter 加为 desktop runtime dep**：main 进程实际用，合理
- **vite 8 vs electron-vite 5 peer warning**：非阻塞（PR #15 build/dev 都验证 OK）
- **CCStatus.error 在 UI 展示**：架构文档未规定 UI 形态，按 LoadState 状态机做了分层展示

## 验收

- [x] \`pnpm typecheck\` 全 workspace 绿
- [x] \`pnpm lint\` 66 files No fixes applied
- [x] \`pnpm -r --if-present test\` 114 tests passed
- [x] \`pnpm --filter @opentrad/desktop build\` main/preload/renderer 三入口通过
- [ ] **需你本地跑 \`pnpm dev\` 看窗口**：确认已登录 Claude 订阅 → 绿色展示邮箱 + Claude 订阅 + v2.1.119

## M0 进度

✅ #2 / ✅ #3 / ✅ #4 / ✅ #5 / ✅ #6 / **本 PR #7** / ✅ #9 / ❌ #8 Hello World demo

## 合并节奏

CI 绿直接自合（Issue #9 合并后规则）。合完后剩最后一个 Issue #8 — Hello World 端到端（点按钮 spawn CC → stream events → UI 气泡 → 完成）。**M0 就差这一步收官**。

🤖 Generated with [Claude Code](https://claude.com/claude-code)