### PR TITLE
fix(preload): split channel constants to avoid zod evaluation chain (PR B)

### DIFF
--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -5,6 +5,13 @@
 // - 可用：contextBridge、ipcRenderer（Electron 白名单）
 // - 不可用：任意 require、fs、child_process 等 Node API
 // 这是 03-architecture.md §9 安全边界的一部分。
+//
+// **重要：本文件只允许从 "@opentrad/shared/channels" 拿运行时常量**。
+// 从 "@opentrad/shared" 根 export 拿任何 value 会触发 zod evaluation chain
+// （ipc.ts / db.ts 等模块顶部 import zod），vite 会在 preload bundle 里留
+// require("zod")，sandbox 模式 require 拒绝 → 白屏 bug。
+// type imports 编译时擦除，不影响运行时，从根 export 拿 type 没问题。
+// 详见 packages/shared/src/channels.ts module-level 注释。
 
 import type {
   CCCancelTaskRequest,
@@ -20,7 +27,7 @@ import type {
   PtySpawnResponse,
   PtyWriteRequest,
 } from "@opentrad/shared";
-import { IpcChannels } from "@opentrad/shared";
+import { IpcChannels } from "@opentrad/shared/channels";
 import { contextBridge, ipcRenderer } from "electron";
 
 // 对 renderer 暴露的 API。每个 domain 对应一个子对象。

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -5,6 +5,10 @@
   "type": "module",
   "main": "./src/index.ts",
   "types": "./src/index.ts",
+  "exports": {
+    ".": "./src/index.ts",
+    "./channels": "./src/channels.ts"
+  },
   "scripts": {
     "typecheck": "tsc --noEmit",
     "test": "vitest run"

--- a/packages/shared/src/channels.ts
+++ b/packages/shared/src/channels.ts
@@ -1,0 +1,46 @@
+// IPC channel 名常量。**纯 const，本文件不 import zod**。
+//
+// 设计动机（PR B / W1 抽查 bug 2 修复）：
+// preload 脚本在 Electron sandbox 模式下不能 runtime require external module。
+// 历史上 preload 从 @opentrad/shared 根 export 拿 IpcChannels，会触发 ipc.ts
+// 顶部的 `import { z } from "zod"` evaluation chain → vite 在 preload bundle 里
+// 留 require("zod") → sandbox 加载 preload 时 module not found 白屏。
+//
+// 修复（对齐 03-architecture.md §三 "contextBridge + typed IPC，不用 remote"
+// 的 thin-preload 精神 + TD-002 #30 收益预提）：
+// - 所有纯 const channel 名拆到本文件
+// - shared/package.json 通过 exports 字段暴露 `@opentrad/shared/channels` 子路径
+// - preload 走子路径 import，**完全不进入 zod 依赖链**
+// - shared/index.ts 仍 re-export 这里的 const，main 进程 / 其他 packages 继续从根
+//   拿到，零迁移成本
+//
+// 长期边界原则：**preload 永远只 import 本文件**（或 type-only import，编译时擦除）。
+// preload 不做 zod 校验；所有 zod 校验在 main 进程的 IPC handlers 里做。
+
+// -------- Renderer ↔ Main 主 IPC 通道 --------
+
+export const IpcChannels = {
+  CCStartTask: "cc:start-task",
+  CCCancelTask: "cc:cancel-task",
+  CCEvent: "cc:event",
+  CCStatus: "cc:status",
+  SkillList: "skill:list",
+  SkillInstall: "skill:install",
+  SessionList: "session:list",
+  SessionGet: "session:get",
+  SessionDelete: "session:delete",
+  SessionResume: "session:resume",
+  InstalledSkillList: "installed-skill:list",
+  RiskGateConfirm: "risk-gate:confirm",
+  RiskGateResponse: "risk-gate:response",
+  SettingsGet: "settings:get",
+  SettingsSet: "settings:set",
+  PtySpawn: "pty:spawn",
+  PtyWrite: "pty:write",
+  PtyResize: "pty:resize",
+  PtyKill: "pty:kill",
+  PtyData: "pty:data",
+  PtyExit: "pty:exit",
+} as const;
+
+export type IpcChannel = (typeof IpcChannels)[keyof typeof IpcChannels];

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -5,6 +5,7 @@
 // - domain 类型（本文件根级 export）：OpenTrad 内部统一消费形态，字段 camelCase
 // - wire 类型（./types/wire/* export，带 Wire 前缀）：CC 原始事件保真，仅 stream-parser 内部使用
 
+export * from "./channels";
 export * from "./types/cc-event";
 export * from "./types/cc-task";
 export * from "./types/db";

--- a/packages/shared/src/types/ipc.ts
+++ b/packages/shared/src/types/ipc.ts
@@ -1,35 +1,14 @@
 // Electron Main ↔ Renderer IPC 协议。对应 03-architecture.md §3。
 // 原则：Renderer 永不直接 spawn CC，只通过 IPC 请求；Main 负责全部子进程管理。
+//
+// IpcChannels / IpcChannel 已拆到 ../channels.ts（纯 const，不 import zod）。
+// preload 必须从 "@opentrad/shared/channels" 子路径 import，避免触发 zod
+// evaluation chain（详见 channels.ts 的 module-level 注释）。
+// 本文件保留 zod schemas 用于 main 进程的 IPC handler 校验。
 
 import { z } from "zod";
 
-// -------- Channel 名常量（避免字符串硬编码） --------
-
-export const IpcChannels = {
-  CCStartTask: "cc:start-task",
-  CCCancelTask: "cc:cancel-task",
-  CCEvent: "cc:event",
-  CCStatus: "cc:status",
-  SkillList: "skill:list",
-  SkillInstall: "skill:install",
-  SessionList: "session:list",
-  SessionGet: "session:get",
-  SessionDelete: "session:delete",
-  SessionResume: "session:resume",
-  InstalledSkillList: "installed-skill:list",
-  RiskGateConfirm: "risk-gate:confirm",
-  RiskGateResponse: "risk-gate:response",
-  SettingsGet: "settings:get",
-  SettingsSet: "settings:set",
-  PtySpawn: "pty:spawn",
-  PtyWrite: "pty:write",
-  PtyResize: "pty:resize",
-  PtyKill: "pty:kill",
-  PtyData: "pty:data",
-  PtyExit: "pty:exit",
-} as const;
-
-export type IpcChannel = (typeof IpcChannels)[keyof typeof IpcChannels];
+export { type IpcChannel, IpcChannels } from "../channels";
 
 // -------- cc:start-task（Renderer → Main） --------
 // Renderer 提供 skillId 和表单填值，Main 内部 compose prompt / 生成 mcp-config / 派 sessionId。


### PR DESCRIPTION
W1 抽查发现的 bug 2 修复。配套 [PR A #34](https://github.com/open-trad/opentrad/pull/34)(已合,bug 1 electron ABI)。

对齐 [03-architecture.md §三](https://github.com/open-trad/docs/blob/main/design/03-architecture.md) "contextBridge + typed IPC,不用 remote" 的 thin-preload 精神,并提前给 [TD-002](https://github.com/open-trad/docs/blob/main/design/retrospective-m0.md) (#30) 一份 preload bundle 减重收益。

## 根因

preload 在 \`sandbox:true\` 下不能 runtime require external module。M0 留下的 preload 从 \`@opentrad/shared\` 根 export 拿 \`IpcChannels\`(value import),会触发 \`ipc.ts\` 顶部的 \`import { z } from "zod"\` evaluation chain → vite 在 preload bundle 里留 \`require("zod")\` → sandbox 加载 preload 时 module not found → 窗口白屏 + \`window.api\` 未定义。

W1 之前没暴露是因为 M0 渲染端只用了 \`cc.status()\`,preload 跑通的 happy path 浅。M1 #19 / #20 开始 zod schemas 越来越多,evaluation chain 越来越重,第一次有人本地真把 dev 跑起来时(发起人抽查)就炸。

## 改动

### \`packages/shared/src/channels.ts\`(新增)

把所有纯 const channel 名独立出来,**本文件不 import zod**。

### \`packages/shared/src/types/ipc.ts\`

删除 \`IpcChannels\` 定义,改成 \`export { IpcChannels } from "../channels"\`,保持向后兼容(main 进程 / packages 仍可从根 export 拿,零迁移)。

### \`packages/shared/src/index.ts\`

加 \`export * from "./channels"\`,shared root 仍暴露 \`IpcChannels\`。

### \`packages/shared/package.json\`

加 \`exports\` 字段暴露 \`@opentrad/shared/channels\` 子路径,让 preload 直接 import 子路径。

### \`apps/desktop/src/preload/index.ts\`

\`import { IpcChannels } from "@opentrad/shared"\` → \`import { IpcChannels } from "@opentrad/shared/channels"\`。顶部加注释,明确 preload 永远只能从 channels 子路径拿运行时常量(type-only import 编译时擦除,从根 export 拿没问题)。

## 验证

- \`pnpm typecheck\`:8 packages 全过
- \`pnpm test\`:154 tests 全过
- \`pnpm lint\`:clean
- **\`pnpm exec electron-vite build\`**:
  * preload bundle **18.73 KB → 2.32 KB(-87%)**
  * \`grep -c "require(\\"zod\\")\\|from\\"zod\\"" out/preload/index.js\` → **0 匹配**
  * 82 行 bundle,纯 IPC channel 转发

## 边界原则(本 PR 落地的长期约束)

> **preload 永远只 import \`@opentrad/shared/channels\`(或 type-only import)。preload 不做 zod 校验;所有 zod 校验在 main 进程的 IPC handlers 里做。**

未来贡献者新加 IPC 时,channels.ts 加常量、ipc.ts 加 schema、preload 加转发,**三步分离不互相污染**。

## TD-002 (#30) 顺手收益

retrospective-m0.md §五 TD-002 原计划 M1 中期把 preload bundle 138 KB 拆分。本 PR 把 preload 减到 2.32 KB(远优于 ≤ 80 KB 目标),#30 这部分基本提前完成;#30 剩下 IPC channels 按 domain 拆分(cc / pty / session 等多个文件)的工作量大幅降低。

## Refs

- 修发起人在 W1 抽查发现的 bug 2(preload sandbox 加载报 zod module not found)
- 配套 PR A:#34(已合,bug 1 electron ABI)
- 解锁 #25 重启(rebase main 后 IPC channels 层不再受 zod 链污染)