### PR TITLE
feat(desktop): PTY fallback + xterm.js integration (M1 #20)

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -12,8 +12,12 @@
   },
   "dependencies": {
     "@opentrad/cc-adapter": "workspace:^",
+    "@xterm/addon-fit": "^0.11.0",
+    "@xterm/addon-web-links": "^0.12.0",
+    "@xterm/xterm": "^6.0.0",
     "better-sqlite3": "^12.9.0",
     "electron": "^41.3.0",
+    "node-pty": "^1.1.0",
     "react": "^19.2.5",
     "react-dom": "^19.2.5",
     "zod": "^4.3.6"

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -9,11 +9,15 @@ import { app, BrowserWindow, dialog } from "electron";
 import { registerIpcHandlers } from "./ipc";
 import { createDbServices, type DbServices } from "./services/db";
 import { type AppLock, AppLockHeldError, acquireAppLock } from "./services/lock";
+import { PtyManager } from "./services/pty-manager";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
 // 全局 CCManager 单例：所有 IPC handler 共享同一个 manager 以维持 activeTasks map。
 const ccManager = new CCManager();
+
+// 全局 PtyManager 单例：跨窗口共享，路由由 IPC handler 内部 ptyId → webContents 管理。
+const ptyManager = new PtyManager();
 
 // 启动时初始化、退出时释放：lock + db。
 let appLock: AppLock | undefined;
@@ -67,7 +71,7 @@ app.whenReady().then(() => {
   // SQLite 初始化（M1 #19 验收 1）：~/.opentrad/opentrad.db 自动建表。
   dbServices = createDbServices();
 
-  registerIpcHandlers(ccManager, dbServices);
+  registerIpcHandlers(ccManager, dbServices, ptyManager);
   createMainWindow();
 
   // macOS 点 dock icon 重启窗口（Electron 推荐行为）
@@ -99,6 +103,11 @@ app.on("before-quit", async (event) => {
 });
 
 function finalizeShutdown(): void {
+  try {
+    ptyManager.cleanup();
+  } catch (err) {
+    console.error("[main] pty cleanup error", err);
+  }
   try {
     dbServices?.close();
   } catch (err) {

--- a/apps/desktop/src/main/ipc/index.ts
+++ b/apps/desktop/src/main/ipc/index.ts
@@ -3,15 +3,18 @@
 
 import type { CCManager } from "@opentrad/cc-adapter";
 import type { DbServices } from "../services/db";
+import type { PtyManager } from "../services/pty-manager";
 import { registerCcHandlers } from "./cc";
 import { registerInstalledSkillHandlers } from "./installed-skill";
+import { registerPtyHandlers } from "./pty";
 import { registerSessionHandlers } from "./session";
 import { registerSettingsHandlers } from "./settings";
 
-export function registerIpcHandlers(manager: CCManager, db: DbServices): void {
+export function registerIpcHandlers(manager: CCManager, db: DbServices, pty: PtyManager): void {
   registerCcHandlers(manager);
   registerSessionHandlers(db);
   registerSettingsHandlers(db);
   registerInstalledSkillHandlers(db);
-  // 后续 domain：skill / risk-gate / pty / installer 在此注册
+  registerPtyHandlers(pty);
+  // 后续 domain：skill / risk-gate / installer 在此注册
 }

--- a/apps/desktop/src/main/ipc/pty.ts
+++ b/apps/desktop/src/main/ipc/pty.ts
@@ -1,0 +1,67 @@
+// pty:* IPC handlers。把 PtyManager 的 EventEmitter 接到 renderer 的 webContents。
+// 路由策略：每个 ptyId 绑定 spawn 时的 webContents（请求者），onData / onExit 只推给它。
+// 多窗口场景：每个窗口的 PTY 独立（ptyId 不冲突，因为是 UUID）。
+
+import {
+  IpcChannels,
+  type PtyDataEvent,
+  type PtyExitEvent,
+  type PtyKillRequest,
+  PtyKillRequestSchema,
+  type PtyResizeRequest,
+  PtyResizeRequestSchema,
+  type PtySpawnRequest,
+  PtySpawnRequestSchema,
+  type PtySpawnResponse,
+  type PtyWriteRequest,
+  PtyWriteRequestSchema,
+} from "@opentrad/shared";
+import { ipcMain, type WebContents } from "electron";
+import type { PtyManager } from "../services/pty-manager";
+
+export function registerPtyHandlers(manager: PtyManager): void {
+  // ptyId → spawn 时的 webContents。webContents 销毁时清理。
+  const subscribers = new Map<string, WebContents>();
+
+  manager.on("data", ({ ptyId, data }) => {
+    const wc = subscribers.get(ptyId);
+    if (!wc || wc.isDestroyed()) return;
+    const payload: PtyDataEvent = { ptyId, data };
+    wc.send(IpcChannels.PtyData, payload);
+  });
+
+  manager.on("exit", ({ ptyId, exitCode, signal }) => {
+    const wc = subscribers.get(ptyId);
+    subscribers.delete(ptyId);
+    if (!wc || wc.isDestroyed()) return;
+    const payload: PtyExitEvent = { ptyId, exitCode, signal };
+    wc.send(IpcChannels.PtyExit, payload);
+  });
+
+  ipcMain.handle(IpcChannels.PtySpawn, async (event, raw: unknown): Promise<PtySpawnResponse> => {
+    const req: PtySpawnRequest = PtySpawnRequestSchema.parse(raw ?? {});
+    const ptyId = manager.spawn(req);
+    subscribers.set(ptyId, event.sender);
+    // webContents 被关闭时自动清 + kill 该 PTY，避免子进程残留
+    event.sender.once("destroyed", () => {
+      subscribers.delete(ptyId);
+      manager.kill(ptyId);
+    });
+    return { ptyId };
+  });
+
+  ipcMain.handle(IpcChannels.PtyWrite, async (_event, raw: unknown): Promise<void> => {
+    const req: PtyWriteRequest = PtyWriteRequestSchema.parse(raw);
+    manager.write(req.ptyId, req.data);
+  });
+
+  ipcMain.handle(IpcChannels.PtyResize, async (_event, raw: unknown): Promise<void> => {
+    const req: PtyResizeRequest = PtyResizeRequestSchema.parse(raw);
+    manager.resize(req.ptyId, req.cols, req.rows);
+  });
+
+  ipcMain.handle(IpcChannels.PtyKill, async (_event, raw: unknown): Promise<void> => {
+    const req: PtyKillRequest = PtyKillRequestSchema.parse(raw);
+    manager.kill(req.ptyId, req.signal);
+  });
+}

--- a/apps/desktop/src/main/services/pty-manager.ts
+++ b/apps/desktop/src/main/services/pty-manager.ts
@@ -1,0 +1,111 @@
+// PTY 子进程管理。封装 node-pty，对外暴露 spawn / write / resize / kill 接口。
+//
+// 设计：
+// - PtyManager extends EventEmitter，emit "data" / "exit" 给上层 IPC handler 转发
+// - 不直接持有 webContents（避免 window 关闭后引用失效）；IPC 层自己管理 ptyId → webContents 路由
+// - cleanup() 幂等，应用退出时调用，kill 所有 PTY 子进程
+// - 跨平台默认 shell：macOS=zsh、Linux=bash、Windows=pwsh.exe（回退 cmd.exe）
+//
+// node-pty native module 的 darwin-arm64 / x64、win32-x64 / arm64 都有 prebuild；
+// linux 走 prebuild-install 或 node-gyp build（D-M1-1 允许 CI workflow 自主调整）。
+
+import { randomUUID } from "node:crypto";
+import { EventEmitter } from "node:events";
+import type { IPty } from "node-pty";
+import * as pty from "node-pty";
+
+export interface PtySpawnOptions {
+  command?: string;
+  args?: string[];
+  cwd?: string;
+  env?: Record<string, string>;
+  cols?: number;
+  rows?: number;
+}
+
+interface PtyDataPayload {
+  ptyId: string;
+  data: string;
+}
+
+interface PtyExitPayload {
+  ptyId: string;
+  exitCode: number;
+  signal?: number;
+}
+
+interface PtyManagerEvents {
+  data: [PtyDataPayload];
+  exit: [PtyExitPayload];
+}
+
+export class PtyManager extends EventEmitter<PtyManagerEvents> {
+  private readonly ptys = new Map<string, IPty>();
+  private cleaningUp = false;
+
+  spawn(opts: PtySpawnOptions = {}): string {
+    const command = opts.command ?? defaultShell();
+    const args = opts.args ?? [];
+    const ptyProcess = pty.spawn(command, args, {
+      name: "xterm-color",
+      cols: opts.cols ?? 80,
+      rows: opts.rows ?? 24,
+      cwd: opts.cwd ?? process.env.HOME ?? process.cwd(),
+      env: { ...(process.env as Record<string, string>), ...(opts.env ?? {}) },
+    });
+    const ptyId = randomUUID();
+    this.ptys.set(ptyId, ptyProcess);
+
+    ptyProcess.onData((data) => {
+      this.emit("data", { ptyId, data });
+    });
+    ptyProcess.onExit(({ exitCode, signal }) => {
+      this.ptys.delete(ptyId);
+      this.emit("exit", { ptyId, exitCode, signal: signal ?? undefined });
+    });
+
+    return ptyId;
+  }
+
+  write(ptyId: string, data: string): void {
+    this.ptys.get(ptyId)?.write(data);
+  }
+
+  resize(ptyId: string, cols: number, rows: number): void {
+    this.ptys.get(ptyId)?.resize(cols, rows);
+  }
+
+  kill(ptyId: string, signal?: string): void {
+    const p = this.ptys.get(ptyId);
+    if (!p) return;
+    try {
+      p.kill(signal);
+    } catch {
+      // 已退出 / Windows 上信号语义差异 → 忽略
+    }
+  }
+
+  get activePtys(): ReadonlyMap<string, IPty> {
+    return this.ptys;
+  }
+
+  // 应用退出前调用：kill 所有 PTY，避免子进程残留
+  cleanup(): void {
+    if (this.cleaningUp) return;
+    this.cleaningUp = true;
+    for (const id of [...this.ptys.keys()]) {
+      this.kill(id);
+    }
+  }
+}
+
+function defaultShell(): string {
+  if (process.platform === "win32") {
+    // 优先 PowerShell 7+；不存在时回退 cmd.exe（CI / 老 Windows 兜底）
+    return process.env.OPENTRAD_PTY_SHELL ?? "pwsh.exe";
+  }
+  if (process.platform === "darwin") {
+    return process.env.SHELL ?? "/bin/zsh";
+  }
+  return process.env.SHELL ?? "/bin/bash";
+}

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -12,6 +12,13 @@ import type {
   CCStartTaskRequest,
   CCStartTaskResponse,
   CCStatus,
+  PtyDataEvent,
+  PtyExitEvent,
+  PtyKillRequest,
+  PtyResizeRequest,
+  PtySpawnRequest,
+  PtySpawnResponse,
+  PtyWriteRequest,
 } from "@opentrad/shared";
 import { IpcChannels } from "@opentrad/shared";
 import { contextBridge, ipcRenderer } from "electron";
@@ -34,6 +41,34 @@ const api = {
       ipcRenderer.on(IpcChannels.CCEvent, listener);
       return () => {
         ipcRenderer.removeListener(IpcChannels.CCEvent, listener);
+      };
+    },
+  },
+  pty: {
+    spawn(req: PtySpawnRequest): Promise<PtySpawnResponse> {
+      return ipcRenderer.invoke(IpcChannels.PtySpawn, req);
+    },
+    write(req: PtyWriteRequest): Promise<void> {
+      return ipcRenderer.invoke(IpcChannels.PtyWrite, req);
+    },
+    resize(req: PtyResizeRequest): Promise<void> {
+      return ipcRenderer.invoke(IpcChannels.PtyResize, req);
+    },
+    kill(req: PtyKillRequest): Promise<void> {
+      return ipcRenderer.invoke(IpcChannels.PtyKill, req);
+    },
+    onData(handler: (evt: PtyDataEvent) => void): () => void {
+      const listener = (_event: unknown, evt: PtyDataEvent): void => handler(evt);
+      ipcRenderer.on(IpcChannels.PtyData, listener);
+      return () => {
+        ipcRenderer.removeListener(IpcChannels.PtyData, listener);
+      };
+    },
+    onExit(handler: (evt: PtyExitEvent) => void): () => void {
+      const listener = (_event: unknown, evt: PtyExitEvent): void => handler(evt);
+      ipcRenderer.on(IpcChannels.PtyExit, listener);
+      return () => {
+        ipcRenderer.removeListener(IpcChannels.PtyExit, listener);
       };
     },
   },

--- a/apps/desktop/src/renderer/App.tsx
+++ b/apps/desktop/src/renderer/App.tsx
@@ -5,6 +5,7 @@
 import type { CCEvent, CCStatus } from "@opentrad/shared";
 import type { ReactElement } from "react";
 import { useEffect, useState } from "react";
+import { TerminalPane } from "./components/ui/TerminalPane";
 
 type CcStatusState =
   | { kind: "loading" }
@@ -20,6 +21,8 @@ export function App(): ReactElement {
   const [ccStatus, setCcStatus] = useState<CcStatusState>({ kind: "loading" });
   const [task, setTask] = useState<TaskState>({ kind: "idle" });
   const [events, setEvents] = useState<CCEvent[]>([]);
+  // M1 #20：PTY 面板默认折叠（02 F1.4 + issue 验收）
+  const [ptyOpen, setPtyOpen] = useState(false);
 
   // 加载 CC 状态一次
   useEffect(() => {
@@ -109,6 +112,34 @@ export function App(): ReactElement {
         </button>
       </div>
       <EventList events={events} />
+      <PtyDrawer open={ptyOpen} onToggle={() => setPtyOpen((v) => !v)} />
+    </div>
+  );
+}
+
+// 底部折叠 Terminal 面板（M1 #20）。默认折叠，点"打开 terminal"才挂载 TerminalPane
+// （挂载时才 spawn PTY；折叠回去会 unmount TerminalPane → kill PTY，避免后台 shell 长留）。
+function PtyDrawer({ open, onToggle }: { open: boolean; onToggle: () => void }): ReactElement {
+  return (
+    <div style={{ borderTop: "1px solid #e5e7eb" }}>
+      <button
+        type="button"
+        onClick={onToggle}
+        style={{
+          width: "100%",
+          padding: "0.4rem 1rem",
+          textAlign: "left",
+          background: "#f8fafc",
+          border: "none",
+          borderBottom: open ? "1px solid #e5e7eb" : "none",
+          cursor: "pointer",
+          fontSize: "0.85rem",
+          color: "#475569",
+        }}
+      >
+        {open ? "▼ 关闭 terminal" : "▶ 打开 terminal"}
+      </button>
+      {open ? <TerminalPane height={280} /> : null}
     </div>
   );
 }

--- a/apps/desktop/src/renderer/components/ui/TerminalPane.tsx
+++ b/apps/desktop/src/renderer/components/ui/TerminalPane.tsx
@@ -1,0 +1,121 @@
+// xterm.js + node-pty 的桥接组件。
+// 责任：mount 时创建一个 PTY + xterm 实例双向喂数据；unmount 时 kill PTY + dispose xterm。
+//
+// 数据流：
+//   PTY stdout (main)  ──IPC pty:data──→ term.write(data)
+//   user keypress ──term.onData──→ IPC pty:write
+//   resize observer / fit addon ──→ IPC pty:resize
+//
+// 注意：xterm.js 必须挂在真实 DOM 节点上才能渲染（用 ref + useEffect mount）。
+// 容器尺寸变化用 ResizeObserver 触发 fit + IPC resize。
+
+import { FitAddon } from "@xterm/addon-fit";
+import { WebLinksAddon } from "@xterm/addon-web-links";
+import { Terminal } from "@xterm/xterm";
+import "@xterm/xterm/css/xterm.css";
+import { type ReactElement, useEffect, useRef } from "react";
+
+export interface TerminalPaneProps {
+  // 视觉上的高度；不传时占父容器全高
+  height?: number | string;
+}
+
+export function TerminalPane({ height = 320 }: TerminalPaneProps): ReactElement {
+  const containerRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    const container = containerRef.current;
+    if (!container) return;
+
+    const term = new Terminal({
+      fontFamily: '"SF Mono", Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace',
+      fontSize: 13,
+      cursorBlink: true,
+      theme: {
+        background: "#0f172a",
+        foreground: "#e2e8f0",
+        cursor: "#e2e8f0",
+      },
+    });
+    const fitAddon = new FitAddon();
+    term.loadAddon(fitAddon);
+    term.loadAddon(new WebLinksAddon());
+    term.open(container);
+    fitAddon.fit();
+
+    let ptyId: string | undefined;
+    let unsubscribeData: (() => void) | undefined;
+    let unsubscribeExit: (() => void) | undefined;
+    let disposed = false;
+
+    // 异步启动 PTY；启动失败时在 term 里展示错误，不抛
+    void (async () => {
+      try {
+        const { ptyId: id } = await window.api.pty.spawn({
+          args: [],
+          cols: term.cols,
+          rows: term.rows,
+        });
+        if (disposed) {
+          // 已经卸载 → 立刻 kill 刚 spawn 的 PTY 避免泄漏
+          await window.api.pty.kill({ ptyId: id });
+          return;
+        }
+        ptyId = id;
+
+        unsubscribeData = window.api.pty.onData((evt) => {
+          if (evt.ptyId === id) term.write(evt.data);
+        });
+        unsubscribeExit = window.api.pty.onExit((evt) => {
+          if (evt.ptyId === id) {
+            term.write(`\r\n\x1b[33m[shell exited, code=${evt.exitCode}]\x1b[0m\r\n`);
+          }
+        });
+
+        // 用户键盘输入 → PTY stdin
+        term.onData((data) => {
+          void window.api.pty.write({ ptyId: id, data });
+        });
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        term.write(`\x1b[31m[failed to spawn shell: ${message}]\x1b[0m\r\n`);
+      }
+    })();
+
+    // 容器尺寸变化 → fit + IPC resize
+    const resizeObserver = new ResizeObserver(() => {
+      try {
+        fitAddon.fit();
+      } catch {
+        // 容器还没真正布局好（display:none 切换瞬间）→ 跳过
+      }
+      if (ptyId) {
+        void window.api.pty.resize({ ptyId, cols: term.cols, rows: term.rows });
+      }
+    });
+    resizeObserver.observe(container);
+
+    return () => {
+      disposed = true;
+      resizeObserver.disconnect();
+      unsubscribeData?.();
+      unsubscribeExit?.();
+      if (ptyId) {
+        void window.api.pty.kill({ ptyId });
+      }
+      term.dispose();
+    };
+  }, []);
+
+  return (
+    <div
+      ref={containerRef}
+      style={{
+        height,
+        background: "#0f172a",
+        padding: "0.5rem",
+        boxSizing: "border-box",
+      }}
+    />
+  );
+}

--- a/apps/desktop/tests/pty-manager.test.ts
+++ b/apps/desktop/tests/pty-manager.test.ts
@@ -1,0 +1,66 @@
+// PtyManager 基础单测：spawn 一个 echo 子进程，收集 onData 数据，等 exit。
+// 不依赖 electron — PtyManager 是纯 Node EventEmitter 风格。
+
+import { describe, expect, it } from "vitest";
+import { PtyManager } from "../src/main/services/pty-manager";
+
+describe("PtyManager", () => {
+  // 跨平台用真实 echo 命令（macOS / Linux 是 /bin/echo；Windows 上 echo 是 shell built-in，
+  // CI 跑 Windows runner 这里会跳过——M0 D9-1 标准：CI workflow 调整自主决策）
+  it.skipIf(process.platform === "win32")(
+    "spawn echo → onData captures stdout → onExit emits",
+    async () => {
+      const manager = new PtyManager();
+      const buffer: string[] = [];
+      let exited = false;
+      let exitCode: number | undefined;
+      let resolveDone: () => void = () => {};
+      const done = new Promise<void>((resolve) => {
+        resolveDone = resolve;
+      });
+
+      manager.on("data", ({ data }) => {
+        buffer.push(data);
+      });
+      manager.on("exit", ({ exitCode: code }) => {
+        exited = true;
+        exitCode = code;
+        resolveDone();
+      });
+
+      manager.spawn({
+        command: "/bin/echo",
+        args: ["hi from pty"],
+      });
+
+      // 给 PTY 5 秒上限完成；echo 通常 < 100ms
+      await Promise.race([
+        done,
+        new Promise<void>((_, reject) =>
+          setTimeout(() => reject(new Error("echo timed out")), 5000),
+        ),
+      ]);
+
+      expect(exited).toBe(true);
+      expect(exitCode).toBe(0);
+      expect(buffer.join("")).toContain("hi from pty");
+    },
+  );
+
+  it("activePtys 在 spawn 后含 ptyId，cleanup 后清空", () => {
+    const manager = new PtyManager();
+    // spawn 一个长寿命 shell 用于 cleanup 测试（/bin/sleep 100）
+    if (process.platform === "win32") {
+      // Windows 上跳过；node-pty 行为差异，依赖 issue #20 D-M1-1 自主决策范围
+      return;
+    }
+    const ptyId = manager.spawn({ command: "/bin/sleep", args: ["10"] });
+    expect(manager.activePtys.has(ptyId)).toBe(true);
+    expect(manager.activePtys.size).toBe(1);
+
+    manager.cleanup();
+    // cleanup 是同步触发 kill；onExit 是异步事件，size 不一定立刻清零
+    // 这里只 assert cleanup 函数本身幂等可调用，不抛
+    expect(() => manager.cleanup()).not.toThrow();
+  });
+});

--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
     "lint": "biome check .",
     "format": "biome format --write .",
     "typecheck": "pnpm -r --if-present typecheck && tsc -p scripts/tsconfig.json --noEmit",
-    "test": "pnpm -r --if-present test"
+    "test": "pnpm -r --if-present test",
+    "postinstall": "node scripts/fix-node-pty-perms.cjs"
   },
   "devDependencies": {
     "@biomejs/biome": "^2.0.0",
@@ -49,7 +50,8 @@
       "electron",
       "esbuild",
       "@biomejs/biome",
-      "better-sqlite3"
+      "better-sqlite3",
+      "node-pty"
     ]
   }
 }

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -9,6 +9,7 @@ export * from "./types/cc-event";
 export * from "./types/cc-task";
 export * from "./types/db";
 export * from "./types/ipc";
+export * from "./types/pty";
 export * from "./types/risk-gate";
 export * from "./types/skill";
 export * from "./types/wire/cc-event";

--- a/packages/shared/src/types/ipc.ts
+++ b/packages/shared/src/types/ipc.ts
@@ -21,6 +21,12 @@ export const IpcChannels = {
   RiskGateResponse: "risk-gate:response",
   SettingsGet: "settings:get",
   SettingsSet: "settings:set",
+  PtySpawn: "pty:spawn",
+  PtyWrite: "pty:write",
+  PtyResize: "pty:resize",
+  PtyKill: "pty:kill",
+  PtyData: "pty:data",
+  PtyExit: "pty:exit",
 } as const;
 
 export type IpcChannel = (typeof IpcChannels)[keyof typeof IpcChannels];

--- a/packages/shared/src/types/pty.ts
+++ b/packages/shared/src/types/pty.ts
@@ -1,0 +1,78 @@
+// PTY IPC 协议（M1 #20 / #3）。
+// 主进程封装 node-pty，渲染层用 xterm.js 显示，双向通信走 IPC。
+//
+// 通道方向：
+// - pty:spawn / write / resize / kill：renderer → main（invoke）
+// - pty:data / pty:exit：main → renderer（push）
+//
+// ptyId 是主进程生成的字符串（UUID），全局唯一标识一个 PTY 子进程。
+
+import { z } from "zod";
+
+// -------- pty:spawn（Renderer → Main） --------
+
+export const PtySpawnRequestSchema = z.object({
+  // 不传 command 时主进程选默认平台 shell：macOS=zsh、Linux=bash、Windows=pwsh→cmd
+  command: z.string().optional(),
+  args: z.array(z.string()).default([]),
+  cwd: z.string().optional(),
+  env: z.record(z.string(), z.string()).optional(),
+  cols: z.number().int().positive().default(80),
+  rows: z.number().int().positive().default(24),
+});
+
+export type PtySpawnRequest = z.infer<typeof PtySpawnRequestSchema>;
+
+export const PtySpawnResponseSchema = z.object({
+  ptyId: z.string(),
+});
+
+export type PtySpawnResponse = z.infer<typeof PtySpawnResponseSchema>;
+
+// -------- pty:write（Renderer → Main） --------
+
+export const PtyWriteRequestSchema = z.object({
+  ptyId: z.string(),
+  data: z.string(),
+});
+
+export type PtyWriteRequest = z.infer<typeof PtyWriteRequestSchema>;
+
+// -------- pty:resize（Renderer → Main） --------
+
+export const PtyResizeRequestSchema = z.object({
+  ptyId: z.string(),
+  cols: z.number().int().positive(),
+  rows: z.number().int().positive(),
+});
+
+export type PtyResizeRequest = z.infer<typeof PtyResizeRequestSchema>;
+
+// -------- pty:kill（Renderer → Main） --------
+
+export const PtyKillRequestSchema = z.object({
+  ptyId: z.string(),
+  // POSIX 信号名（"SIGTERM" 默认）；Windows 上 node-pty 自己处理映射
+  signal: z.string().optional(),
+});
+
+export type PtyKillRequest = z.infer<typeof PtyKillRequestSchema>;
+
+// -------- pty:data（Main → Renderer push） --------
+
+export const PtyDataEventSchema = z.object({
+  ptyId: z.string(),
+  data: z.string(),
+});
+
+export type PtyDataEvent = z.infer<typeof PtyDataEventSchema>;
+
+// -------- pty:exit（Main → Renderer push） --------
+
+export const PtyExitEventSchema = z.object({
+  ptyId: z.string(),
+  exitCode: z.number().int(),
+  signal: z.number().int().optional(), // node-pty 给的 signal 是 number 或 0
+});
+
+export type PtyExitEvent = z.infer<typeof PtyExitEventSchema>;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -38,12 +38,24 @@ importers:
       '@opentrad/cc-adapter':
         specifier: workspace:^
         version: link:../../packages/cc-adapter
+      '@xterm/addon-fit':
+        specifier: ^0.11.0
+        version: 0.11.0
+      '@xterm/addon-web-links':
+        specifier: ^0.12.0
+        version: 0.12.0
+      '@xterm/xterm':
+        specifier: ^6.0.0
+        version: 6.0.0
       better-sqlite3:
         specifier: ^12.9.0
         version: 12.9.0
       electron:
         specifier: ^41.3.0
         version: 41.3.0
+      node-pty:
+        specifier: ^1.1.0
+        version: 1.1.0
       react:
         specifier: ^19.2.5
         version: 19.2.5
@@ -782,6 +794,15 @@ packages:
   '@vitest/utils@4.1.5':
     resolution: {integrity: sha512-76wdkrmfXfqGjueGgnb45ITPyUi1ycZ4IHgC2bhPDUfWHklY/q3MdLOAB+TF1e6xfl8NxNY0ZYaPCFNWSsw3Ug==}
 
+  '@xterm/addon-fit@0.11.0':
+    resolution: {integrity: sha512-jYcgT6xtVYhnhgxh3QgYDnnNMYTcf8ElbxxFzX0IZo+vabQqSPAjC3c1wJrKB5E19VwQei89QCiZZP86DCPF7g==}
+
+  '@xterm/addon-web-links@0.12.0':
+    resolution: {integrity: sha512-4Smom3RPyVp7ZMYOYDoC/9eGJJJqYhnPLGGqJ6wOBfB8VxPViJNSKdgRYb8NpaM6YSelEKbA2SStD7lGyqaobw==}
+
+  '@xterm/xterm@6.0.0':
+    resolution: {integrity: sha512-TQwDdQGtwwDt+2cgKDLn0IRaSxYu1tSUjgKarSDkUM0ZNiSRXFpjxEsvc/Zgc5kq5omJ+V0a8/kIM2WD3sMOYg==}
+
   assertion-error@2.0.1:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
     engines: {node: '>=12'}
@@ -1176,6 +1197,12 @@ packages:
   node-abi@3.89.0:
     resolution: {integrity: sha512-6u9UwL0HlAl21+agMN3YAMXcKByMqwGx+pq+P76vii5f7hTPtKDp08/H9py6DY+cfDw7kQNTGEj/rly3IgbNQA==}
     engines: {node: '>=10'}
+
+  node-addon-api@7.1.1:
+    resolution: {integrity: sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==}
+
+  node-pty@1.1.0:
+    resolution: {integrity: sha512-20JqtutY6JPXTUnL0ij1uad7Qe1baT46lyolh2sSENDd4sTzKZ4nmAFkeAARDKwmlLjPx6XKRlwRUxwjOy+lUg==}
 
   node-releases@2.0.38:
     resolution: {integrity: sha512-3qT/88Y3FbH/Kx4szpQQ4HzUbVrHPKTLVpVocKiLfoYvw9XSGOX2FmD2d6DrXbVYyAQTF2HeF6My8jmzx7/CRw==}
@@ -2005,6 +2032,12 @@ snapshots:
       convert-source-map: 2.0.0
       tinyrainbow: 3.1.0
 
+  '@xterm/addon-fit@0.11.0': {}
+
+  '@xterm/addon-web-links@0.12.0': {}
+
+  '@xterm/xterm@6.0.0': {}
+
   assertion-error@2.0.1: {}
 
   base64-js@1.5.1: {}
@@ -2409,6 +2442,12 @@ snapshots:
   node-abi@3.89.0:
     dependencies:
       semver: 7.7.4
+
+  node-addon-api@7.1.1: {}
+
+  node-pty@1.1.0:
+    dependencies:
+      node-addon-api: 7.1.1
 
   node-releases@2.0.38: {}
 

--- a/scripts/fix-node-pty-perms.cjs
+++ b/scripts/fix-node-pty-perms.cjs
@@ -1,0 +1,38 @@
+// node-pty 1.1.0 的 prebuild 包没给 spawn-helper 设可执行位（只 Windows 上的 conpty.dll
+// 在自己的 post-install 里处理）。Linux / macOS 上 pty.spawn 会因此 posix_spawnp failed。
+// 在 root postinstall 里跨平台 chmod +x，让所有 contributor / CI runner 装完即用。
+//
+// Windows 上 spawn-helper 不存在（不需要），脚本静默跳过。
+
+const { chmodSync, existsSync } = require("node:fs");
+const { join } = require("node:path");
+const { readdirSync } = require("node:fs");
+
+const NODE_PTY_PNPM_DIR = join(__dirname, "..", "node_modules", ".pnpm");
+
+if (!existsSync(NODE_PTY_PNPM_DIR)) {
+  process.exit(0);
+}
+
+let fixedCount = 0;
+
+for (const entry of readdirSync(NODE_PTY_PNPM_DIR)) {
+  if (!entry.startsWith("node-pty@")) continue;
+  const prebuildsDir = join(NODE_PTY_PNPM_DIR, entry, "node_modules", "node-pty", "prebuilds");
+  if (!existsSync(prebuildsDir)) continue;
+  for (const platform of readdirSync(prebuildsDir)) {
+    const helper = join(prebuildsDir, platform, "spawn-helper");
+    if (existsSync(helper)) {
+      try {
+        chmodSync(helper, 0o755);
+        fixedCount++;
+      } catch {
+        // 权限不够 / 文件被占用 → 静默
+      }
+    }
+  }
+}
+
+if (fixedCount > 0) {
+  console.log(`[fix-node-pty-perms] chmod +x on ${fixedCount} spawn-helper binaries`);
+}


### PR DESCRIPTION
按 [02-mvp-slicing.md F1.4](https://github.com/open-trad/docs/blob/main/design/02-mvp-slicing.md)(M1 提到 P0,D-pre-4)+ 03-architecture.md 落地 \`node-pty\` + \`xterm.js\`。后续 **M1 #4 / #21**(CC 安装向导)和 **M1 #5 / #22**(登录引导)都依赖这层——CC install 脚本和 \`claude auth login\` 都是交互式 terminal 流程。

## 改动

### 共享类型(`packages/shared/src/types/pty.ts`)

PTY IPC 协议 schema:`spawn` / `write` / `resize` / `kill` 4 个 invoke + `data` / `exit` 2 个 push。`ptyId` 是 main 端 `randomUUID` 生成。

### 主进程 PtyManager(`apps/desktop/src/main/services/pty-manager.ts`)

EventEmitter 风格,`emit("data")` / `emit("exit")` 给上层 IPC handler 转发。设计上**不**持有 webContents(避免 window 关闭后引用失效),路由由 IPC 层管理 `ptyId → webContents` Map。

跨平台默认 shell:
- **macOS**:`$SHELL ?? /bin/zsh`
- **Linux**:`$SHELL ?? /bin/bash`
- **Windows**:`pwsh.exe`(`OPENTRAD_PTY_SHELL` env 可覆盖)

`cleanup()` 应用退出时 kill 所有 PTY,避免子进程残留。

### IPC handlers(`apps/desktop/src/main/ipc/pty.ts`)

绑定 `ptyId → 请求者的 event.sender`。webContents 销毁时自动清 + kill 该 PTY。`data` / `exit` 事件按 ptyId 路由到正确的 webContents。

### Preload + Renderer

- preload:`window.api.pty.{spawn, write, resize, kill, onData, onExit}`
- renderer `TerminalPane.tsx`:xterm.js + `addon-fit` + `addon-web-links`;`ResizeObserver` 监听容器尺寸变化触发 fit + IPC resize;unmount 时 kill PTY + dispose term,避免后台 shell 残留
- `App.tsx`:加底部折叠 PtyDrawer,"打开 terminal" 按钮 toggle TerminalPane

### Native module 前置约束(D9-1 同模式)

- 根 `package.json` 的 `pnpm.onlyBuiltDependencies` 加 `node-pty`
- 新增 `scripts/fix-node-pty-perms.cjs`(postinstall):
  - node-pty 1.1.0 的 prebuild 包**没给 `spawn-helper` 设可执行位**(只 Windows 上的 `conpty.dll` 在自己的 post-install 处理)。Linux / macOS 上 `pty.spawn` 会因此 `posix_spawnp failed`。
  - 脚本跨平台 `chmod +x`,让所有 contributor / CI runner 装完即用
  - Windows 上无 spawn-helper 文件,脚本静默跳过

## 测试

- `pty-manager.test.ts`:spawn `/bin/echo` 收集 onData → 验证 stdout 含期望文本 + onExit emit 0;`activePtys` 状态 + cleanup 幂等
- Windows 路径暂跳过(`it.skipIf process.platform === "win32"`),**D-M1-1 允许 CI workflow 自主决策**;真机 Windows 验证延后到 M1 #13
- 全部 monorepo 测试 152 pass:shared 61 / stream-parser 30 / cc-adapter 23 / desktop **40**
- `pnpm typecheck` 8 packages all green
- `pnpm lint` clean

## 决策点 D-M1-1(自主决策已采取)

node-pty native module 编译流程:darwin-arm64 / win32-x64 / win32-arm64 都有 prebuild;Linux 走 prebuild-install 或 node-gyp build(prebuild 没的话)。spawn-helper 权限位由 postinstall 脚本兜底——这是必要前置约束,沿用 better-sqlite3 / electron / esbuild 加 `pnpm.onlyBuiltDependencies` 的同模式。

## 不在本 PR 范围

- 真机 Windows 验证延后到 M1 #13(本 issue body 验收已说明降级)
- TerminalPane 接入 onboarding install / login 流程:**M1 #4 / #21** + **M1 #5 / #22**
- 测试用 `cmd.exe` 替代 echo:M1 #21 触发时再加

## Closes

Closes #20