### PR TITLE
docs(stream-parser): clarify per-wire-event semantics + add Consumer guide

### DIFF
--- a/packages/shared/src/types/cc-event.ts
+++ b/packages/shared/src/types/cc-event.ts
@@ -1,8 +1,12 @@
 // CC stream-json 事件的 domain 层：OpenTrad 内部统一消费形态。
-// 设计原则（按发起人拍板 D1 = 方案 B'、D6 = 方案 X + D6a 修正）：
+// 设计原则（按发起人拍板 D1 = 方案 B'、D6 = 方案 X + D6a 修正、D6 后续修订）：
 // - 字段统一 camelCase
 // - assistant event 扁平化为 assistant_text / assistant_thinking / assistant_tool_use 独立变体
-// - 同一逻辑消息的多个 domain 事件用 msgId + seq 关联；最后一个带 isLast=true + messageMeta
+// - 同一 wire assistant event 内多个 block 用 msgId + seq 关联；最后一个 block 带 isLast=true + messageMeta
+// - **per-wire-event 语义（重要）**：CC 2.1.119 实测每个 content block 是独立 wire assistant event，
+//   因此 isLast=true 表示"本 wire event 的最后一个 block"，**不**等同"整条逻辑消息说完"。
+//   消费方判断"消息真说完"应观察 tool_result / result / 下一个 user turn 三个锚点；
+//   完整 Consumer guide 见 packages/stream-parser/README.md。
 // - 不泄漏 wire 层字段（snake_case、Anthropic API message 包裹结构等）
 // stream-parser 的 normalize 函数负责 wire → domain 映射（含 1→N 扁平化）。
 
@@ -19,7 +23,12 @@ export const UsageSchema = z.object({
 });
 export type Usage = z.infer<typeof UsageSchema>;
 
-// per-message 元数据，挂在同一 msgId 的最后一个 domain 事件上（D6a）。
+// per-message 元数据：model / usage / stopReason。
+// 挂在同一 wire assistant event 内最后一个 block 对应的 domain 事件上（D6a + 后续修订）。
+// **per-wire-event 语义**：CC 2.1.119 实测每个 content block 一个独立 wire event，
+// 因此 messageMeta 实际是"per wire event 快照"——usage / stopReason 反映的是
+// 这个 wire event 截至此刻的 message-level 累计状态。整条消息真说完的判断详见
+// packages/stream-parser/README.md 的 Consumer guide。
 export const MessageMetaSchema = z.object({
   model: z.string(),
   usage: UsageSchema,
@@ -99,7 +108,11 @@ export const AssistantTextEventSchema = z.object({
   seq: z.number().int(),
   sessionId: z.string(),
   uuid: z.string(),
+  // per-wire-event 语义：本 wire event 内最后一个 block 时 true。
+  // 不等同"整条消息说完"——同 msgId 的下一个 wire event 到达前不可信。
+  // 消费方判断详见 stream-parser/README.md Consumer guide。
   isLast: z.boolean(),
+  // 仅当 isLast=true 时存在；per-wire-event 快照（不是整条消息终态）。
   messageMeta: MessageMetaSchema.optional(),
   text: z.string(),
 });
@@ -111,7 +124,9 @@ export const AssistantThinkingEventSchema = z.object({
   seq: z.number().int(),
   sessionId: z.string(),
   uuid: z.string(),
+  // per-wire-event 语义：本 wire event 内最后一个 block 时 true。详见 README Consumer guide。
   isLast: z.boolean(),
+  // 仅当 isLast=true 时存在；per-wire-event 快照。
   messageMeta: MessageMetaSchema.optional(),
   thinking: z.string(),
   signature: z.string(),
@@ -124,7 +139,9 @@ export const AssistantToolUseEventSchema = z.object({
   seq: z.number().int(),
   sessionId: z.string(),
   uuid: z.string(),
+  // per-wire-event 语义：本 wire event 内最后一个 block 时 true。详见 README Consumer guide。
   isLast: z.boolean(),
+  // 仅当 isLast=true 时存在；per-wire-event 快照。
   messageMeta: MessageMetaSchema.optional(),
   toolUseId: z.string(),
   name: z.string(),

--- a/packages/stream-parser/README.md
+++ b/packages/stream-parser/README.md
@@ -1,0 +1,107 @@
+# @opentrad/stream-parser
+
+Claude Code stream-json (NDJSON) → OpenTrad domain 事件流的解析器。
+
+## 职责
+
+- 行级 NDJSON 缓冲与切分(`parser.ts`)
+- wire 层 zod 校验(`WireCCEvent`,在 `@opentrad/shared`)
+- wire → domain 显式映射(`normalize.ts`):字段 camelCase 化 + assistant 1→N 扁平化
+- 任何失败(非 JSON 行、wire schema 不匹配、未知 type)→ `unknown` domain 事件兜底,不丢数据
+
+## 公开 API
+
+```ts
+import { StreamParser } from "@opentrad/stream-parser";
+import type { CCEvent } from "@opentrad/shared";
+
+const parser = new StreamParser();
+
+// 子进程 stdout 喂入 chunk,yield 出可完整解析的 CCEvent
+ccStdout.on("data", (chunk: string) => {
+  for (const event of parser.parseChunk(chunk)) {
+    handleEvent(event);
+  }
+});
+
+// 流结束(子进程退出)时
+ccStdout.on("end", () => {
+  for (const event of parser.flush()) {
+    handleEvent(event);
+  }
+});
+```
+
+## Consumer guide:如何判断 message 真的说完
+
+`isLast=true` 与 `messageMeta` 是 **per-wire-event 语义**:CC 2.1.119 实测每个 content block 是一个独立 wire `assistant` event,所以 `normalize` 函数 1→N 中的 N 通常等于 1。这意味着:
+
+- **`isLast=true` 仅表示"本 wire event 内最后一个 block 的 domain 事件"**,不等同"整条逻辑消息真的说完"
+- **`messageMeta` 是 per-wire-event 快照**——`usage` / `stopReason` 反映这个 wire event 截至此刻的 message-level 累计状态,**不**是整条消息的最终值
+
+要判断"消息真的说完"(例如 UI 关闭 streaming 动画 / 关闭对话气泡 / 入库结算),消费方应观察以下三个锚点中的任一个。
+
+### 锚点 1:同 msgId 后跟 `tool_result`
+
+CC 调用工具后,会发送 `tool_result` 事件。如果一条 assistant message 以 `tool_use` 结尾(模型决定调用工具),则 `tool_result` 到达可视为"该 message 已切换到工具结果阶段,assistant 这一轮说完了"。
+
+```ts
+for (const event of parser.parseChunk(chunk)) {
+  if (event.type === "tool_result") {
+    // 上一个 assistant message 已结束(进入工具结果阶段)
+    closeAssistantBubble(event.msgId);
+  }
+}
+```
+
+### 锚点 2:`result` 事件到达
+
+`result` 事件表示整个 task 结束,携带 `stopReason` / `totalCostUsd` / `durationMs` 等终态字段。这是最强信号——message 和整个 task 都说完。
+
+```ts
+for (const event of parser.parseChunk(chunk)) {
+  if (event.type === "result") {
+    finalizeTask(event.sessionId, event.data.totalCostUsd, event.data.durationMs);
+  }
+}
+```
+
+### 锚点 3:新 msgId 的 assistant event(下一个 user turn 后)
+
+如果用户继续聊天,CC 在下一轮 user turn 后会发送**新 msgId** 的 assistant event。前一个 msgId 的所有事件视为已结束。
+
+```ts
+let lastMsgId: string | undefined;
+
+function isAssistantBlockEvent(e: CCEvent): e is
+  | Extract<CCEvent, { type: "assistant_text" }>
+  | Extract<CCEvent, { type: "assistant_thinking" }>
+  | Extract<CCEvent, { type: "assistant_tool_use" }> {
+  return (
+    e.type === "assistant_text" ||
+    e.type === "assistant_thinking" ||
+    e.type === "assistant_tool_use"
+  );
+}
+
+for (const event of parser.parseChunk(chunk)) {
+  if (isAssistantBlockEvent(event)) {
+    if (lastMsgId && event.msgId !== lastMsgId) {
+      closeMessage(lastMsgId);  // 上一个 message 真的结束了
+    }
+    lastMsgId = event.msgId;
+  }
+}
+```
+
+### 为什么不能直接信 `isLast=true`
+
+历史背景:M0 期间 D6 决策"扁平化事件流"的初版假设是"一个 wire event 包含 N 个 content blocks,最后一个 block 带 isLast + messageMeta"。实测 CC 2.1.119 是**每个 content block 一个独立 wire event**,导致每个 wire event 内 blocks.length 通常 = 1,**每个 domain 事件都是 `isLast=true` 且都带 messageMeta**。这使 `isLast` 退化为"per wire event last",不再具备"per message last"的判别力。
+
+完整背景见 `open-trad/docs` repo `design/retrospective-m0.md` §三 D6 后续 + §四 勘误 3。
+
+## 设计参考
+
+- `open-trad/docs` repo `design/03-architecture.md` §4.2
+- `design/retrospective-m0.md` §三 D6 后续 + §四 勘误 3 + §五 TD-D6
+- 拍板:D1(wire/domain 两层类型)、D6(扁平化事件流)、D6 后续修订(per-wire-event 语义)

--- a/packages/stream-parser/src/normalize.ts
+++ b/packages/stream-parser/src/normalize.ts
@@ -1,7 +1,11 @@
-// wire → domain 显式映射（按发起人 D1=B' / D6=X / D6a 拍板）。
+// wire → domain 显式映射（按发起人 D1=B' / D6=X / D6a 拍板 / D6 后续修订）。
 // 输入 wire 层 schema 化后的 WireCCEvent，产出 0-N 个 domain CCEvent：
 // - system/rate_limit/result：1→1 直接字段改名 + 挑选
 // - assistant：1→N 按 content block 扁平化，metadata 挂最后一个事件（isLast=true）
+//
+// **per-wire-event 语义（重要）**：CC 2.1.119 实测每个 content block 是独立 wire assistant event，
+// 所以 1→N 中 N 通常 = 1。isLast=true 的语义是"本 wire event 内最后一个 block"，
+// **不是**"整条逻辑消息说完"。消费方判断详见 packages/stream-parser/README.md 的 Consumer guide。
 //
 // 设计不变量：
 // - 每个 domain 事件都带 msgId / seq / sessionId / uuid（D6e）
@@ -76,6 +80,7 @@ function normalizeUsage(wire: WireUsage): Usage {
 
 // 1 个 wire assistant event → N 个 domain events（按 content block 数量）。
 // metadata 挂最后一个 event 的 messageMeta 字段，isLast=true。
+// per-wire-event 语义说明见模块顶部注释 + README Consumer guide。
 function* normalizeAssistant(wire: WireAssistantEvent): Generator<CCEvent> {
   const blocks = wire.message.content;
   const msgId = wire.message.id;


### PR DESCRIPTION
## 背景

落地 [retrospective-m0.md](https://github.com/open-trad/docs/blob/main/design/retrospective-m0.md) §五 TD-D6 + §四 勘误 3 的代码与 README 部分（M1 #1 / #18 第一部分）。

D6 决策"扁平化事件流"的初版假设是"一个 wire assistant event 包含 N 个 content blocks，最后一个 block 带 `isLast=true` + `messageMeta`"。M0 实测 CC 2.1.119 实际是 **每个 content block 一个独立 wire assistant event**，导致每个 wire event 内 `blocks.length` 通常 = 1，每个 domain 事件都是 `isLast=true` 且都带 `messageMeta`。这使 `isLast` 退化为 "per-wire-event last"，不再具备 "per-message last" 的判别力（详见 retrospective §三 D6 后续）。

## 路径修正(自查)

#18 issue body 写"\`packages/stream-parser/src/types.ts\`"，但 M0 实际把 domain 类型放在 \`packages/shared/src/types/cc-event.ts\`（D1 决策"两层类型放 shared"的体现）。本 PR 把 JSDoc 加在实际定义所在的 shared 包；stream-parser 包先前不存在 README，本 PR 新建。

## 改动

- \`packages/shared/src/types/cc-event.ts\`：\`AssistantTextEventSchema\` / \`AssistantThinkingEventSchema\` / \`AssistantToolUseEventSchema\` 的 \`isLast\` / \`messageMeta\` 字段加行内注释；模块顶部和 \`MessageMetaSchema\` 注释扩展为 per-wire-event 语义说明，指向 README Consumer guide
- \`packages/stream-parser/src/normalize.ts\`：顶部注释 + \`normalizeAssistant\` 函数注释扩展
- \`packages/stream-parser/README.md\`：新建。含 Consumer guide「如何判断 message 真的说完」三锚点（\`tool_result\` / \`result\` / 新 \`msgId\`）+ TS 代码片段

## 不在本 PR 范围(#18 后续 PR)

- \`open-trad/docs\` repo \`design/03-architecture.md\` §4.2 勘误 3（单独 PR）
- evidence 样本采集 (a) MCP wire 协议 + (b) disallowed 路径事件流（docs repo \`evidence/m1-prep-samples/\` 单独 PR）

## 测试

- \`pnpm --filter @opentrad/stream-parser test\`：30 passed
- \`pnpm --filter @opentrad/shared test\`：61 passed
- \`pnpm typecheck\`：8 packages all green
- \`pnpm lint\`：clean

## Issue

Refs #18（M1 #1，本 PR 是该 issue 的第一部分）