### PR TITLE
feat(desktop): Hello World end-to-end demo (M0 finale)

### DIFF
--- a/apps/desktop/electron.vite.config.ts
+++ b/apps/desktop/electron.vite.config.ts
@@ -1,17 +1,29 @@
 // electron-vite 配置：三入口（main/preload/renderer）。
 // 开发阶段 `pnpm dev` 启动 electron-vite dev server；构建输出到 ./out/。
-// M0 范围：只要能启动窗口、渲染 React 页面。electron-builder 打包留到 M1。
+// M0 范围：只要能启动窗口、渲染 React 页面、跑通 IPC 事件流。
 
 import react from "@vitejs/plugin-react";
-import { defineConfig } from "electron-vite";
+import { defineConfig, externalizeDepsPlugin } from "electron-vite";
+
+// @opentrad/* 是 workspace 源码 TS，未 build。externalizeDepsPlugin 默认
+// 把所有 dependencies 当 external，会让 main/preload 在 Node 运行时按
+// ESM 规则 resolve，找不到 `.ts` 扩展名报 ERR_MODULE_NOT_FOUND。
+// 把 @opentrad/* 排除（即一起 bundle）避开此问题。
+const OPENTRAD_WORKSPACE_DEPS = [
+  "@opentrad/shared",
+  "@opentrad/stream-parser",
+  "@opentrad/cc-adapter",
+];
 
 export default defineConfig({
   main: {
+    plugins: [externalizeDepsPlugin({ exclude: OPENTRAD_WORKSPACE_DEPS })],
     build: {
       outDir: "out/main",
     },
   },
   preload: {
+    plugins: [externalizeDepsPlugin({ exclude: OPENTRAD_WORKSPACE_DEPS })],
     build: {
       outDir: "out/preload",
     },

--- a/apps/desktop/src/main/ipc/cc.ts
+++ b/apps/desktop/src/main/ipc/cc.ts
@@ -1,15 +1,71 @@
 // cc:* IPC handlers。对应 03-architecture.md §3 IPC channels + §4.1 Process Manager。
-// M0 范围：只实现 cc:status（Issue #7 验收要求）。
-// 后续里程碑：cc:start-task / cc:cancel-task / cc:event（Issue #8 + M1）。
+// 实现范围：
+// - cc:status（Issue #7）：CC 安装 + 登录状态查询
+// - cc:start-task（Issue #8）：spawn CC 任务，立刻返回 sessionId
+// - cc:cancel-task（Issue #8）：按 sessionId 取消
+// - cc:event（Issue #8）：main 向 renderer 推 domain CCEvent 流
+//
+// M0 阶段简化：prompt 硬编码 "Say hi in Chinese"，mcp-config 写一个空文件；
+// skill 管理和真实 prompt composer 在 M1。
 
+import { randomUUID } from "node:crypto";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { type CCManager, redactEmail } from "@opentrad/cc-adapter";
-import { type CCStatus, IpcChannels } from "@opentrad/shared";
+import {
+  type CCCancelTaskRequest,
+  type CCStartTaskResponse,
+  type CCStatus,
+  IpcChannels,
+} from "@opentrad/shared";
 import { ipcMain } from "electron";
 
 export function registerCcHandlers(manager: CCManager): void {
   ipcMain.handle(IpcChannels.CCStatus, async (): Promise<CCStatus> => {
     return buildCcStatus(manager);
   });
+
+  ipcMain.handle(IpcChannels.CCStartTask, async (event): Promise<CCStartTaskResponse> => {
+    // M0：忽略 renderer 传的 skillId/inputs，固定 demo prompt。M1 接 skill runtime。
+    const sessionId = randomUUID();
+    const tmpDir = await mkdtemp(join(tmpdir(), "opentrad-m0-"));
+    const mcpConfigPath = join(tmpDir, "mcp-config.json");
+    await writeFile(mcpConfigPath, JSON.stringify({ mcpServers: {} }));
+
+    const handle = await manager.startTask({
+      sessionId,
+      prompt: "Say hi in Chinese",
+      mcpConfigPath,
+      allowedTools: [],
+      model: "haiku",
+    });
+
+    // 异步把 events 推给这个 webContents；结束后清临时目录。
+    // 不 await 这个 IIFE —— startTask 要立刻返回 sessionId 给 renderer。
+    void (async () => {
+      try {
+        for await (const evt of handle.events) {
+          if (event.sender.isDestroyed()) break;
+          event.sender.send(IpcChannels.CCEvent, evt);
+        }
+      } catch (err) {
+        console.error("[cc:event] stream error", err);
+      } finally {
+        await rm(tmpDir, { recursive: true, force: true });
+      }
+    })();
+
+    return { sessionId };
+  });
+
+  ipcMain.handle(
+    IpcChannels.CCCancelTask,
+    async (_event, req: CCCancelTaskRequest): Promise<void> => {
+      const handle = manager.activeTasks.get(req.sessionId);
+      if (handle) await handle.cancel();
+    },
+  );
 }
 
 // 合成 CCStatus：detectInstallation + getAuthStatus 两步的合并视图。

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -6,7 +6,13 @@
 // - 不可用：任意 require、fs、child_process 等 Node API
 // 这是 03-architecture.md §9 安全边界的一部分。
 
-import type { CCStatus } from "@opentrad/shared";
+import type {
+  CCCancelTaskRequest,
+  CCEvent,
+  CCStartTaskRequest,
+  CCStartTaskResponse,
+  CCStatus,
+} from "@opentrad/shared";
 import { IpcChannels } from "@opentrad/shared";
 import { contextBridge, ipcRenderer } from "electron";
 
@@ -15,6 +21,20 @@ const api = {
   cc: {
     status(): Promise<CCStatus> {
       return ipcRenderer.invoke(IpcChannels.CCStatus);
+    },
+    startTask(req: CCStartTaskRequest): Promise<CCStartTaskResponse> {
+      return ipcRenderer.invoke(IpcChannels.CCStartTask, req);
+    },
+    cancelTask(req: CCCancelTaskRequest): Promise<void> {
+      return ipcRenderer.invoke(IpcChannels.CCCancelTask, req);
+    },
+    // 订阅 CC 事件流。返回 unsubscribe 函数，renderer 在 useEffect 清理时调用。
+    onEvent(handler: (evt: CCEvent) => void): () => void {
+      const listener = (_event: unknown, evt: CCEvent): void => handler(evt);
+      ipcRenderer.on(IpcChannels.CCEvent, listener);
+      return () => {
+        ipcRenderer.removeListener(IpcChannels.CCEvent, listener);
+      };
     },
   },
   // skill / session / settings / risk-gate 后续补

--- a/apps/desktop/src/renderer/App.tsx
+++ b/apps/desktop/src/renderer/App.tsx
@@ -1,115 +1,299 @@
-// App 组件 — M0 阶段：通过 IPC 拿 CC 状态并展示。
-// Issue #7 验收点：window.api.cc.status() 能拿到 typed CCStatus，
-// 未装/未登录场景 UI 友好提示。
+// App 组件 — M0 收官（Issue #8）：
+// 用户点"Say Hi"按钮 → main spawn CC → stream-json 事件流渲染 → "完成" 标记。
+// 不做 markdown（M1）、skill 表单（M1）、MCP 工具（M2）、Risk Gate（M2）。
 
-import type { CCStatus } from "@opentrad/shared";
+import type { CCEvent, CCStatus } from "@opentrad/shared";
 import type { ReactElement } from "react";
 import { useEffect, useState } from "react";
 
-type LoadState =
+type CcStatusState =
   | { kind: "loading" }
   | { kind: "ready"; data: CCStatus }
   | { kind: "error"; message: string };
 
-export function App(): ReactElement {
-  const [state, setState] = useState<LoadState>({ kind: "loading" });
+type TaskState =
+  | { kind: "idle" }
+  | { kind: "running"; sessionId: string }
+  | { kind: "finished"; sessionId: string; success: boolean };
 
+export function App(): ReactElement {
+  const [ccStatus, setCcStatus] = useState<CcStatusState>({ kind: "loading" });
+  const [task, setTask] = useState<TaskState>({ kind: "idle" });
+  const [events, setEvents] = useState<CCEvent[]>([]);
+
+  // 加载 CC 状态一次
   useEffect(() => {
     let cancelled = false;
     window.api.cc
       .status()
       .then((data) => {
-        if (!cancelled) setState({ kind: "ready", data });
+        if (!cancelled) setCcStatus({ kind: "ready", data });
       })
       .catch((err: unknown) => {
         if (cancelled) return;
         const message = err instanceof Error ? err.message : String(err);
-        setState({ kind: "error", message });
+        setCcStatus({ kind: "error", message });
       });
     return () => {
       cancelled = true;
     };
   }, []);
 
+  // 订阅 CC 事件流（全局一次）
+  useEffect(() => {
+    const unsubscribe = window.api.cc.onEvent((evt) => {
+      setEvents((prev) => [...prev, evt]);
+      if (evt.type === "result") {
+        setTask((prev) =>
+          prev.kind === "running"
+            ? {
+                kind: "finished",
+                sessionId: prev.sessionId,
+                success: evt.subtype === "success",
+              }
+            : prev,
+        );
+      }
+    });
+    return unsubscribe;
+  }, []);
+
+  const canStart =
+    ccStatus.kind === "ready" &&
+    ccStatus.data.installed &&
+    ccStatus.data.loggedIn === true &&
+    task.kind !== "running";
+
+  const onSayHi = async (): Promise<void> => {
+    setEvents([]);
+    setTask({ kind: "running", sessionId: "pending" });
+    try {
+      const { sessionId } = await window.api.cc.startTask({
+        skillId: "__m0_demo__",
+        inputs: {},
+      });
+      setTask({ kind: "running", sessionId });
+    } catch (err) {
+      console.error("[App] startTask failed", err);
+      setTask({ kind: "idle" });
+    }
+  };
+
   return (
     <div
       style={{
         display: "flex",
         flexDirection: "column",
-        alignItems: "center",
-        justifyContent: "center",
         height: "100vh",
         fontFamily: "system-ui, -apple-system, sans-serif",
         color: "#333",
       }}
     >
-      <h1 style={{ fontSize: "2rem", marginBottom: "0.5rem" }}>OpenTrad</h1>
-      <CcStatusPanel state={state} />
-      <p style={{ color: "#999", fontSize: "0.85rem", marginTop: "2rem" }}>
-        M0 骨架 — Issue #7 IPC 通信
-      </p>
+      <Header ccStatus={ccStatus} task={task} />
+      <div style={{ padding: "0 2rem 1rem", textAlign: "center" }}>
+        <button
+          type="button"
+          onClick={onSayHi}
+          disabled={!canStart}
+          style={{
+            padding: "0.6rem 1.5rem",
+            fontSize: "1rem",
+            borderRadius: 6,
+            border: "none",
+            background: canStart ? "#2563eb" : "#cbd5e1",
+            color: "white",
+            cursor: canStart ? "pointer" : "not-allowed",
+          }}
+        >
+          {task.kind === "running" ? "进行中..." : "Say Hi in Chinese"}
+        </button>
+      </div>
+      <EventList events={events} />
     </div>
   );
 }
 
-function CcStatusPanel({ state }: { state: LoadState }): ReactElement {
+function Header({ ccStatus, task }: { ccStatus: CcStatusState; task: TaskState }): ReactElement {
+  return (
+    <header
+      style={{
+        padding: "1rem 2rem",
+        borderBottom: "1px solid #e5e7eb",
+        display: "flex",
+        justifyContent: "space-between",
+        alignItems: "center",
+      }}
+    >
+      <h1 style={{ fontSize: "1.5rem", margin: 0 }}>OpenTrad</h1>
+      <div style={{ fontSize: "0.85rem" }}>
+        <CcStatusInline state={ccStatus} />
+        {task.kind === "finished" ? (
+          <span
+            style={{
+              marginLeft: "1rem",
+              color: task.success ? "#166534" : "#b91c1c",
+            }}
+          >
+            {task.success ? "✓ 完成" : "× 失败"}
+          </span>
+        ) : null}
+      </div>
+    </header>
+  );
+}
+
+function CcStatusInline({ state }: { state: CcStatusState }): ReactElement {
   if (state.kind === "loading") {
-    return <p style={{ color: "#999" }}>检测 Claude Code...</p>;
+    return <span style={{ color: "#999" }}>检测中...</span>;
   }
   if (state.kind === "error") {
-    return (
-      <div
-        style={{
-          color: "#b91c1c",
-          background: "#fee2e2",
-          padding: "0.75rem 1rem",
-          borderRadius: 6,
-          maxWidth: 420,
-          textAlign: "center",
-        }}
-      >
-        <strong>IPC 调用失败：</strong>
-        {state.message}
-      </div>
-    );
+    return <span style={{ color: "#b91c1c" }}>IPC 错误：{state.message}</span>;
   }
   const s = state.data;
   if (!s.installed) {
+    return <span style={{ color: "#92400e" }}>CC 未安装</span>;
+  }
+  if (!s.loggedIn) {
+    return <span style={{ color: "#92400e" }}>v{s.version} · 未登录</span>;
+  }
+  const methodLabel = s.authMethod === "subscription" ? "订阅" : "API";
+  return (
+    <span style={{ color: "#166534" }}>
+      v{s.version} · {s.email ?? "(?)"}（{methodLabel}）
+    </span>
+  );
+}
+
+function EventList({ events }: { events: CCEvent[] }): ReactElement {
+  if (events.length === 0) {
     return (
       <div
         style={{
-          color: "#92400e",
-          background: "#fef3c7",
-          padding: "0.75rem 1rem",
-          borderRadius: 6,
-          maxWidth: 420,
-          textAlign: "center",
+          flex: 1,
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "center",
+          color: "#9ca3af",
         }}
       >
-        未检测到 Claude Code
-        {s.error ? (
-          <div style={{ fontSize: "0.85rem", marginTop: "0.25rem" }}>{s.error}</div>
-        ) : null}
+        点按钮发送 "Say Hi in Chinese" 到 Claude Code
       </div>
     );
   }
-  if (!s.loggedIn) {
-    return (
-      <div style={{ color: "#666", textAlign: "center" }}>
-        <div>Claude Code 已安装（v{s.version}）</div>
-        <div style={{ color: "#92400e", marginTop: "0.25rem" }}>尚未登录</div>
-      </div>
-    );
-  }
-  const methodLabel = s.authMethod === "subscription" ? "Claude 订阅" : "API key";
   return (
-    <div style={{ color: "#166534", textAlign: "center" }}>
-      <div>
-        已登录 <code>{s.email ?? "(unknown)"}</code>（{methodLabel}）
-      </div>
-      <div style={{ color: "#666", fontSize: "0.85rem", marginTop: "0.25rem" }}>
-        Claude Code v{s.version}
-      </div>
+    <div style={{ flex: 1, overflowY: "auto", padding: "0 2rem 2rem" }}>
+      {events.map((evt, i) => (
+        // biome-ignore lint/suspicious/noArrayIndexKey: event list is append-only, order is stable
+        <EventCard key={`${i}-${evt.type}`} evt={evt} />
+      ))}
+    </div>
+  );
+}
+
+function EventCard({ evt }: { evt: CCEvent }): ReactElement {
+  switch (evt.type) {
+    case "system":
+      return (
+        <Card tone="neutral">
+          <strong>system/init</strong>
+          <div style={{ fontSize: "0.8rem", color: "#666" }}>
+            model={evt.data.model} · cc={evt.data.claudeCodeVersion}
+          </div>
+        </Card>
+      );
+    case "rate_limit_event":
+      return (
+        <Card tone="warning">
+          <strong>rate limit</strong>
+          <div style={{ fontSize: "0.8rem" }}>
+            type={evt.rateLimitInfo.rateLimitType} · status={evt.rateLimitInfo.status}
+          </div>
+        </Card>
+      );
+    case "assistant_thinking":
+      return (
+        <Card tone="thinking">
+          <details>
+            <summary style={{ cursor: "pointer", color: "#64748b" }}>思考过程</summary>
+            <div style={{ whiteSpace: "pre-wrap", fontSize: "0.85rem", marginTop: "0.5rem" }}>
+              {evt.thinking}
+            </div>
+          </details>
+        </Card>
+      );
+    case "assistant_text":
+      return (
+        <Card tone="assistant">
+          <div style={{ whiteSpace: "pre-wrap" }}>{evt.text}</div>
+        </Card>
+      );
+    case "assistant_tool_use":
+      return (
+        <Card tone="tool">
+          <strong>工具调用：{evt.name}</strong>
+          <pre style={{ fontSize: "0.75rem", margin: "0.25rem 0 0", overflow: "auto" }}>
+            {JSON.stringify(evt.input, null, 2)}
+          </pre>
+        </Card>
+      );
+    case "tool_result":
+      return (
+        <Card tone="tool">
+          <strong>工具结果</strong>
+          <pre style={{ fontSize: "0.75rem", margin: "0.25rem 0 0", overflow: "auto" }}>
+            {JSON.stringify(evt.content, null, 2)}
+          </pre>
+        </Card>
+      );
+    case "result":
+      return (
+        <Card tone={evt.subtype === "success" ? "success" : "error"}>
+          <strong>{evt.subtype === "success" ? "✓ 任务完成" : "× 任务失败"}</strong>
+          <div style={{ fontSize: "0.8rem", color: "#666" }}>
+            duration={evt.data.durationMs}ms · cost=${evt.data.totalCostUsd.toFixed(6)}
+          </div>
+        </Card>
+      );
+    case "unknown":
+      return (
+        <Card tone="neutral">
+          <strong>unknown event</strong>
+          <pre style={{ fontSize: "0.75rem", margin: "0.25rem 0 0", overflow: "auto" }}>
+            {JSON.stringify(evt.raw, null, 2)}
+          </pre>
+        </Card>
+      );
+  }
+}
+
+function Card({
+  tone,
+  children,
+}: {
+  tone: "neutral" | "warning" | "thinking" | "assistant" | "tool" | "success" | "error";
+  children: React.ReactNode;
+}): ReactElement {
+  const palette: Record<typeof tone, { bg: string; border: string }> = {
+    neutral: { bg: "#f3f4f6", border: "#e5e7eb" },
+    warning: { bg: "#fef3c7", border: "#fde68a" },
+    thinking: { bg: "#f1f5f9", border: "#e2e8f0" },
+    assistant: { bg: "#e0f2fe", border: "#bae6fd" },
+    tool: { bg: "#ede9fe", border: "#ddd6fe" },
+    success: { bg: "#dcfce7", border: "#bbf7d0" },
+    error: { bg: "#fee2e2", border: "#fecaca" },
+  };
+  const c = palette[tone];
+  return (
+    <div
+      style={{
+        background: c.bg,
+        border: `1px solid ${c.border}`,
+        borderRadius: 6,
+        padding: "0.75rem 1rem",
+        margin: "0.5rem 0",
+      }}
+    >
+      {children}
     </div>
   );
 }


### PR DESCRIPTION
Closes #8

## 🎉 M0 收官 PR

这是 M0 骨架可跑的最后一个 issue。合并后 **M0 全部 8 个 issue 完成**，OpenTrad 达到"图形化应用 + 真实 Claude Code 对话完整跑通"的初始形态。

## 一句话改动

串起 renderer/preload/main/cc-adapter/stream-parser 全链路：点按钮 → spawn CC → stream-json 事件流式渲染到 UI → "✓ 任务完成" 标记。

## IPC 三个新 channel

| channel | 方向 | 作用 |
|---|---|---|
| `cc:start-task` | Renderer → Main | 返回 `sessionId`；main 里 spawn CC + 写临时空 mcp-config；异步订阅 handle.events 推送 |
| `cc:cancel-task` | Renderer → Main | 按 sessionId 找 activeTasks 调 cancel |
| `cc:event` | Main → Renderer push | 每个 domain CCEvent 推给触发者的 webContents |

## UI 展示 8 种事件变体

| 类型 | 样式 |
|---|---|
| `system` | 灰色 "model + cc 版本" |
| `rate_limit_event` | 黄色 "type + status" |
| `assistant_thinking` | 灰色折叠 `<details>` 思考过程 |
| `assistant_text` | 蓝色对话气泡 |
| `assistant_tool_use` | 紫色工具卡片（name + input JSON） |
| `tool_result` | 紫色结果 |
| `result` | 绿色"✓ 任务完成" + duration + cost |
| `unknown` | 灰色 raw JSON |

## 配置修正（小偏离）

`electron.vite.config.ts` 的 `externalizeDepsPlugin` 加 `exclude: ["@opentrad/shared", "@opentrad/stream-parser", "@opentrad/cc-adapter"]`。

**根因**：electron-vite 默认把 `package.json dependencies` 全部 external，Node 运行时按 ESM 规则解析 `./auth` 找不到 `.ts` 扩展报 `ERR_MODULE_NOT_FOUND`。workspace 源码包必须 bundle。

发现方式：Issue #7 合并后新增 main 侧 `import { CCManager } from '@opentrad/cc-adapter'`，dev 启动触发该错误；修完 dev 正常启动。

## 验收

- [x] `pnpm typecheck` 全 workspace + scripts 绿
- [x] `pnpm lint` 66 files No fixes applied
- [x] `pnpm -r --if-present test` 114 tests passed (shared 61 + stream-parser 30 + cc-adapter 23)
- [x] `pnpm --filter @opentrad/desktop build`: main 156KB / preload 139KB / renderer 495KB
- [x] `pnpm dev` dev server + electron process 启动，SIGTERM 后 0 残留
- [ ] **需你本地端到端验收**：`pnpm dev` → 点"Say Hi in Chinese" → 看到 thinking 折叠 + "好的。"气泡 + "✓ 任务完成"

## 不在本 PR 内（按架构文档归属 M1/M2）

- Markdown 渲染（M1 F2.3）
- Skill 表单 UI（M1 F3.4）
- 对话多轮续聊（M1 F1.5）
- 三栏布局 / 侧边栏 / 历史（M1 F6.3-6.5）
- OpenTrad MCP server + Playwright（M2）
- Risk Gate business-level 弹窗卡（M2 F5.2）

## M0 完成清单

| Issue | PR | Done |
|---|---|---|
| #2 monorepo 骨架 | #10 | ✅ |
| #3 shared 类型地基 | #11 | ✅ |
| #4 stream-parser | #12 | ✅ |
| #5 cc-adapter | #13 | ✅ |
| #6 Electron 骨架 | #15 | ✅ |
| #7 IPC 通信 | #16 | ✅ |
| #9 CI/CD | #14 | ✅ |
| #8 Hello World demo | **本 PR** | 🔄 |

## 合并后建议

按 `04-kickoff-checklist.md` §6："M0 跑通后由总工（Claude Opus 4.7）单独起草 M1 issue 清单"。建议你合完本 PR → 新开 claude.ai 对话召唤总工 → 起草 M1 的 12 个 issue（F1.4 PTY fallback、F2.3 Markdown、F3.1-F3.3 Skill runtime、F6.1-F6.2 安装/登录向导、F6.4-F6.7 主界面 + 输入框 + 导出、`trade-email-writer` skill 端到端）。

### M0 剩余技术债（docs/tech-debt.md）

- **TD-001** Playwright Chromium 打包 vs 下载（M1 开工前决策）
- **TD-002** preload bundle 含 zod 138KB（M1 按架构 §2 做 `src/common/ipc-channels.ts`）
- **D6 follow-up**（未创建 TD 条目，但在 memory feedback_autonomy 的 M0 收官前调节阀清单里）：StreamParser 的 isLast/messageMeta 语义 JSDoc 澄清 + README consumer guide

## 合并节奏

CI 绿直接自合。合完后我暂停等你新开总工对话 + M1 issue 清单。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
