### PR TITLE
feat(desktop): SQLite persistence layer (M1 #19)

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -7,16 +7,20 @@
     "dev": "electron-vite dev",
     "build": "electron-vite build",
     "typecheck": "tsc --noEmit",
-    "start": "electron-vite preview"
+    "start": "electron-vite preview",
+    "test": "vitest run"
   },
   "dependencies": {
     "@opentrad/cc-adapter": "workspace:^",
+    "better-sqlite3": "^12.9.0",
     "electron": "^41.3.0",
     "react": "^19.2.5",
-    "react-dom": "^19.2.5"
+    "react-dom": "^19.2.5",
+    "zod": "^4.3.6"
   },
   "devDependencies": {
     "@opentrad/shared": "workspace:^",
+    "@types/better-sqlite3": "^7.6.13",
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^6.0.1",

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -1,17 +1,23 @@
 // Electron 主进程入口。对应 03-architecture.md §2 apps/desktop/src/main/index.ts。
 // M0 范围：BrowserWindow、CCManager 单例、IPC handlers 注册、退出时清理。
-// 不在本 issue 内：session 持久化（M2）、托盘/菜单、自动更新。
+// M1 #19：SQLite 初始化、单实例互斥锁、session / settings / installed-skill IPC。
 
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { CCManager } from "@opentrad/cc-adapter";
-import { app, BrowserWindow } from "electron";
+import { app, BrowserWindow, dialog } from "electron";
 import { registerIpcHandlers } from "./ipc";
+import { createDbServices, type DbServices } from "./services/db";
+import { type AppLock, AppLockHeldError, acquireAppLock } from "./services/lock";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
 // 全局 CCManager 单例：所有 IPC handler 共享同一个 manager 以维持 activeTasks map。
 const ccManager = new CCManager();
+
+// 启动时初始化、退出时释放：lock + db。
+let appLock: AppLock | undefined;
+let dbServices: DbServices | undefined;
 
 // contextIsolation + sandbox 按 03-architecture.md §9「沙箱和权限」开启。
 function createMainWindow(): BrowserWindow {
@@ -43,7 +49,25 @@ function createMainWindow(): BrowserWindow {
 }
 
 app.whenReady().then(() => {
-  registerIpcHandlers(ccManager);
+  // 单实例互斥（M1 #19 验收 6）：另一个 OpenTrad 已运行时，提示后退出。
+  try {
+    appLock = acquireAppLock();
+  } catch (err) {
+    if (err instanceof AppLockHeldError) {
+      dialog.showErrorBox(
+        "OpenTrad 已在运行",
+        `检测到另一个 OpenTrad 实例（PID=${err.heldByPid}）。请使用已打开的窗口。`,
+      );
+      app.quit();
+      return;
+    }
+    throw err;
+  }
+
+  // SQLite 初始化（M1 #19 验收 1）：~/.opentrad/opentrad.db 自动建表。
+  dbServices = createDbServices();
+
+  registerIpcHandlers(ccManager, dbServices);
   createMainWindow();
 
   // macOS 点 dock icon 重启窗口（Electron 推荐行为）
@@ -61,11 +85,28 @@ app.on("window-all-closed", () => {
   }
 });
 
-// 应用退出前清理 CC 子进程（避免 claude 残留）。
+// 应用退出前清理 CC 子进程（避免 claude 残留）+ 关闭 db + 释放 lock。
 // CCManager 内部也注册了 SIGINT/SIGTERM/exit handler，这里是业务层再加一道保险。
 app.on("before-quit", async (event) => {
-  if (ccManager.activeTasks.size === 0) return;
-  event.preventDefault();
-  await ccManager.cleanup();
-  app.quit();
+  if (ccManager.activeTasks.size > 0) {
+    event.preventDefault();
+    await ccManager.cleanup();
+    finalizeShutdown();
+    app.quit();
+    return;
+  }
+  finalizeShutdown();
 });
+
+function finalizeShutdown(): void {
+  try {
+    dbServices?.close();
+  } catch (err) {
+    console.error("[main] db close error", err);
+  }
+  try {
+    appLock?.release();
+  } catch (err) {
+    console.error("[main] lock release error", err);
+  }
+}

--- a/apps/desktop/src/main/ipc/index.ts
+++ b/apps/desktop/src/main/ipc/index.ts
@@ -2,9 +2,16 @@
 // 新增 domain 时在此 register 进来。
 
 import type { CCManager } from "@opentrad/cc-adapter";
+import type { DbServices } from "../services/db";
 import { registerCcHandlers } from "./cc";
+import { registerInstalledSkillHandlers } from "./installed-skill";
+import { registerSessionHandlers } from "./session";
+import { registerSettingsHandlers } from "./settings";
 
-export function registerIpcHandlers(manager: CCManager): void {
+export function registerIpcHandlers(manager: CCManager, db: DbServices): void {
   registerCcHandlers(manager);
-  // 后续 domain：skill / session / settings / risk-gate 在此注册
+  registerSessionHandlers(db);
+  registerSettingsHandlers(db);
+  registerInstalledSkillHandlers(db);
+  // 后续 domain：skill / risk-gate / pty / installer 在此注册
 }

--- a/apps/desktop/src/main/ipc/installed-skill.ts
+++ b/apps/desktop/src/main/ipc/installed-skill.ts
@@ -1,0 +1,13 @@
+// installed-skill:* IPC handlers。
+// M1 #19 仅暴露 list（installed_skills 表 read-only 视图）；install / enable / disable 等
+// 写操作在 M1 #23 / #6 (Skill runtime 后端) 接通时再加。
+
+import { type InstalledSkillRow, IpcChannels } from "@opentrad/shared";
+import { ipcMain } from "electron";
+import type { DbServices } from "../services/db";
+
+export function registerInstalledSkillHandlers(db: DbServices): void {
+  ipcMain.handle(IpcChannels.InstalledSkillList, async (): Promise<InstalledSkillRow[]> => {
+    return db.installedSkills.list();
+  });
+}

--- a/apps/desktop/src/main/ipc/session.ts
+++ b/apps/desktop/src/main/ipc/session.ts
@@ -1,0 +1,52 @@
+// session:* IPC handlers。对应 03-architecture.md §5 sessions 表 + §3 IPC 协议。
+// 实现范围（M1 #19 / #2）：
+// - session:list（分页 limit/offset）→ SessionMeta[] 精简视图
+// - session:get → SessionRow 完整视图（M1 #29 / #12 历史回放查 lastModel / totalCostUsd 用）
+// - session:delete → 删 session（events FK CASCADE 自动清理）
+//
+// session:resume 在 M1 #29 / #12 落地（D-M1-7：M1 只查看 events 回放，不重启 CC 子进程）。
+
+import {
+  IpcChannels,
+  type SessionDeleteRequest,
+  SessionDeleteRequestSchema,
+  type SessionGetRequest,
+  SessionGetRequestSchema,
+  type SessionListRequest,
+  SessionListRequestSchema,
+  type SessionMeta,
+  type SessionRow,
+} from "@opentrad/shared";
+import { ipcMain } from "electron";
+import type { DbServices } from "../services/db";
+
+export function registerSessionHandlers(db: DbServices): void {
+  ipcMain.handle(IpcChannels.SessionList, async (_event, raw: unknown): Promise<SessionMeta[]> => {
+    const req: SessionListRequest = SessionListRequestSchema.parse(raw ?? {});
+    return db.sessions.list(req).map(toMeta);
+  });
+
+  ipcMain.handle(
+    IpcChannels.SessionGet,
+    async (_event, raw: unknown): Promise<SessionRow | null> => {
+      const req: SessionGetRequest = SessionGetRequestSchema.parse(raw);
+      return db.sessions.get(req.sessionId) ?? null;
+    },
+  );
+
+  ipcMain.handle(IpcChannels.SessionDelete, async (_event, raw: unknown): Promise<void> => {
+    const req: SessionDeleteRequest = SessionDeleteRequestSchema.parse(raw);
+    db.sessions.delete(req.sessionId);
+  });
+}
+
+function toMeta(row: SessionRow): SessionMeta {
+  return {
+    id: row.id,
+    title: row.title,
+    skillId: row.skillId,
+    createdAt: row.createdAt,
+    updatedAt: row.updatedAt,
+    status: row.status,
+  };
+}

--- a/apps/desktop/src/main/ipc/settings.ts
+++ b/apps/desktop/src/main/ipc/settings.ts
@@ -1,0 +1,25 @@
+// settings:* IPC handlers。
+// value 是任意 JSON 值（service 内部 JSON.stringify / JSON.parse）。
+// renderer 应在自己侧用 zod 校验具体 key 的 value 形态。
+
+import {
+  IpcChannels,
+  type SettingsGetRequest,
+  SettingsGetRequestSchema,
+  type SettingsSetRequest,
+  SettingsSetRequestSchema,
+} from "@opentrad/shared";
+import { ipcMain } from "electron";
+import type { DbServices } from "../services/db";
+
+export function registerSettingsHandlers(db: DbServices): void {
+  ipcMain.handle(IpcChannels.SettingsGet, async (_event, raw: unknown): Promise<unknown> => {
+    const req: SettingsGetRequest = SettingsGetRequestSchema.parse(raw);
+    return db.settings.get(req.key) ?? null;
+  });
+
+  ipcMain.handle(IpcChannels.SettingsSet, async (_event, raw: unknown): Promise<void> => {
+    const req: SettingsSetRequest = SettingsSetRequestSchema.parse(raw);
+    db.settings.set(req.key, req.value);
+  });
+}

--- a/apps/desktop/src/main/services/db/audit-log.ts
+++ b/apps/desktop/src/main/services/db/audit-log.ts
@@ -1,0 +1,108 @@
+// AuditLogService：audit_log 表 append-only。
+// 每次 RiskGate.check 都写一条（automated allow / deny / user 决策都写），保证可追溯。
+//
+// automated INTEGER 0/1 ↔ boolean 在本服务转换。
+// paramsJson 是已脱敏的参数 JSON 字符串（脱敏在 RiskGate UI 侧做，service 不感知）。
+
+import { type AuditLogAppendInput, type AuditLogRow, AuditLogRowSchema } from "@opentrad/shared";
+import type Database from "better-sqlite3";
+
+interface AuditLogRawRow {
+  id: number;
+  timestamp: number;
+  session_id: string;
+  skill_id: string | null;
+  tool_name: string;
+  business_action: string | null;
+  params_json: string | null;
+  decision: string;
+  automated: number; // 0/1
+  reason: string | null;
+}
+
+function toDomain(raw: AuditLogRawRow): AuditLogRow {
+  return AuditLogRowSchema.parse({
+    id: raw.id,
+    timestamp: raw.timestamp,
+    sessionId: raw.session_id,
+    skillId: raw.skill_id,
+    toolName: raw.tool_name,
+    businessAction: raw.business_action,
+    paramsJson: raw.params_json,
+    decision: raw.decision,
+    automated: raw.automated === 1,
+    reason: raw.reason,
+  });
+}
+
+export class AuditLogService {
+  private readonly stmtAppend;
+  private readonly stmtBySession;
+  private readonly stmtByDateRange;
+
+  constructor(db: Database.Database) {
+    this.stmtAppend = db.prepare<
+      [
+        number,
+        string,
+        string | null,
+        string,
+        string | null,
+        string | null,
+        string,
+        number,
+        string | null,
+      ]
+    >(
+      `INSERT INTO audit_log
+        (timestamp, session_id, skill_id, tool_name, business_action, params_json, decision, automated, reason)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+    );
+    this.stmtBySession = db.prepare<[string, number, number]>(
+      `SELECT * FROM audit_log WHERE session_id = ?
+       ORDER BY timestamp DESC, id DESC LIMIT ? OFFSET ?`,
+    );
+    this.stmtByDateRange = db.prepare<[number, number, number, number]>(
+      `SELECT * FROM audit_log WHERE timestamp >= ? AND timestamp < ?
+       ORDER BY timestamp DESC, id DESC LIMIT ? OFFSET ?`,
+    );
+  }
+
+  append(input: AuditLogAppendInput): void {
+    this.stmtAppend.run(
+      input.timestamp ?? Date.now(),
+      input.sessionId,
+      input.skillId ?? null,
+      input.toolName,
+      input.businessAction ?? null,
+      input.paramsJson ?? null,
+      input.decision,
+      input.automated ? 1 : 0,
+      input.reason ?? null,
+    );
+  }
+
+  queryBySession(sessionId: string, opts: { limit?: number; offset?: number } = {}): AuditLogRow[] {
+    const rows = this.stmtBySession.all(
+      sessionId,
+      opts.limit ?? 50,
+      opts.offset ?? 0,
+    ) as AuditLogRawRow[];
+    return rows.map(toDomain);
+  }
+
+  // [from, to) 半开区间，单位 unix ms
+  queryByDateRange(
+    from: number,
+    to: number,
+    opts: { limit?: number; offset?: number } = {},
+  ): AuditLogRow[] {
+    const rows = this.stmtByDateRange.all(
+      from,
+      to,
+      opts.limit ?? 50,
+      opts.offset ?? 0,
+    ) as AuditLogRawRow[];
+    return rows.map(toDomain);
+  }
+}

--- a/apps/desktop/src/main/services/db/events.ts
+++ b/apps/desktop/src/main/services/db/events.ts
@@ -1,0 +1,69 @@
+// EventService：events 表 append + 按 session 回放。
+// payload 存为 JSON 字符串（service 层 JSON.stringify）。读出时不解析（消费方可能不需要 / 自己处理）。
+//
+// **append ownership 在 M1 #9 (#26)**（见 issue #18 close 评论 + #26 验收）：
+// sessionStore.startTask 收到 cc:event 时，在推送 renderer 之前调用 EventService.append。
+// 这样 #29 历史回放（features/history/HistoryList.tsx）可以直接 readBySession 渲染。
+
+import { type EventAppendInput, type EventRow, EventRowSchema } from "@opentrad/shared";
+import type Database from "better-sqlite3";
+
+interface EventRawRow {
+  id: number;
+  session_id: string;
+  seq: number;
+  type: string;
+  payload: string;
+  timestamp: number;
+}
+
+function toDomain(raw: EventRawRow): EventRow {
+  return EventRowSchema.parse({
+    id: raw.id,
+    sessionId: raw.session_id,
+    seq: raw.seq,
+    type: raw.type,
+    payload: raw.payload,
+    timestamp: raw.timestamp,
+  });
+}
+
+export class EventService {
+  private readonly stmtAppend;
+  private readonly stmtReadBySession;
+  private readonly stmtCountBySession;
+
+  constructor(db: Database.Database) {
+    this.stmtAppend = db.prepare<[string, number, string, string, number]>(
+      `INSERT INTO events (session_id, seq, type, payload, timestamp) VALUES (?, ?, ?, ?, ?)`,
+    );
+    this.stmtReadBySession = db.prepare<[string]>(
+      `SELECT * FROM events WHERE session_id = ? ORDER BY seq ASC`,
+    );
+    this.stmtCountBySession = db.prepare<[string]>(
+      `SELECT COUNT(*) AS c FROM events WHERE session_id = ?`,
+    );
+  }
+
+  // payload 接受任意 unknown，service 层负责 JSON.stringify
+  append(input: EventAppendInput): void {
+    const payload =
+      typeof input.payload === "string" ? input.payload : JSON.stringify(input.payload);
+    this.stmtAppend.run(
+      input.sessionId,
+      input.seq,
+      input.type,
+      payload,
+      input.timestamp ?? Date.now(),
+    );
+  }
+
+  readBySession(sessionId: string): EventRow[] {
+    const rows = this.stmtReadBySession.all(sessionId) as EventRawRow[];
+    return rows.map(toDomain);
+  }
+
+  countBySession(sessionId: string): number {
+    return (this.stmtCountBySession.get(sessionId) as { c: number }).c;
+  }
+}

--- a/apps/desktop/src/main/services/db/index.ts
+++ b/apps/desktop/src/main/services/db/index.ts
@@ -1,0 +1,48 @@
+// DB 服务集合：把 6 个 service 装在一个 DbServices bundle 里，单例方便注入。
+
+import type Database from "better-sqlite3";
+import { AuditLogService } from "./audit-log";
+import { EventService } from "./events";
+import { type OpenDbOptions, openDatabase } from "./init";
+import { InstalledSkillService } from "./installed-skills";
+import { RiskRuleService } from "./risk-rules";
+import { SessionService } from "./sessions";
+import { SettingsService } from "./settings";
+
+export interface DbServices {
+  db: Database.Database;
+  sessions: SessionService;
+  settings: SettingsService;
+  installedSkills: InstalledSkillService;
+  events: EventService;
+  riskRules: RiskRuleService;
+  auditLog: AuditLogService;
+  close: () => void;
+}
+
+export function createDbServices(opts: OpenDbOptions = {}): DbServices {
+  const db = openDatabase(opts);
+  return {
+    db,
+    sessions: new SessionService(db),
+    settings: new SettingsService(db),
+    installedSkills: new InstalledSkillService(db),
+    events: new EventService(db),
+    riskRules: new RiskRuleService(db),
+    auditLog: new AuditLogService(db),
+    close: () => {
+      // foreign_keys 在 close 时自动 release；DELETE journal mode 不留 -wal/-shm
+      db.close();
+    },
+  };
+}
+
+export { AuditLogService } from "./audit-log";
+export { EventService } from "./events";
+export { type OpenDbOptions, openDatabase } from "./init";
+export { InstalledSkillService } from "./installed-skills";
+export { getDbPath, getLockPath, getUserDataDir } from "./paths";
+export { RiskRuleService } from "./risk-rules";
+export { SCHEMA_SQL, SCHEMA_VERSION } from "./schema";
+export { SessionService } from "./sessions";
+export { SettingsService } from "./settings";

--- a/apps/desktop/src/main/services/db/init.ts
+++ b/apps/desktop/src/main/services/db/init.ts
@@ -1,0 +1,43 @@
+// 数据库打开 + 初始化建表 + schema_version 写入。
+// 设计：
+// - 同步 API（better-sqlite3，按 ADR-004）
+// - foreign_keys ON（events.session_id 外键依赖）
+// - journal_mode = DELETE（不用 WAL；单写者足够，避免 -wal/-shm 残留 + 应用退出时干净 close）
+// - schema_version 通过 settings 表记录，预留 M2 迁移机制（M1 不实现迁移）
+// - 支持 ":memory:" 用于单元测试
+
+import { mkdirSync } from "node:fs";
+import Database from "better-sqlite3";
+import { getDbPath, getUserDataDir } from "./paths";
+import { SCHEMA_SQL, SCHEMA_VERSION } from "./schema";
+
+export interface OpenDbOptions {
+  // 显式指定 db 文件路径；不传时用 getDbPath()。":memory:" 启用 in-memory 模式（单测用）。
+  dbPath?: string;
+}
+
+export function openDatabase(opts: OpenDbOptions = {}): Database.Database {
+  const dbPath = opts.dbPath ?? getDbPath();
+
+  // 文件路径需要确保父目录存在；in-memory 跳过
+  if (dbPath !== ":memory:") {
+    mkdirSync(getUserDataDir(), { recursive: true });
+  }
+
+  const db = new Database(dbPath);
+  db.pragma("foreign_keys = ON");
+  db.pragma("journal_mode = DELETE");
+
+  db.exec(SCHEMA_SQL);
+  ensureSchemaVersion(db);
+
+  return db;
+}
+
+function ensureSchemaVersion(db: Database.Database): void {
+  // INSERT OR IGNORE：首次启动写入；后续启动幂等
+  const stmt = db.prepare(
+    "INSERT OR IGNORE INTO settings (key, value, updated_at) VALUES (?, ?, ?)",
+  );
+  stmt.run("schema_version", JSON.stringify(SCHEMA_VERSION), Date.now());
+}

--- a/apps/desktop/src/main/services/db/installed-skills.ts
+++ b/apps/desktop/src/main/services/db/installed-skills.ts
@@ -1,0 +1,94 @@
+// InstalledSkillService：installed_skills 表 CRUD。
+// enabled INTEGER 0/1 ↔ boolean 在本服务做转换。
+
+import {
+  type InstalledSkillInstallInput,
+  type InstalledSkillRow,
+  InstalledSkillRowSchema,
+} from "@opentrad/shared";
+import type Database from "better-sqlite3";
+
+interface InstalledSkillRawRow {
+  id: string;
+  source: string;
+  version: string;
+  install_path: string;
+  enabled: number; // 0/1
+  installed_at: number;
+}
+
+function toDomain(raw: InstalledSkillRawRow): InstalledSkillRow {
+  return InstalledSkillRowSchema.parse({
+    id: raw.id,
+    source: raw.source,
+    version: raw.version,
+    installPath: raw.install_path,
+    enabled: raw.enabled === 1,
+    installedAt: raw.installed_at,
+  });
+}
+
+export class InstalledSkillService {
+  private readonly stmtList;
+  private readonly stmtGet;
+  private readonly stmtInsert;
+  private readonly stmtSetEnabled;
+  private readonly stmtDelete;
+
+  constructor(db: Database.Database) {
+    this.stmtList = db.prepare(`SELECT * FROM installed_skills ORDER BY installed_at DESC`);
+    this.stmtGet = db.prepare<[string]>(`SELECT * FROM installed_skills WHERE id = ?`);
+    this.stmtInsert = db.prepare<[string, string, string, string, number, number]>(
+      `INSERT INTO installed_skills (id, source, version, install_path, enabled, installed_at)
+       VALUES (?, ?, ?, ?, ?, ?)
+       ON CONFLICT(id) DO UPDATE SET
+         source = excluded.source,
+         version = excluded.version,
+         install_path = excluded.install_path,
+         enabled = excluded.enabled`,
+    );
+    this.stmtSetEnabled = db.prepare<[number, string]>(
+      `UPDATE installed_skills SET enabled = ? WHERE id = ?`,
+    );
+    this.stmtDelete = db.prepare<[string]>(`DELETE FROM installed_skills WHERE id = ?`);
+  }
+
+  list(): InstalledSkillRow[] {
+    const rows = this.stmtList.all() as InstalledSkillRawRow[];
+    return rows.map(toDomain);
+  }
+
+  get(id: string): InstalledSkillRow | undefined {
+    const raw = this.stmtGet.get(id) as InstalledSkillRawRow | undefined;
+    return raw ? toDomain(raw) : undefined;
+  }
+
+  // upsert 语义：用作"安装或更新到新版本"
+  install(input: InstalledSkillInstallInput): InstalledSkillRow {
+    this.stmtInsert.run(
+      input.id,
+      input.source,
+      input.version,
+      input.installPath,
+      input.enabled ? 1 : 0,
+      Date.now(),
+    );
+    const row = this.get(input.id);
+    if (!row) {
+      throw new Error(`InstalledSkillService.install: row not found after insert (id=${input.id})`);
+    }
+    return row;
+  }
+
+  enable(id: string): void {
+    this.stmtSetEnabled.run(1, id);
+  }
+
+  disable(id: string): void {
+    this.stmtSetEnabled.run(0, id);
+  }
+
+  delete(id: string): void {
+    this.stmtDelete.run(id);
+  }
+}

--- a/apps/desktop/src/main/services/db/paths.ts
+++ b/apps/desktop/src/main/services/db/paths.ts
@@ -1,0 +1,22 @@
+// 跨平台用户数据目录定位。
+// macOS / Linux：~/.opentrad/
+// Windows：%APPDATA%\OpenTrad\
+
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+export function getUserDataDir(): string {
+  if (process.platform === "win32") {
+    const appData = process.env.APPDATA ?? join(homedir(), "AppData", "Roaming");
+    return join(appData, "OpenTrad");
+  }
+  return join(homedir(), ".opentrad");
+}
+
+export function getDbPath(): string {
+  return join(getUserDataDir(), "opentrad.db");
+}
+
+export function getLockPath(): string {
+  return join(getUserDataDir(), ".lock");
+}

--- a/apps/desktop/src/main/services/db/risk-rules.ts
+++ b/apps/desktop/src/main/services/db/risk-rules.ts
@@ -1,0 +1,93 @@
+// RiskRuleService：risk_rules 表（"以后都允许 / 以后都拒绝" 规则）。
+// 唯一索引由 COALESCE(skill_id, '') / COALESCE(tool_name, '') / COALESCE(business_action, '') 组合而成
+// （见 schema.ts 的 idx_risk_rules_key）。upsert 语义用 ON CONFLICT 触发同样的 COALESCE key 来更新。
+//
+// findMatching：由 RiskGate（M1 #11 / #28）调用。给出当前 tool 调用的 skillId / toolName / businessAction，
+// 找匹配规则。优先级在 RiskGate 内部决策，不在本 service。
+
+import {
+  type RiskRuleMatchQuery,
+  type RiskRuleRow,
+  RiskRuleRowSchema,
+  type RiskRuleSaveInput,
+} from "@opentrad/shared";
+import type Database from "better-sqlite3";
+
+interface RiskRuleRawRow {
+  id: number;
+  skill_id: string | null;
+  tool_name: string | null;
+  business_action: string | null;
+  decision: string;
+  created_at: number;
+}
+
+function toDomain(raw: RiskRuleRawRow): RiskRuleRow {
+  return RiskRuleRowSchema.parse({
+    id: raw.id,
+    skillId: raw.skill_id,
+    toolName: raw.tool_name,
+    businessAction: raw.business_action,
+    decision: raw.decision,
+    createdAt: raw.created_at,
+  });
+}
+
+export class RiskRuleService {
+  private readonly stmtList;
+  private readonly stmtFindExact;
+  private readonly stmtSave;
+  private readonly stmtDelete;
+
+  constructor(db: Database.Database) {
+    this.stmtList = db.prepare(`SELECT * FROM risk_rules ORDER BY created_at DESC`);
+    // 用 IS 判等 nullable 字段（IS NULL 比 = NULL 健壮）
+    this.stmtFindExact = db.prepare<[string | null, string | null, string | null]>(
+      `SELECT * FROM risk_rules
+       WHERE skill_id IS ? AND tool_name IS ? AND business_action IS ?
+       LIMIT 1`,
+    );
+    this.stmtSave = db.prepare<[string | null, string | null, string | null, string, number]>(
+      `INSERT INTO risk_rules (skill_id, tool_name, business_action, decision, created_at)
+       VALUES (?, ?, ?, ?, ?)
+       ON CONFLICT DO UPDATE SET decision = excluded.decision, created_at = excluded.created_at`,
+    );
+    this.stmtDelete = db.prepare<[number]>(`DELETE FROM risk_rules WHERE id = ?`);
+  }
+
+  list(): RiskRuleRow[] {
+    return (this.stmtList.all() as RiskRuleRawRow[]).map(toDomain);
+  }
+
+  findMatching(query: RiskRuleMatchQuery): RiskRuleRow | undefined {
+    const raw = this.stmtFindExact.get(
+      query.skillId ?? null,
+      query.toolName ?? null,
+      query.businessAction ?? null,
+    ) as RiskRuleRawRow | undefined;
+    return raw ? toDomain(raw) : undefined;
+  }
+
+  save(input: RiskRuleSaveInput): RiskRuleRow {
+    this.stmtSave.run(
+      input.skillId ?? null,
+      input.toolName ?? null,
+      input.businessAction ?? null,
+      input.decision,
+      Date.now(),
+    );
+    const found = this.findMatching({
+      skillId: input.skillId ?? null,
+      toolName: input.toolName ?? null,
+      businessAction: input.businessAction ?? null,
+    });
+    if (!found) {
+      throw new Error(`RiskRuleService.save: row not found after upsert`);
+    }
+    return found;
+  }
+
+  delete(id: number): void {
+    this.stmtDelete.run(id);
+  }
+}

--- a/apps/desktop/src/main/services/db/schema.ts
+++ b/apps/desktop/src/main/services/db/schema.ts
@@ -1,0 +1,92 @@
+// SQLite schema 定义（按 03-architecture.md §五）。
+// 6 张表：sessions / events / risk_rules / audit_log / settings / installed_skills。
+// 字段命名遵循 SQL 惯例 snake_case；domain 层的 camelCase 映射在 service 层做。
+//
+// CHECK 约束：
+//   sessions.status ∈ ('active','completed','cancelled','error')
+//   risk_rules.decision ∈ ('allow','deny')
+//   installed_skills.source ∈ ('builtin','user_import','marketplace')
+//
+// 索引：
+//   idx_sessions_updated         (sessions.updated_at DESC) — list 分页
+//   idx_sessions_skill           (sessions.skill_id)        — 按 skill 过滤
+//   idx_events_session_seq       (events.session_id, seq)   — 事件回放
+//   idx_risk_rules_key UNIQUE    (COALESCE 三键)            — 唯一规则匹配（D-M1 §三 (3)）
+//   idx_audit_session            (audit_log.session_id)
+//   idx_audit_timestamp          (audit_log.timestamp DESC) — /settings/risk 审计页
+//
+// 外键：events.session_id → sessions.id ON DELETE CASCADE。
+
+export const SCHEMA_VERSION = 1;
+
+export const SCHEMA_SQL = `
+  CREATE TABLE IF NOT EXISTS sessions (
+    id TEXT PRIMARY KEY,
+    title TEXT NOT NULL,
+    skill_id TEXT,
+    cc_session_path TEXT,
+    created_at INTEGER NOT NULL,
+    updated_at INTEGER NOT NULL,
+    last_model TEXT,
+    total_cost_usd REAL NOT NULL DEFAULT 0,
+    message_count INTEGER NOT NULL DEFAULT 0,
+    status TEXT NOT NULL CHECK(status IN ('active', 'completed', 'cancelled', 'error'))
+  );
+  CREATE INDEX IF NOT EXISTS idx_sessions_updated ON sessions(updated_at DESC);
+  CREATE INDEX IF NOT EXISTS idx_sessions_skill ON sessions(skill_id);
+
+  CREATE TABLE IF NOT EXISTS events (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    session_id TEXT NOT NULL,
+    seq INTEGER NOT NULL,
+    type TEXT NOT NULL,
+    payload TEXT NOT NULL,
+    timestamp INTEGER NOT NULL,
+    FOREIGN KEY (session_id) REFERENCES sessions(id) ON DELETE CASCADE
+  );
+  CREATE INDEX IF NOT EXISTS idx_events_session_seq ON events(session_id, seq);
+
+  CREATE TABLE IF NOT EXISTS risk_rules (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    skill_id TEXT,
+    tool_name TEXT,
+    business_action TEXT,
+    decision TEXT NOT NULL CHECK(decision IN ('allow', 'deny')),
+    created_at INTEGER NOT NULL
+  );
+  CREATE UNIQUE INDEX IF NOT EXISTS idx_risk_rules_key ON risk_rules(
+    COALESCE(skill_id, ''),
+    COALESCE(tool_name, ''),
+    COALESCE(business_action, '')
+  );
+
+  CREATE TABLE IF NOT EXISTS audit_log (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    timestamp INTEGER NOT NULL,
+    session_id TEXT NOT NULL,
+    skill_id TEXT,
+    tool_name TEXT NOT NULL,
+    business_action TEXT,
+    params_json TEXT,
+    decision TEXT NOT NULL,
+    automated INTEGER NOT NULL,
+    reason TEXT
+  );
+  CREATE INDEX IF NOT EXISTS idx_audit_session ON audit_log(session_id);
+  CREATE INDEX IF NOT EXISTS idx_audit_timestamp ON audit_log(timestamp DESC);
+
+  CREATE TABLE IF NOT EXISTS settings (
+    key TEXT PRIMARY KEY,
+    value TEXT NOT NULL,
+    updated_at INTEGER NOT NULL
+  );
+
+  CREATE TABLE IF NOT EXISTS installed_skills (
+    id TEXT PRIMARY KEY,
+    source TEXT NOT NULL CHECK(source IN ('builtin', 'user_import', 'marketplace')),
+    version TEXT NOT NULL,
+    install_path TEXT NOT NULL,
+    enabled INTEGER NOT NULL DEFAULT 1,
+    installed_at INTEGER NOT NULL
+  );
+`;

--- a/apps/desktop/src/main/services/db/sessions.ts
+++ b/apps/desktop/src/main/services/db/sessions.ts
@@ -1,0 +1,126 @@
+// SessionService：sessions 表 CRUD。
+// row 列 snake_case ↔ domain 字段 camelCase 在本服务做显式映射（沿用 D1 wire/domain 风格）。
+// CASCADE：FK 配置 ON DELETE CASCADE，删 session 时关联 events 自动清理。
+
+import {
+  type ListPagination,
+  type SessionCreateInput,
+  type SessionRow,
+  SessionRowSchema,
+  type SessionStatus,
+} from "@opentrad/shared";
+import type Database from "better-sqlite3";
+
+interface SessionRawRow {
+  id: string;
+  title: string;
+  skill_id: string | null;
+  cc_session_path: string | null;
+  created_at: number;
+  updated_at: number;
+  last_model: string | null;
+  total_cost_usd: number;
+  message_count: number;
+  status: string;
+}
+
+function toDomain(raw: SessionRawRow): SessionRow {
+  return SessionRowSchema.parse({
+    id: raw.id,
+    title: raw.title,
+    skillId: raw.skill_id,
+    ccSessionPath: raw.cc_session_path,
+    createdAt: raw.created_at,
+    updatedAt: raw.updated_at,
+    lastModel: raw.last_model,
+    totalCostUsd: raw.total_cost_usd,
+    messageCount: raw.message_count,
+    status: raw.status,
+  });
+}
+
+export class SessionService {
+  private readonly stmtCreate;
+  private readonly stmtGet;
+  private readonly stmtList;
+  private readonly stmtUpdateStatus;
+  private readonly stmtUpdateMeta;
+  private readonly stmtDelete;
+  private readonly stmtCount;
+
+  constructor(db: Database.Database) {
+    this.stmtCreate = db.prepare(
+      `INSERT INTO sessions (id, title, skill_id, cc_session_path, created_at, updated_at, status)
+       VALUES (?, ?, ?, ?, ?, ?, ?)`,
+    );
+    this.stmtGet = db.prepare<[string]>(`SELECT * FROM sessions WHERE id = ?`);
+    this.stmtList = db.prepare<[number, number]>(
+      `SELECT * FROM sessions ORDER BY updated_at DESC LIMIT ? OFFSET ?`,
+    );
+    this.stmtUpdateStatus = db.prepare<[string, number, string]>(
+      `UPDATE sessions SET status = ?, updated_at = ? WHERE id = ?`,
+    );
+    this.stmtUpdateMeta = db.prepare<[number, string | null, number, number, string]>(
+      `UPDATE sessions
+       SET updated_at = ?, last_model = ?, total_cost_usd = ?, message_count = ?
+       WHERE id = ?`,
+    );
+    this.stmtDelete = db.prepare<[string]>(`DELETE FROM sessions WHERE id = ?`);
+    this.stmtCount = db.prepare(`SELECT COUNT(*) AS c FROM sessions`);
+  }
+
+  create(input: SessionCreateInput): SessionRow {
+    const now = Date.now();
+    this.stmtCreate.run(
+      input.id,
+      input.title,
+      input.skillId ?? null,
+      input.ccSessionPath ?? null,
+      now,
+      now,
+      input.status,
+    );
+    const created = this.get(input.id);
+    if (!created) {
+      throw new Error(`SessionService.create: row not found after insert (id=${input.id})`);
+    }
+    return created;
+  }
+
+  get(id: string): SessionRow | undefined {
+    const raw = this.stmtGet.get(id) as SessionRawRow | undefined;
+    return raw ? toDomain(raw) : undefined;
+  }
+
+  list(pagination: ListPagination): SessionRow[] {
+    const rows = this.stmtList.all(pagination.limit, pagination.offset) as SessionRawRow[];
+    return rows.map(toDomain);
+  }
+
+  count(): number {
+    return (this.stmtCount.get() as { c: number }).c;
+  }
+
+  updateStatus(id: string, status: SessionStatus): void {
+    this.stmtUpdateStatus.run(status, Date.now(), id);
+  }
+
+  // 任务结束时更新 cost/usage 元数据（M1 #9 接通 sessionStore.startTask 时使用）
+  updateMeta(
+    id: string,
+    meta: { lastModel?: string | null; totalCostUsd: number; messageCount: number },
+  ): void {
+    this.stmtUpdateMeta.run(
+      Date.now(),
+      meta.lastModel ?? null,
+      meta.totalCostUsd,
+      meta.messageCount,
+      id,
+    );
+  }
+
+  // events 通过 FK ON DELETE CASCADE 自动清理
+  delete(id: string): void {
+    this.stmtDelete.run(id);
+  }
+}

--- a/apps/desktop/src/main/services/db/settings.ts
+++ b/apps/desktop/src/main/services/db/settings.ts
@@ -1,0 +1,50 @@
+// SettingsService：settings 表 key-value 存储。
+// value 在 SQLite 是 TEXT（JSON.stringify 后），domain 层是任意 unknown 值。
+// 调用方应在自己侧用 zod 校验具体 key 的 value 形态（service 不感知 key 语义）。
+
+import type Database from "better-sqlite3";
+
+interface SettingsRawRow {
+  key: string;
+  value: string; // JSON-encoded
+  updated_at: number;
+}
+
+export class SettingsService {
+  private readonly stmtGet;
+  private readonly stmtSet;
+  private readonly stmtDelete;
+
+  constructor(db: Database.Database) {
+    this.stmtGet = db.prepare<[string]>(`SELECT * FROM settings WHERE key = ?`);
+    this.stmtSet = db.prepare<[string, string, number]>(
+      `INSERT INTO settings (key, value, updated_at) VALUES (?, ?, ?)
+       ON CONFLICT(key) DO UPDATE SET value = excluded.value, updated_at = excluded.updated_at`,
+    );
+    this.stmtDelete = db.prepare<[string]>(`DELETE FROM settings WHERE key = ?`);
+  }
+
+  get(key: string): unknown | undefined {
+    const raw = this.stmtGet.get(key) as SettingsRawRow | undefined;
+    if (!raw) return undefined;
+    try {
+      return JSON.parse(raw.value);
+    } catch {
+      // 历史脏数据保护：不抛异常，返回 undefined 让调用方走默认值路径
+      return undefined;
+    }
+  }
+
+  set(key: string, value: unknown): void {
+    this.stmtSet.run(key, JSON.stringify(value), Date.now());
+  }
+
+  // 重置为指定值（语义等同 set，命名清晰用于"恢复默认"场景）
+  reset(key: string, defaultValue: unknown): void {
+    this.set(key, defaultValue);
+  }
+
+  delete(key: string): void {
+    this.stmtDelete.run(key);
+  }
+}

--- a/apps/desktop/src/main/services/lock.ts
+++ b/apps/desktop/src/main/services/lock.ts
@@ -1,0 +1,86 @@
+// 单实例互斥锁。
+// 在用户数据目录下写一个 .lock 文件，内容是 PID。
+//
+// 启动逻辑（开工前对齐 A2 + M1 #19 / #2 验收 6）：
+// 1. 若 .lock 不存在 → 写入当前 PID
+// 2. 若 .lock 存在：
+//    - 读 PID，用 process.kill(pid, 0) 探活
+//    - throw ESRCH（POSIX）/ Windows 同等错误 → 视为死进程，覆盖 .lock
+//    - 探活通过 → 视为活进程，抛 AppLockHeldError 让调用方退出应用
+// 3. 退出时只删自己写的 .lock（PID 校验）；防止崩溃残留 .lock 误删别人的
+//
+// 跨平台说明：
+// - process.kill(pid, 0) 在 POSIX 是发 signal 0（不实际发，只查存在性）
+// - Windows 上 Node 也实现了 signal 0 探活语义（但精度比 POSIX 略差）
+// - M1 简化版够用；M2 如发现误判可上 pidusage 等第三方包
+
+import { existsSync, mkdirSync, readFileSync, unlinkSync, writeFileSync } from "node:fs";
+import { getLockPath, getUserDataDir } from "./db/paths";
+
+export class AppLockHeldError extends Error {
+  readonly code = "APP_LOCK_HELD" as const;
+  constructor(public readonly heldByPid: number) {
+    super(`OpenTrad is already running (PID=${heldByPid})`);
+    this.name = "AppLockHeldError";
+  }
+}
+
+export interface AppLock {
+  release: () => void;
+}
+
+export function acquireAppLock(): AppLock {
+  const lockPath = getLockPath();
+  mkdirSync(getUserDataDir(), { recursive: true });
+
+  if (existsSync(lockPath)) {
+    const heldPid = readPidFromLock(lockPath);
+    if (heldPid !== undefined && isProcessAlive(heldPid)) {
+      throw new AppLockHeldError(heldPid);
+    }
+    // PID 不可解析 / 进程已死 → stale .lock，安全覆盖
+  }
+
+  writeFileSync(lockPath, String(process.pid), "utf-8");
+
+  return {
+    release: () => releaseLock(lockPath),
+  };
+}
+
+function readPidFromLock(lockPath: string): number | undefined {
+  try {
+    const content = readFileSync(lockPath, "utf-8").trim();
+    const pid = Number.parseInt(content, 10);
+    if (Number.isFinite(pid) && pid > 0) return pid;
+    return undefined; // 文件内容损坏 → 视为可覆盖
+  } catch {
+    return undefined; // 读不出来 → 视为可覆盖
+  }
+}
+
+function isProcessAlive(pid: number): boolean {
+  try {
+    // signal 0：仅检查进程是否存在，不实际发信号
+    process.kill(pid, 0);
+    return true;
+  } catch (err) {
+    const code = (err as NodeJS.ErrnoException).code;
+    if (code === "ESRCH") return false; // 进程不存在
+    if (code === "EPERM") return true; // 存在但无权限（cross-user）→ 保守视为活
+    return true; // 未知错误 → 保守视为活，避免误覆盖
+  }
+}
+
+function releaseLock(lockPath: string): void {
+  try {
+    if (!existsSync(lockPath)) return;
+    const heldPid = readPidFromLock(lockPath);
+    // 只删自己持有的 lock（PID 校验），保护并发场景下不误删他人
+    if (heldPid === process.pid) {
+      unlinkSync(lockPath);
+    }
+  } catch {
+    // 静默：清理失败不应阻塞退出流程
+  }
+}

--- a/apps/desktop/tests/db/audit-log.test.ts
+++ b/apps/desktop/tests/db/audit-log.test.ts
@@ -1,0 +1,86 @@
+// AuditLogService 主路径测试。
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { createDbServices, type DbServices } from "../../src/main/services/db";
+
+describe("AuditLogService", () => {
+  let svc: DbServices;
+
+  beforeEach(() => {
+    svc = createDbServices({ dbPath: ":memory:" });
+  });
+
+  afterEach(() => {
+    svc.close();
+  });
+
+  it("append + queryBySession：boolean automated 转换", () => {
+    svc.auditLog.append({
+      sessionId: "s1",
+      toolName: "browser_open",
+      decision: "allow",
+      automated: false,
+      reason: "user clicked allow_once",
+    });
+    svc.auditLog.append({
+      sessionId: "s1",
+      toolName: "draft_save",
+      decision: "allow",
+      automated: true,
+      reason: "safe tool",
+    });
+
+    const rows = svc.auditLog.queryBySession("s1");
+    expect(rows).toHaveLength(2);
+    // 按 timestamp DESC（后写的在前）
+    expect(rows[0]?.toolName).toBe("draft_save");
+    expect(rows[0]?.automated).toBe(true);
+    expect(rows[1]?.toolName).toBe("browser_open");
+    expect(rows[1]?.automated).toBe(false);
+  });
+
+  it("queryByDateRange：[from, to) 半开区间", () => {
+    const T0 = 1_700_000_000_000;
+    svc.auditLog.append({
+      sessionId: "s1",
+      toolName: "a",
+      decision: "allow",
+      automated: true,
+      timestamp: T0 + 100,
+    });
+    svc.auditLog.append({
+      sessionId: "s1",
+      toolName: "b",
+      decision: "allow",
+      automated: true,
+      timestamp: T0 + 200,
+    });
+    svc.auditLog.append({
+      sessionId: "s1",
+      toolName: "c",
+      decision: "allow",
+      automated: true,
+      timestamp: T0 + 300,
+    });
+
+    // [T0+100, T0+300)：含 100 / 200，不含 300
+    const result = svc.auditLog.queryByDateRange(T0 + 100, T0 + 300);
+    expect(result.map((r) => r.toolName)).toEqual(["b", "a"]);
+  });
+
+  it("分页 limit / offset", () => {
+    for (let i = 0; i < 10; i++) {
+      svc.auditLog.append({
+        sessionId: "s1",
+        toolName: `t${i}`,
+        decision: "allow",
+        automated: true,
+        timestamp: 1000 + i,
+      });
+    }
+    const page1 = svc.auditLog.queryBySession("s1", { limit: 3, offset: 0 });
+    expect(page1.map((r) => r.toolName)).toEqual(["t9", "t8", "t7"]);
+    const page2 = svc.auditLog.queryBySession("s1", { limit: 3, offset: 3 });
+    expect(page2.map((r) => r.toolName)).toEqual(["t6", "t5", "t4"]);
+  });
+});

--- a/apps/desktop/tests/db/events.test.ts
+++ b/apps/desktop/tests/db/events.test.ts
@@ -1,0 +1,52 @@
+// EventService 主路径测试 + cascade 删除验证。
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { createDbServices, type DbServices } from "../../src/main/services/db";
+
+describe("EventService", () => {
+  let svc: DbServices;
+
+  beforeEach(() => {
+    svc = createDbServices({ dbPath: ":memory:" });
+    svc.sessions.create({ id: "s1", title: "S1", status: "active" });
+  });
+
+  afterEach(() => {
+    svc.close();
+  });
+
+  it("append + readBySession：按 seq ASC", () => {
+    svc.events.append({ sessionId: "s1", seq: 0, type: "system", payload: { v: 1 } });
+    svc.events.append({ sessionId: "s1", seq: 1, type: "assistant_text", payload: { text: "hi" } });
+    svc.events.append({ sessionId: "s1", seq: 2, type: "result", payload: { cost: 0.001 } });
+
+    const rows = svc.events.readBySession("s1");
+    expect(rows).toHaveLength(3);
+    expect(rows.map((e) => e.type)).toEqual(["system", "assistant_text", "result"]);
+    expect(rows.map((e) => e.seq)).toEqual([0, 1, 2]);
+    // payload 是 JSON string，调用方自行 parse
+    expect(JSON.parse(rows[1]?.payload)).toEqual({ text: "hi" });
+  });
+
+  it("payload 接受 string 也接受任意 unknown（service 自己 stringify）", () => {
+    svc.events.append({ sessionId: "s1", seq: 0, type: "raw", payload: '{"already":"string"}' });
+    svc.events.append({ sessionId: "s1", seq: 1, type: "obj", payload: { foo: "bar" } });
+
+    const rows = svc.events.readBySession("s1");
+    expect(JSON.parse(rows[0]?.payload)).toEqual({ already: "string" });
+    expect(JSON.parse(rows[1]?.payload)).toEqual({ foo: "bar" });
+  });
+
+  it("countBySession：精确计数", () => {
+    expect(svc.events.countBySession("s1")).toBe(0);
+    svc.events.append({ sessionId: "s1", seq: 0, type: "x", payload: {} });
+    svc.events.append({ sessionId: "s1", seq: 1, type: "x", payload: {} });
+    expect(svc.events.countBySession("s1")).toBe(2);
+  });
+
+  it("外键：写不存在的 session_id 抛错", () => {
+    expect(() =>
+      svc.events.append({ sessionId: "ghost", seq: 0, type: "x", payload: {} }),
+    ).toThrow();
+  });
+});

--- a/apps/desktop/tests/db/installed-skills.test.ts
+++ b/apps/desktop/tests/db/installed-skills.test.ts
@@ -1,0 +1,119 @@
+// InstalledSkillService 主路径测试。
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { createDbServices, type DbServices } from "../../src/main/services/db";
+
+describe("InstalledSkillService", () => {
+  let svc: DbServices;
+
+  beforeEach(() => {
+    svc = createDbServices({ dbPath: ":memory:" });
+  });
+
+  afterEach(() => {
+    svc.close();
+  });
+
+  it("install + get：写读循环 + boolean 转换", () => {
+    const row = svc.installedSkills.install({
+      id: "trade-email-writer",
+      source: "builtin",
+      version: "1.0.0",
+      installPath: "/path/to/skill",
+      enabled: true,
+    });
+    expect(row.id).toBe("trade-email-writer");
+    expect(row.source).toBe("builtin");
+    expect(row.version).toBe("1.0.0");
+    expect(row.installPath).toBe("/path/to/skill");
+    expect(row.enabled).toBe(true);
+    expect(row.installedAt).toBeGreaterThan(0);
+
+    expect(svc.installedSkills.get("trade-email-writer")).toEqual(row);
+  });
+
+  it("list：按 installed_at DESC", async () => {
+    svc.installedSkills.install({
+      id: "first",
+      source: "builtin",
+      version: "1.0.0",
+      installPath: "/a",
+      enabled: true,
+    });
+    await sleep(2);
+    svc.installedSkills.install({
+      id: "second",
+      source: "builtin",
+      version: "1.0.0",
+      installPath: "/b",
+      enabled: true,
+    });
+    const list = svc.installedSkills.list();
+    expect(list.map((s) => s.id)).toEqual(["second", "first"]);
+  });
+
+  it("install upsert：相同 id 第二次更新", () => {
+    svc.installedSkills.install({
+      id: "x",
+      source: "builtin",
+      version: "1.0.0",
+      installPath: "/old",
+      enabled: true,
+    });
+    svc.installedSkills.install({
+      id: "x",
+      source: "user_import",
+      version: "1.1.0",
+      installPath: "/new",
+      enabled: false,
+    });
+    const got = svc.installedSkills.get("x");
+    expect(got?.version).toBe("1.1.0");
+    expect(got?.source).toBe("user_import");
+    expect(got?.installPath).toBe("/new");
+    expect(got?.enabled).toBe(false);
+  });
+
+  it("enable / disable：切换 boolean", () => {
+    svc.installedSkills.install({
+      id: "x",
+      source: "builtin",
+      version: "1.0.0",
+      installPath: "/p",
+      enabled: true,
+    });
+    svc.installedSkills.disable("x");
+    expect(svc.installedSkills.get("x")?.enabled).toBe(false);
+    svc.installedSkills.enable("x");
+    expect(svc.installedSkills.get("x")?.enabled).toBe(true);
+  });
+
+  it("CHECK 约束：非法 source 抛 SqliteError", () => {
+    expect(() =>
+      svc.installedSkills.install({
+        id: "bad",
+        // biome-ignore lint/suspicious/noExplicitAny: testing invalid enum at runtime
+        source: "from-mars" as any,
+        version: "1.0.0",
+        installPath: "/x",
+        enabled: true,
+      }),
+    ).toThrow();
+  });
+
+  it("delete：移除后再读 undefined", () => {
+    svc.installedSkills.install({
+      id: "x",
+      source: "builtin",
+      version: "1.0.0",
+      installPath: "/p",
+      enabled: true,
+    });
+    svc.installedSkills.delete("x");
+    expect(svc.installedSkills.get("x")).toBeUndefined();
+  });
+});
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}

--- a/apps/desktop/tests/db/risk-rules.test.ts
+++ b/apps/desktop/tests/db/risk-rules.test.ts
@@ -1,0 +1,90 @@
+// RiskRuleService 主路径测试。
+// 重点：findMatching 用 IS（而非 =）匹配 nullable 字段；UNIQUE 索引基于 COALESCE 三键组合。
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { createDbServices, type DbServices } from "../../src/main/services/db";
+
+describe("RiskRuleService", () => {
+  let svc: DbServices;
+
+  beforeEach(() => {
+    svc = createDbServices({ dbPath: ":memory:" });
+  });
+
+  afterEach(() => {
+    svc.close();
+  });
+
+  it("save + findMatching：带 skillId / toolName 的具体规则", () => {
+    const saved = svc.riskRules.save({
+      skillId: "trade-email-writer",
+      toolName: "browser_open",
+      decision: "allow",
+    });
+    expect(saved.skillId).toBe("trade-email-writer");
+    expect(saved.toolName).toBe("browser_open");
+    expect(saved.decision).toBe("allow");
+
+    const found = svc.riskRules.findMatching({
+      skillId: "trade-email-writer",
+      toolName: "browser_open",
+    });
+    expect(found).toEqual(saved);
+  });
+
+  it("findMatching：null 字段精确匹配（用 IS NULL 而非 = NULL）", () => {
+    svc.riskRules.save({
+      skillId: null, // 适用所有 skill
+      toolName: "browser_open",
+      decision: "deny",
+    });
+    const found = svc.riskRules.findMatching({
+      skillId: null,
+      toolName: "browser_open",
+    });
+    expect(found).toBeDefined();
+    expect(found?.decision).toBe("deny");
+
+    // skillId 给具体值时不应匹配上面那条 null 规则
+    expect(
+      svc.riskRules.findMatching({
+        skillId: "trade-email-writer",
+        toolName: "browser_open",
+      }),
+    ).toBeUndefined();
+  });
+
+  it("UNIQUE 索引：相同 (skillId, toolName, businessAction) 第二次 save 走 ON CONFLICT 更新", () => {
+    svc.riskRules.save({
+      skillId: "x",
+      toolName: "y",
+      decision: "allow",
+    });
+    svc.riskRules.save({
+      skillId: "x",
+      toolName: "y",
+      decision: "deny",
+    });
+    const found = svc.riskRules.findMatching({ skillId: "x", toolName: "y" });
+    expect(found?.decision).toBe("deny");
+    expect(svc.riskRules.list()).toHaveLength(1);
+  });
+
+  it("list：按 created_at DESC", async () => {
+    svc.riskRules.save({ skillId: "a", toolName: null, decision: "allow" });
+    await sleep(2);
+    svc.riskRules.save({ skillId: "b", toolName: null, decision: "deny" });
+    const list = svc.riskRules.list();
+    expect(list.map((r) => r.skillId)).toEqual(["b", "a"]);
+  });
+
+  it("delete：按 id", () => {
+    const saved = svc.riskRules.save({ skillId: "x", toolName: null, decision: "allow" });
+    svc.riskRules.delete(saved.id);
+    expect(svc.riskRules.list()).toHaveLength(0);
+  });
+});
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}

--- a/apps/desktop/tests/db/sessions.test.ts
+++ b/apps/desktop/tests/db/sessions.test.ts
@@ -1,0 +1,122 @@
+// SessionService 主路径测试。fixture 用 in-memory sqlite。
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { createDbServices, type DbServices } from "../../src/main/services/db";
+
+describe("SessionService", () => {
+  let svc: DbServices;
+
+  beforeEach(() => {
+    svc = createDbServices({ dbPath: ":memory:" });
+  });
+
+  afterEach(() => {
+    svc.close();
+  });
+
+  it("create + get：写读循环", () => {
+    const created = svc.sessions.create({
+      id: "sess-001",
+      title: "测试会话",
+      skillId: "trade-email-writer",
+      status: "active",
+    });
+    expect(created.id).toBe("sess-001");
+    expect(created.title).toBe("测试会话");
+    expect(created.skillId).toBe("trade-email-writer");
+    expect(created.status).toBe("active");
+    expect(created.totalCostUsd).toBe(0);
+    expect(created.messageCount).toBe(0);
+    expect(created.createdAt).toBeGreaterThan(0);
+    expect(created.createdAt).toBe(created.updatedAt);
+
+    const got = svc.sessions.get("sess-001");
+    expect(got).toEqual(created);
+  });
+
+  it("get：不存在的 id 返回 undefined", () => {
+    expect(svc.sessions.get("does-not-exist")).toBeUndefined();
+  });
+
+  it("list 分页：limit / offset 正确按 updated_at DESC", async () => {
+    // 写 10 条 sessions，updated_at 递增（通过 updateStatus 触发更新）
+    for (let i = 0; i < 10; i++) {
+      svc.sessions.create({
+        id: `s${i}`,
+        title: `Session ${i}`,
+        status: "active",
+      });
+      await sleep(2); // 跨毫秒分隔，确保排序稳定
+    }
+
+    const page1 = svc.sessions.list({ limit: 5, offset: 0 });
+    expect(page1).toHaveLength(5);
+    // 最新的 5 条（s9, s8, s7, s6, s5）
+    expect(page1.map((r) => r.id)).toEqual(["s9", "s8", "s7", "s6", "s5"]);
+
+    const page2 = svc.sessions.list({ limit: 5, offset: 5 });
+    expect(page2).toHaveLength(5);
+    expect(page2.map((r) => r.id)).toEqual(["s4", "s3", "s2", "s1", "s0"]);
+  });
+
+  it("count：返回总数", () => {
+    expect(svc.sessions.count()).toBe(0);
+    svc.sessions.create({ id: "a", title: "A", status: "active" });
+    svc.sessions.create({ id: "b", title: "B", status: "active" });
+    expect(svc.sessions.count()).toBe(2);
+  });
+
+  it("updateStatus：updated_at 同时刷新", async () => {
+    const created = svc.sessions.create({ id: "x", title: "X", status: "active" });
+    await sleep(2);
+    svc.sessions.updateStatus("x", "completed");
+    const updated = svc.sessions.get("x");
+    expect(updated?.status).toBe("completed");
+    expect(updated?.updatedAt).toBeGreaterThan(created.updatedAt);
+  });
+
+  it("updateMeta：写入 cost / messageCount / lastModel", () => {
+    svc.sessions.create({ id: "y", title: "Y", status: "active" });
+    svc.sessions.updateMeta("y", {
+      lastModel: "claude-opus-4-7",
+      totalCostUsd: 0.0095,
+      messageCount: 3,
+    });
+    const got = svc.sessions.get("y");
+    expect(got?.lastModel).toBe("claude-opus-4-7");
+    expect(got?.totalCostUsd).toBeCloseTo(0.0095);
+    expect(got?.messageCount).toBe(3);
+  });
+
+  it("delete：cascade 清理 events", () => {
+    svc.sessions.create({ id: "with-events", title: "WE", status: "active" });
+    svc.events.append({ sessionId: "with-events", seq: 0, type: "system", payload: {} });
+    svc.events.append({
+      sessionId: "with-events",
+      seq: 1,
+      type: "assistant_text",
+      payload: { text: "hi" },
+    });
+    expect(svc.events.countBySession("with-events")).toBe(2);
+
+    svc.sessions.delete("with-events");
+
+    expect(svc.sessions.get("with-events")).toBeUndefined();
+    expect(svc.events.countBySession("with-events")).toBe(0); // ON DELETE CASCADE
+  });
+
+  it("CHECK 约束：非法 status 抛 SqliteError", () => {
+    expect(() =>
+      svc.sessions.create({
+        id: "bad",
+        title: "Bad",
+        // biome-ignore lint/suspicious/noExplicitAny: testing invalid enum at runtime
+        status: "not_a_status" as any,
+      }),
+    ).toThrow();
+  });
+});
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}

--- a/apps/desktop/tests/db/settings.test.ts
+++ b/apps/desktop/tests/db/settings.test.ts
@@ -1,0 +1,56 @@
+// SettingsService 主路径测试。
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { createDbServices, type DbServices } from "../../src/main/services/db";
+
+describe("SettingsService", () => {
+  let svc: DbServices;
+
+  beforeEach(() => {
+    svc = createDbServices({ dbPath: ":memory:" });
+  });
+
+  afterEach(() => {
+    svc.close();
+  });
+
+  it("初始化时已写入 schema_version=1", () => {
+    expect(svc.settings.get("schema_version")).toBe(1);
+  });
+
+  it("set + get：写读循环（任意 JSON 值）", () => {
+    svc.settings.set("language", "zh-CN");
+    expect(svc.settings.get("language")).toBe("zh-CN");
+
+    svc.settings.set("layout", { sidebar: 240, rightPanel: 300 });
+    expect(svc.settings.get("layout")).toEqual({ sidebar: 240, rightPanel: 300 });
+
+    svc.settings.set("flags", [1, 2, 3]);
+    expect(svc.settings.get("flags")).toEqual([1, 2, 3]);
+  });
+
+  it("get：不存在的 key 返回 undefined", () => {
+    expect(svc.settings.get("nope")).toBeUndefined();
+  });
+
+  it("set：upsert 语义（同 key 第二次覆盖）", () => {
+    svc.settings.set("language", "zh-CN");
+    svc.settings.set("language", "en");
+    expect(svc.settings.get("language")).toBe("en");
+  });
+
+  it("delete：移除后再读 undefined", () => {
+    svc.settings.set("temp", "value");
+    expect(svc.settings.get("temp")).toBe("value");
+    svc.settings.delete("temp");
+    expect(svc.settings.get("temp")).toBeUndefined();
+  });
+
+  it("脏数据保护：value 列若被外部修改成非 JSON，get 返回 undefined 不抛", () => {
+    // 直接绕过 service 写非 JSON 字符串
+    svc.db
+      .prepare("INSERT INTO settings (key, value, updated_at) VALUES (?, ?, ?)")
+      .run("corrupted", "not-json{", Date.now());
+    expect(svc.settings.get("corrupted")).toBeUndefined();
+  });
+});

--- a/apps/desktop/tests/lock.test.ts
+++ b/apps/desktop/tests/lock.test.ts
@@ -1,0 +1,82 @@
+// 单实例互斥锁测试。
+// 重点：开工前对齐 A2 的 stale PID 处理 — process.kill(pid, 0) 探活语义跨平台正确。
+// 不实际启动两个 OpenTrad 进程；通过控制 .lock 文件内容（PID）来模拟各种状态。
+
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import * as paths from "../src/main/services/db/paths";
+import { AppLockHeldError, acquireAppLock } from "../src/main/services/lock";
+
+describe("AppLock", () => {
+  let tempDir: string;
+  let lockPath: string;
+
+  beforeEach(() => {
+    tempDir = mkdtempSync(join(tmpdir(), "opentrad-lock-test-"));
+    lockPath = join(tempDir, ".lock");
+    vi.spyOn(paths, "getUserDataDir").mockReturnValue(tempDir);
+    vi.spyOn(paths, "getLockPath").mockReturnValue(lockPath);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it("无 .lock 时：写入当前 PID", () => {
+    expect(existsSync(lockPath)).toBe(false);
+    const lock = acquireAppLock();
+    expect(existsSync(lockPath)).toBe(true);
+    expect(readFileSync(lockPath, "utf-8")).toBe(String(process.pid));
+    lock.release();
+  });
+
+  it("release：删除 .lock", () => {
+    const lock = acquireAppLock();
+    expect(existsSync(lockPath)).toBe(true);
+    lock.release();
+    expect(existsSync(lockPath)).toBe(false);
+  });
+
+  it("stale .lock（PID 已死）：覆盖并继续启动", () => {
+    // 找一个已经不存在的 PID。max int 32-bit signed 通常没有进程；用 999999 作 best-effort
+    const deadPid = 999999;
+    writeFileSync(lockPath, String(deadPid), "utf-8");
+
+    const lock = acquireAppLock();
+    // 覆盖成功 → .lock 内容变成当前进程 PID
+    expect(readFileSync(lockPath, "utf-8")).toBe(String(process.pid));
+    lock.release();
+  });
+
+  it("活的 .lock（同进程 PID）：抛 AppLockHeldError", () => {
+    // 写入当前进程的 PID，模拟"另一个 OpenTrad 实例"
+    writeFileSync(lockPath, String(process.pid), "utf-8");
+    expect(() => acquireAppLock()).toThrow(AppLockHeldError);
+    try {
+      acquireAppLock();
+    } catch (err) {
+      expect(err).toBeInstanceOf(AppLockHeldError);
+      expect((err as AppLockHeldError).heldByPid).toBe(process.pid);
+      expect((err as AppLockHeldError).code).toBe("APP_LOCK_HELD");
+    }
+  });
+
+  it("损坏的 .lock（PID 不可解析）：视为可覆盖", () => {
+    writeFileSync(lockPath, "not-a-number", "utf-8");
+    const lock = acquireAppLock();
+    expect(readFileSync(lockPath, "utf-8")).toBe(String(process.pid));
+    lock.release();
+  });
+
+  it("release：只删自己持有的 lock（PID 校验）", () => {
+    const lock = acquireAppLock();
+    // 模拟另一个进程 acquire（写入别的 PID）— release 不应误删
+    writeFileSync(lockPath, "999999", "utf-8");
+    lock.release();
+    expect(existsSync(lockPath)).toBe(true);
+    expect(readFileSync(lockPath, "utf-8")).toBe("999999");
+  });
+});

--- a/apps/desktop/vitest.config.ts
+++ b/apps/desktop/vitest.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    include: ["tests/**/*.test.ts"],
+    // electron API 在 vitest 进程里不可 import；只测纯 Node 模块（db services / lock / paths）。
+    // IPC handler 单测需要 mock electron，目前不在 M1 #19 scope。
+  },
+});

--- a/package.json
+++ b/package.json
@@ -48,7 +48,8 @@
     "onlyBuiltDependencies": [
       "electron",
       "esbuild",
-      "@biomejs/biome"
+      "@biomejs/biome",
+      "better-sqlite3"
     ]
   }
 }

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -7,6 +7,7 @@
 
 export * from "./types/cc-event";
 export * from "./types/cc-task";
+export * from "./types/db";
 export * from "./types/ipc";
 export * from "./types/risk-gate";
 export * from "./types/skill";

--- a/packages/shared/src/types/db.ts
+++ b/packages/shared/src/types/db.ts
@@ -1,0 +1,161 @@
+// SQLite row 的 domain 层类型（按 D1 wire/domain 两层规范）。
+// 设计原则：
+// - SQLite 列名 snake_case（schema 在 apps/desktop/src/main/services/db/schema.ts）
+// - 本文件的 domain 类型全部 camelCase
+// - INTEGER 0/1 → boolean 在 service 层转换
+// - TEXT JSON 字符串 → 任意 unknown value 在 service 层转换
+// 表对应：03-architecture.md §五 SQLite Schema。
+
+import { z } from "zod";
+
+// ==================== sessions ====================
+
+export const SessionStatusSchema = z.enum(["active", "completed", "cancelled", "error"]);
+export type SessionStatus = z.infer<typeof SessionStatusSchema>;
+
+export const SessionRowSchema = z.object({
+  id: z.string(), // UUID
+  title: z.string(),
+  skillId: z.string().nullable(),
+  ccSessionPath: z.string().nullable(),
+  createdAt: z.number().int(),
+  updatedAt: z.number().int(),
+  lastModel: z.string().nullable(),
+  totalCostUsd: z.number(),
+  messageCount: z.number().int(),
+  status: SessionStatusSchema,
+});
+export type SessionRow = z.infer<typeof SessionRowSchema>;
+
+// 创建 session 时不需要传所有字段（id / created_at / updated_at 等由 service 生成或由调用方传）
+export const SessionCreateInputSchema = z.object({
+  id: z.string(),
+  title: z.string(),
+  skillId: z.string().nullable().optional(),
+  ccSessionPath: z.string().nullable().optional(),
+  status: SessionStatusSchema.default("active"),
+});
+export type SessionCreateInput = z.infer<typeof SessionCreateInputSchema>;
+
+// ==================== events ====================
+
+export const EventRowSchema = z.object({
+  id: z.number().int(),
+  sessionId: z.string(),
+  seq: z.number().int(),
+  type: z.string(),
+  payload: z.string(), // JSON string
+  timestamp: z.number().int(),
+});
+export type EventRow = z.infer<typeof EventRowSchema>;
+
+export const EventAppendInputSchema = z.object({
+  sessionId: z.string(),
+  seq: z.number().int(),
+  type: z.string(),
+  payload: z.unknown(), // service 层负责 JSON.stringify
+  timestamp: z.number().int().optional(), // 默认 Date.now()
+});
+export type EventAppendInput = z.infer<typeof EventAppendInputSchema>;
+
+// ==================== risk_rules ====================
+
+export const RiskRuleDecisionSchema = z.enum(["allow", "deny"]);
+export type RiskRuleDecision = z.infer<typeof RiskRuleDecisionSchema>;
+
+export const RiskRuleRowSchema = z.object({
+  id: z.number().int(),
+  skillId: z.string().nullable(),
+  toolName: z.string().nullable(),
+  businessAction: z.string().nullable(),
+  decision: RiskRuleDecisionSchema,
+  createdAt: z.number().int(),
+});
+export type RiskRuleRow = z.infer<typeof RiskRuleRowSchema>;
+
+export const RiskRuleSaveInputSchema = z.object({
+  skillId: z.string().nullable().optional(),
+  toolName: z.string().nullable().optional(),
+  businessAction: z.string().nullable().optional(),
+  decision: RiskRuleDecisionSchema,
+});
+export type RiskRuleSaveInput = z.infer<typeof RiskRuleSaveInputSchema>;
+
+export const RiskRuleMatchQuerySchema = z.object({
+  skillId: z.string().nullable().optional(),
+  toolName: z.string().nullable().optional(),
+  businessAction: z.string().nullable().optional(),
+});
+export type RiskRuleMatchQuery = z.infer<typeof RiskRuleMatchQuerySchema>;
+
+// ==================== audit_log ====================
+
+export const AuditLogRowSchema = z.object({
+  id: z.number().int(),
+  timestamp: z.number().int(),
+  sessionId: z.string(),
+  skillId: z.string().nullable(),
+  toolName: z.string(),
+  businessAction: z.string().nullable(),
+  paramsJson: z.string().nullable(),
+  decision: z.string(),
+  automated: z.boolean(), // 0/1 → boolean
+  reason: z.string().nullable(),
+});
+export type AuditLogRow = z.infer<typeof AuditLogRowSchema>;
+
+export const AuditLogAppendInputSchema = z.object({
+  sessionId: z.string(),
+  skillId: z.string().nullable().optional(),
+  toolName: z.string(),
+  businessAction: z.string().nullable().optional(),
+  paramsJson: z.string().nullable().optional(),
+  decision: z.string(),
+  automated: z.boolean(),
+  reason: z.string().nullable().optional(),
+  timestamp: z.number().int().optional(), // 默认 Date.now()
+});
+export type AuditLogAppendInput = z.infer<typeof AuditLogAppendInputSchema>;
+
+// ==================== settings ====================
+
+// settings 是 key-value：value 是 unknown，service 层负责 JSON.parse / stringify。
+// 调用方应该在自己侧用 zod 校验具体 key 的 value 形态（避免 service 知道所有 key 的类型）。
+export const SettingsRowSchema = z.object({
+  key: z.string(),
+  value: z.unknown(),
+  updatedAt: z.number().int(),
+});
+export type SettingsRow = z.infer<typeof SettingsRowSchema>;
+
+// ==================== installed_skills ====================
+
+export const InstalledSkillSourceSchema = z.enum(["builtin", "user_import", "marketplace"]);
+export type InstalledSkillSource = z.infer<typeof InstalledSkillSourceSchema>;
+
+export const InstalledSkillRowSchema = z.object({
+  id: z.string(),
+  source: InstalledSkillSourceSchema,
+  version: z.string(),
+  installPath: z.string(),
+  enabled: z.boolean(), // 0/1 → boolean
+  installedAt: z.number().int(),
+});
+export type InstalledSkillRow = z.infer<typeof InstalledSkillRowSchema>;
+
+export const InstalledSkillInstallInputSchema = z.object({
+  id: z.string(),
+  source: InstalledSkillSourceSchema,
+  version: z.string(),
+  installPath: z.string(),
+  enabled: z.boolean().default(true),
+});
+export type InstalledSkillInstallInput = z.infer<typeof InstalledSkillInstallInputSchema>;
+
+// ==================== 公共 ====================
+
+export const ListPaginationSchema = z.object({
+  limit: z.number().int().positive().default(50),
+  offset: z.number().int().nonnegative().default(0),
+});
+export type ListPagination = z.infer<typeof ListPaginationSchema>;

--- a/packages/shared/src/types/ipc.ts
+++ b/packages/shared/src/types/ipc.ts
@@ -13,7 +13,10 @@ export const IpcChannels = {
   SkillList: "skill:list",
   SkillInstall: "skill:install",
   SessionList: "session:list",
+  SessionGet: "session:get",
+  SessionDelete: "session:delete",
   SessionResume: "session:resume",
+  InstalledSkillList: "installed-skill:list",
   RiskGateConfirm: "risk-gate:confirm",
   RiskGateResponse: "risk-gate:response",
   SettingsGet: "settings:get",
@@ -90,6 +93,31 @@ export const SessionMetaSchema = z.object({
 });
 
 export type SessionMeta = z.infer<typeof SessionMetaSchema>;
+
+export const SessionListRequestSchema = z.object({
+  limit: z.number().int().positive().default(50),
+  offset: z.number().int().nonnegative().default(0),
+});
+
+export type SessionListRequest = z.infer<typeof SessionListRequestSchema>;
+
+// -------- session:get（Renderer → Main） --------
+// 返回 SessionRow（完整字段；含 lastModel / totalCostUsd / messageCount / ccSessionPath）或 null。
+
+export const SessionGetRequestSchema = z.object({
+  sessionId: z.string(),
+});
+
+export type SessionGetRequest = z.infer<typeof SessionGetRequestSchema>;
+
+// -------- session:delete（Renderer → Main） --------
+// events 通过 FK ON DELETE CASCADE 自动清理。
+
+export const SessionDeleteRequestSchema = z.object({
+  sessionId: z.string(),
+});
+
+export type SessionDeleteRequest = z.infer<typeof SessionDeleteRequestSchema>;
 
 // -------- session:resume（Renderer → Main） --------
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -38,6 +38,9 @@ importers:
       '@opentrad/cc-adapter':
         specifier: workspace:^
         version: link:../../packages/cc-adapter
+      better-sqlite3:
+        specifier: ^12.9.0
+        version: 12.9.0
       electron:
         specifier: ^41.3.0
         version: 41.3.0
@@ -47,10 +50,16 @@ importers:
       react-dom:
         specifier: ^19.2.5
         version: 19.2.5(react@19.2.5)
+      zod:
+        specifier: ^4.3.6
+        version: 4.3.6
     devDependencies:
       '@opentrad/shared':
         specifier: workspace:^
         version: link:../../packages/shared
+      '@types/better-sqlite3':
+        specifier: ^7.6.13
+        version: 7.6.13
       '@types/react':
         specifier: ^19.2.14
         version: 19.2.14
@@ -690,6 +699,9 @@ packages:
   '@tybys/wasm-util@0.10.1':
     resolution: {integrity: sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==}
 
+  '@types/better-sqlite3@7.6.13':
+    resolution: {integrity: sha512-NMv9ASNARoKksWtsq/SHakpYAYnhBrQgGD8zkLYk/jaK8jUGn08CfEdTRgYhMypUQAfzSP8W6gNLe0q19/t4VA==}
+
   '@types/cacheable-request@6.0.3':
     resolution: {integrity: sha512-IQ3EbTzGxIigb1I3qPZc1rWJnH0BmSKv5QYTalEwweFvyBDLSAe24zP0le/hyi7ecGfZVlIVAg4BZqb8WBwKqw==}
 
@@ -774,10 +786,23 @@ packages:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
     engines: {node: '>=12'}
 
+  base64-js@1.5.1:
+    resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
+
   baseline-browser-mapping@2.10.21:
     resolution: {integrity: sha512-Q+rUQ7Uz8AHM7DEaNdwvfFCTq7a43lNTzuS94eiWqwyxfV/wJv+oUivef51T91mmRY4d4A1u9rcSvkeufCVXlA==}
     engines: {node: '>=6.0.0'}
     hasBin: true
+
+  better-sqlite3@12.9.0:
+    resolution: {integrity: sha512-wqUv4Gm3toFpHDQmaKD4QhZm3g1DjUBI0yzS4UBl6lElUmXFYdTQmmEDpAFa5o8FiFiymURypEnfVHzILKaxqQ==}
+    engines: {node: 20.x || 22.x || 23.x || 24.x || 25.x}
+
+  bindings@1.5.0:
+    resolution: {integrity: sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==}
+
+  bl@4.1.0:
+    resolution: {integrity: sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==}
 
   boolean@3.2.0:
     resolution: {integrity: sha512-d0II/GO9uf9lfUHH2BQsjxzRJZBdsjgsBiW4BvhWk/3qoKwQFjIDVN19PfX8F2D/r9PCMTtLWjYVCFrpeYUzsw==}
@@ -790,6 +815,9 @@ packages:
 
   buffer-crc32@0.2.13:
     resolution: {integrity: sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==}
+
+  buffer@5.7.1:
+    resolution: {integrity: sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==}
 
   cac@6.7.14:
     resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
@@ -809,6 +837,9 @@ packages:
   chai@6.2.2:
     resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
     engines: {node: '>=18'}
+
+  chownr@1.1.4:
+    resolution: {integrity: sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==}
 
   clone-response@1.0.3:
     resolution: {integrity: sha512-ROoL94jJH2dUVML2Y/5PEDNaSHgeOdSDicUyS7izcF63G6sTc/FTjLub4b8Il9S8S0beOfYt0TaA5qvFK+w0wA==}
@@ -831,6 +862,10 @@ packages:
   decompress-response@6.0.0:
     resolution: {integrity: sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==}
     engines: {node: '>=10'}
+
+  deep-extend@0.6.0:
+    resolution: {integrity: sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==}
+    engines: {node: '>=4.0.0'}
 
   defer-to-connect@2.0.1:
     resolution: {integrity: sha512-4tvttepXG1VaYGrRibk5EwJd1t4udunSOVMdLSAL6mId1ix438oPwPZMALY41FCijukO1L0twNcGsdzS7dHgDg==}
@@ -912,6 +947,10 @@ packages:
   estree-walker@3.0.3:
     resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
 
+  expand-template@2.0.3:
+    resolution: {integrity: sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==}
+    engines: {node: '>=6'}
+
   expect-type@1.3.0:
     resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
     engines: {node: '>=12.0.0'}
@@ -933,6 +972,12 @@ packages:
       picomatch:
         optional: true
 
+  file-uri-to-path@1.0.0:
+    resolution: {integrity: sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==}
+
+  fs-constants@1.0.0:
+    resolution: {integrity: sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==}
+
   fs-extra@8.1.0:
     resolution: {integrity: sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==}
     engines: {node: '>=6 <7 || >=8'}
@@ -952,6 +997,9 @@ packages:
 
   get-tsconfig@4.14.0:
     resolution: {integrity: sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA==}
+
+  github-from-package@0.0.0:
+    resolution: {integrity: sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==}
 
   global-agent@3.0.0:
     resolution: {integrity: sha512-PT6XReJ+D07JvGoxQMkT6qji/jVNfX/h364XHZOWeRzy64sSFr+xJ5OX7LI3b4MPQzdL4H8Y8M0xzPpsVMwA8Q==}
@@ -981,6 +1029,15 @@ packages:
   http2-wrapper@1.0.3:
     resolution: {integrity: sha512-V+23sDMr12Wnz7iTcDeJr3O6AIxlnvT/bmaAAAP/Xda35C90p9599p0F1eHR/N1KILWSoWVAiOMFjBBXaXSMxg==}
     engines: {node: '>=10.19.0'}
+
+  ieee754@1.2.1:
+    resolution: {integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==}
+
+  inherits@2.0.4:
+    resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
+
+  ini@1.3.8:
+    resolution: {integrity: sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==}
 
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
@@ -1099,6 +1156,12 @@ packages:
     resolution: {integrity: sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==}
     engines: {node: '>=10'}
 
+  minimist@1.2.8:
+    resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
+
+  mkdirp-classic@0.5.3:
+    resolution: {integrity: sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==}
+
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
@@ -1106,6 +1169,13 @@ packages:
     resolution: {integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
+
+  napi-build-utils@2.0.0:
+    resolution: {integrity: sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==}
+
+  node-abi@3.89.0:
+    resolution: {integrity: sha512-6u9UwL0HlAl21+agMN3YAMXcKByMqwGx+pq+P76vii5f7hTPtKDp08/H9py6DY+cfDw7kQNTGEj/rly3IgbNQA==}
+    engines: {node: '>=10'}
 
   node-releases@2.0.38:
     resolution: {integrity: sha512-3qT/88Y3FbH/Kx4szpQQ4HzUbVrHPKTLVpVocKiLfoYvw9XSGOX2FmD2d6DrXbVYyAQTF2HeF6My8jmzx7/CRw==}
@@ -1145,6 +1215,12 @@ packages:
     resolution: {integrity: sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==}
     engines: {node: ^10 || ^12 || >=14}
 
+  prebuild-install@7.1.3:
+    resolution: {integrity: sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==}
+    engines: {node: '>=10'}
+    deprecated: No longer maintained. Please contact the author of the relevant native addon; alternatives are available.
+    hasBin: true
+
   progress@2.0.3:
     resolution: {integrity: sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==}
     engines: {node: '>=0.4.0'}
@@ -1156,6 +1232,10 @@ packages:
     resolution: {integrity: sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==}
     engines: {node: '>=10'}
 
+  rc@1.2.8:
+    resolution: {integrity: sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==}
+    hasBin: true
+
   react-dom@19.2.5:
     resolution: {integrity: sha512-J5bAZz+DXMMwW/wV3xzKke59Af6CHY7G4uYLN1OvBcKEsWOs4pQExj86BBKamxl/Ik5bx9whOrvBlSDfWzgSag==}
     peerDependencies:
@@ -1164,6 +1244,10 @@ packages:
   react@19.2.5:
     resolution: {integrity: sha512-llUJLzz1zTUBrskt2pwZgLq59AemifIftw4aB7JxOqf1HY2FDaGDxgwpAPVzHU1kdWabH7FauP4i1oEeer2WCA==}
     engines: {node: '>=0.10.0'}
+
+  readable-stream@3.6.2:
+    resolution: {integrity: sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==}
+    engines: {node: '>= 6'}
 
   resolve-alpn@1.2.1:
     resolution: {integrity: sha512-0a1F4l73/ZFZOakJnQ3FvkJ2+gSTQWz/r2KE5OdDY0TxPm5h4GkqkWWfM47T7HsbnOtcJVEF4epCVy6u7Q3K+g==}
@@ -1182,6 +1266,9 @@ packages:
     resolution: {integrity: sha512-ZrT53oAKrtA4+YtBWPQbtPOxIbVDbxT0orcYERKd63VJTF13zPcgXTvD4843L8pcsI7M6MErt8QtON6lrB9tyA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
+
+  safe-buffer@5.2.1:
+    resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
 
   scheduler@0.27.0:
     resolution: {integrity: sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==}
@@ -1205,6 +1292,12 @@ packages:
   siginfo@2.0.0:
     resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
 
+  simple-concat@1.0.1:
+    resolution: {integrity: sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==}
+
+  simple-get@4.0.1:
+    resolution: {integrity: sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==}
+
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
     engines: {node: '>=0.10.0'}
@@ -1218,9 +1311,23 @@ packages:
   std-env@4.1.0:
     resolution: {integrity: sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==}
 
+  string_decoder@1.3.0:
+    resolution: {integrity: sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==}
+
+  strip-json-comments@2.0.1:
+    resolution: {integrity: sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==}
+    engines: {node: '>=0.10.0'}
+
   sumchecker@3.0.1:
     resolution: {integrity: sha512-MvjXzkz/BOfyVDkG0oFOtBxHX2u3gKbMHIF/dXblZsgD3BWOFLmHovIpZY7BykJdAjcqRCBi1WYBNdEC9yI7vg==}
     engines: {node: '>= 8.0'}
+
+  tar-fs@2.1.4:
+    resolution: {integrity: sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ==}
+
+  tar-stream@2.2.0:
+    resolution: {integrity: sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==}
+    engines: {node: '>=6'}
 
   tinybench@2.9.0:
     resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
@@ -1244,6 +1351,9 @@ packages:
     resolution: {integrity: sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==}
     engines: {node: '>=18.0.0'}
     hasBin: true
+
+  tunnel-agent@0.6.0:
+    resolution: {integrity: sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==}
 
   type-fest@0.13.1:
     resolution: {integrity: sha512-34R7HTnG0XIJcBSn5XhDd7nNFPRcXYRZrBB2O2jdKqYODldSzBAqzsWoZYYvduky73toYS/ESqxPvkDf/F0XMg==}
@@ -1269,6 +1379,9 @@ packages:
     hasBin: true
     peerDependencies:
       browserslist: '>= 4.21.0'
+
+  util-deprecate@1.0.2:
+    resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
 
   vite@8.0.10:
     resolution: {integrity: sha512-rZuUu9j6J5uotLDs+cAA4O5H4K1SfPliUlQwqa6YEwSrWDZzP4rhm00oJR5snMewjxF5V/K3D4kctsUTsIU9Mw==}
@@ -1795,6 +1908,10 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
+  '@types/better-sqlite3@7.6.13':
+    dependencies:
+      '@types/node': 25.6.0
+
   '@types/cacheable-request@6.0.3':
     dependencies:
       '@types/http-cache-semantics': 4.2.0
@@ -1890,7 +2007,24 @@ snapshots:
 
   assertion-error@2.0.1: {}
 
+  base64-js@1.5.1: {}
+
   baseline-browser-mapping@2.10.21: {}
+
+  better-sqlite3@12.9.0:
+    dependencies:
+      bindings: 1.5.0
+      prebuild-install: 7.1.3
+
+  bindings@1.5.0:
+    dependencies:
+      file-uri-to-path: 1.0.0
+
+  bl@4.1.0:
+    dependencies:
+      buffer: 5.7.1
+      inherits: 2.0.4
+      readable-stream: 3.6.2
 
   boolean@3.2.0:
     optional: true
@@ -1904,6 +2038,11 @@ snapshots:
       update-browserslist-db: 1.2.3(browserslist@4.28.2)
 
   buffer-crc32@0.2.13: {}
+
+  buffer@5.7.1:
+    dependencies:
+      base64-js: 1.5.1
+      ieee754: 1.2.1
 
   cac@6.7.14: {}
 
@@ -1923,6 +2062,8 @@ snapshots:
 
   chai@6.2.2: {}
 
+  chownr@1.1.4: {}
+
   clone-response@1.0.3:
     dependencies:
       mimic-response: 1.0.1
@@ -1938,6 +2079,8 @@ snapshots:
   decompress-response@6.0.0:
     dependencies:
       mimic-response: 3.1.0
+
+  deep-extend@0.6.0: {}
 
   defer-to-connect@2.0.1: {}
 
@@ -2066,6 +2209,8 @@ snapshots:
     dependencies:
       '@types/estree': 1.0.8
 
+  expand-template@2.0.3: {}
+
   expect-type@1.3.0: {}
 
   extract-zip@2.0.1:
@@ -2086,6 +2231,10 @@ snapshots:
     optionalDependencies:
       picomatch: 4.0.4
 
+  file-uri-to-path@1.0.0: {}
+
+  fs-constants@1.0.0: {}
+
   fs-extra@8.1.0:
     dependencies:
       graceful-fs: 4.2.11
@@ -2104,6 +2253,8 @@ snapshots:
   get-tsconfig@4.14.0:
     dependencies:
       resolve-pkg-maps: 1.0.0
+
+  github-from-package@0.0.0: {}
 
   global-agent@3.0.0:
     dependencies:
@@ -2151,6 +2302,12 @@ snapshots:
     dependencies:
       quick-lru: 5.1.1
       resolve-alpn: 1.2.1
+
+  ieee754@1.2.1: {}
+
+  inherits@2.0.4: {}
+
+  ini@1.3.8: {}
 
   js-tokens@4.0.0: {}
 
@@ -2239,9 +2396,19 @@ snapshots:
 
   mimic-response@3.1.0: {}
 
+  minimist@1.2.8: {}
+
+  mkdirp-classic@0.5.3: {}
+
   ms@2.1.3: {}
 
   nanoid@3.3.11: {}
+
+  napi-build-utils@2.0.0: {}
+
+  node-abi@3.89.0:
+    dependencies:
+      semver: 7.7.4
 
   node-releases@2.0.38: {}
 
@@ -2272,6 +2439,21 @@ snapshots:
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
+  prebuild-install@7.1.3:
+    dependencies:
+      detect-libc: 2.1.2
+      expand-template: 2.0.3
+      github-from-package: 0.0.0
+      minimist: 1.2.8
+      mkdirp-classic: 0.5.3
+      napi-build-utils: 2.0.0
+      node-abi: 3.89.0
+      pump: 3.0.4
+      rc: 1.2.8
+      simple-get: 4.0.1
+      tar-fs: 2.1.4
+      tunnel-agent: 0.6.0
+
   progress@2.0.3: {}
 
   pump@3.0.4:
@@ -2281,12 +2463,25 @@ snapshots:
 
   quick-lru@5.1.1: {}
 
+  rc@1.2.8:
+    dependencies:
+      deep-extend: 0.6.0
+      ini: 1.3.8
+      minimist: 1.2.8
+      strip-json-comments: 2.0.1
+
   react-dom@19.2.5(react@19.2.5):
     dependencies:
       react: 19.2.5
       scheduler: 0.27.0
 
   react@19.2.5: {}
+
+  readable-stream@3.6.2:
+    dependencies:
+      inherits: 2.0.4
+      string_decoder: 1.3.0
+      util-deprecate: 1.0.2
 
   resolve-alpn@1.2.1: {}
 
@@ -2327,6 +2522,8 @@ snapshots:
       '@rolldown/binding-win32-arm64-msvc': 1.0.0-rc.17
       '@rolldown/binding-win32-x64-msvc': 1.0.0-rc.17
 
+  safe-buffer@5.2.1: {}
+
   scheduler@0.27.0: {}
 
   semver-compare@1.0.0:
@@ -2334,8 +2531,7 @@ snapshots:
 
   semver@6.3.1: {}
 
-  semver@7.7.4:
-    optional: true
+  semver@7.7.4: {}
 
   serialize-error@7.0.1:
     dependencies:
@@ -2343,6 +2539,14 @@ snapshots:
     optional: true
 
   siginfo@2.0.0: {}
+
+  simple-concat@1.0.1: {}
+
+  simple-get@4.0.1:
+    dependencies:
+      decompress-response: 6.0.0
+      once: 1.4.0
+      simple-concat: 1.0.1
 
   source-map-js@1.2.1: {}
 
@@ -2353,11 +2557,32 @@ snapshots:
 
   std-env@4.1.0: {}
 
+  string_decoder@1.3.0:
+    dependencies:
+      safe-buffer: 5.2.1
+
+  strip-json-comments@2.0.1: {}
+
   sumchecker@3.0.1:
     dependencies:
       debug: 4.4.3
     transitivePeerDependencies:
       - supports-color
+
+  tar-fs@2.1.4:
+    dependencies:
+      chownr: 1.1.4
+      mkdirp-classic: 0.5.3
+      pump: 3.0.4
+      tar-stream: 2.2.0
+
+  tar-stream@2.2.0:
+    dependencies:
+      bl: 4.1.0
+      end-of-stream: 1.4.5
+      fs-constants: 1.0.0
+      inherits: 2.0.4
+      readable-stream: 3.6.2
 
   tinybench@2.9.0: {}
 
@@ -2380,6 +2605,10 @@ snapshots:
     optionalDependencies:
       fsevents: 2.3.3
 
+  tunnel-agent@0.6.0:
+    dependencies:
+      safe-buffer: 5.2.1
+
   type-fest@0.13.1:
     optional: true
 
@@ -2396,6 +2625,8 @@ snapshots:
       browserslist: 4.28.2
       escalade: 3.2.0
       picocolors: 1.1.1
+
+  util-deprecate@1.0.2: {}
 
   vite@8.0.10(@types/node@25.6.0)(esbuild@0.27.7)(tsx@4.21.0):
     dependencies:


### PR DESCRIPTION
按 [03-architecture.md §五](https://github.com/open-trad/docs/blob/main/design/03-architecture.md#sqlite-数据库) 落地 SQLite 持久化层。M0 完全没碰持久化，本 PR 是 M1 第一个有用户可见持久状态的模块；后续 M1 #11 / #28 (RiskGate)、M1 #29 / #12 (history 回放) 直接消费这层 service。

## 改动

### 共享类型(`packages/shared/src/types/db.ts`)

6 张表的 domain 层 row schema + 输入 schema。沿用 D1 wire/domain 两层规范：SQLite 列 snake_case ↔ domain 字段 camelCase 在 service 层显式映射；INTEGER 0/1 ↔ boolean、TEXT JSON ↔ unknown 也在 service 层转。

### Desktop 实现(`apps/desktop/src/main/services/db/`)

- `schema.ts`：6 张表 + 索引 SQL 字符串(sessions / events / risk_rules / audit_log / settings / installed_skills),含 CHECK 约束和 FK CASCADE
- `paths.ts`：跨平台用户数据目录(macOS/Linux `~/.opentrad/`、Windows `%APPDATA%\OpenTrad\`)
- `init.ts`：`openDatabase` 同步 API,foreign_keys ON、journal_mode=DELETE,支持 `:memory:` 单测模式;首次启动写 `schema_version=1`(预留 M2 迁移机制)
- 6 个 service:`sessions` / `settings` / `installed-skills` / `events` / `risk-rules` / `audit-log`。每个 service 在 constructor 一次性 prepare statements 缓存
- `index.ts`：`DbServices` bundle,把 6 个 service 装一个对象方便注入

### 单实例互斥锁(`apps/desktop/src/main/services/lock.ts`)

写 `.lock` 文件 + PID。**A2 stale PID 处理**(开工前对齐):

- `.lock` 已存在时,`process.kill(pid, 0)` 探活
- `ESRCH`(进程已死)→ 视为 stale,覆盖
- `EPERM`(cross-user)→ 保守视为活
- 其他错误 → 保守视为活
- release 时 PID 校验,只删自己持有的(防止崩溃残留误删别人)

### IPC handlers

- `session:list`(分页 limit/offset)→ `SessionMeta[]` 精简视图
- `session:get` → `SessionRow` 完整字段
- `session:delete` → CASCADE 自动清 events
- `settings:get` / `settings:set` → 任意 JSON 值(service JSON.stringify/parse)
- `installed-skill:list` → `InstalledSkillRow[]`

### main 集成

- 启动时 `acquireAppLock` + `createDbServices`
- 启动失败(lock held)→ `dialog.showErrorBox` + `app.quit`
- 退出时 `db.close` + `lock.release`(PID 校验保护)

## 测试

- `apps/desktop` 单测 38 个:6 个 service 主路径 + lock 7 种状态(含 stale PID 探活)
- 所有 monorepo 包测试 152 通过:shared 61 / stream-parser 30 / cc-adapter 23 / desktop 38
- `pnpm typecheck` 8 packages 全过
- `pnpm lint` clean
- **物理 db smoke**:`~/.opentrad/opentrad.db` 自动建表,6 张表 + 6 索引 + `schema_version=1` 全部正确

## 配置变更

根 `package.json` 的 `pnpm.onlyBuiltDependencies` 加 `better-sqlite3`(native module 必须跑 install script 才能 build prebuilt binary;沿用 M0 D9-1 自主决策标准——必要前置约束,跟当前已有的 `electron` / `esbuild` / `@biomejs/biome` 同列表)。

## 自查发现的取舍

- `audit-log` ORDER BY 加 `id DESC` 二级 key(仅 `timestamp DESC` 在同毫秒时排序不稳定)
- service 的 `db` 参数从 `private readonly` 改为普通参数(biome 提示 `noUnusedPrivateClassMembers`,prepared statements 在 constructor 全部缓存,运行时不再访问 db)

## 不在本 PR 范围

- `skill` / `risk-gate` / `pty` / `installer` 等 IPC:后续 issue 接通
- events 表的 append 调用:在 M1 #9 / #26 接通 `sessionStore.startTask` 时挂上(已在 #26 issue body 标注 ownership)
- `session:resume` 真正实现:M1 #29 / #12(D-M1-7 决策只做 events 回放)

## Closes

Closes #19