### PR TITLE
fix(desktop): sentinel-based Electron ABI guard + CI smoke job (PR A v2)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,10 +41,10 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
-      # apps/desktop 的 postinstall 把 better-sqlite3 / node-pty rebuild 成 Electron ABI
-      # （让 `pnpm dev` 开箱即用，详见 CONTRIBUTING.md）。CI 跑 vitest 时需要的是
-      # 系统 Node ABI，所以在 lint/test 前切回 Node ABI。build:dist（M1 #13）真打包时
-      # 再切回 Electron ABI 即可。
+      # 本 job 跑 vitest，需要 better-sqlite3 / node-pty 是系统 Node ABI。
+      # 实测 pnpm install 在 monorepo workspace already-up-to-date 时跳过所有 hook
+      # （PR A v2 / open-trad/opentrad#36 根因），所以显式 rebuild:node 强制切回。
+      # build:dist（M1 #13）真打包时改用 rebuild:electron 切到 Electron ABI。
       - name: Rebuild native modules for Node ABI (vitest)
         run: pnpm --filter @opentrad/desktop rebuild:node
 
@@ -56,3 +56,43 @@ jobs:
 
       - name: Test
         run: pnpm -r --if-present test
+
+  # PR A v2 / #36：Electron dlopen smoke test（治本于 hands-off 路径回归）。
+  # 主 check job 永远跑系统 Node ABI 的 vitest，不会暴露 Electron ABI 问题。
+  # 这个 job 模拟用户真起 Electron 的代码路径：fresh checkout → pnpm install →
+  # apps/desktop scripts/ensure-electron-abi.cjs（postinstall + 显式调）→ 用
+  # ELECTRON_RUN_AS_NODE=1 让 electron 二进制以 Node 模式 require + new Database。
+  # 不依赖 GUI display / xvfb，三平台一致跑。
+  electron-abi-smoke:
+    name: electron-abi-smoke (${{ matrix.os }})
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10.0.0
+          run_install: false
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: '.nvmrc'
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      # 显式调 ensure-electron-abi（fresh install 时 hook 已经跑过了，这里幂等;
+      # 已 up-to-date 时是真把 binary 切到 Electron ABI 的关键步骤）。
+      - name: Ensure Electron ABI
+        run: node apps/desktop/scripts/ensure-electron-abi.cjs
+
+      - name: Smoke test (Electron dlopen + new Database)
+        run: pnpm --filter @opentrad/desktop smoke

--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,7 @@ ehthumbs.db
 
 # OpenTrad runtime data（如果开发时生成到项目目录）
 .opentrad/
+
+# Electron ABI sentinel —— 由 apps/desktop/scripts/ensure-electron-abi.cjs
+# 维护，记录上次 rebuild 后的 binary 指纹，本机状态不进版本控制
+apps/desktop/.electron-abi-sentinel.json

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -54,31 +54,48 @@ Skill 是独立的 markdown + yaml 包，贡献到 [open-trad/skills](https://gi
 pnpm install
 ```
 
-`pnpm install` 自动跑两个 postinstall:
-- `scripts/fix-node-pty-perms.cjs` 给 node-pty 的 spawn-helper 加 +x(prebuild 没设)
-- `apps/desktop` 下 `electron-rebuild` 把 better-sqlite3 / node-pty 重新编译为 Electron 的 ABI
-
-完成后即可 `pnpm dev`,**新机器 / 新贡献者第一次开就能跑**,无需手动 rebuild。
-
 ### 常用命令
 
 ```bash
-pnpm dev          # 启动 desktop 应用(Electron)
+pnpm dev          # 启动 desktop 应用(Electron) — predev hook 自动确保 ABI
 pnpm test         # 跑全 monorepo 单测
 pnpm typecheck    # 全 monorepo TypeScript 校验
 pnpm lint         # biome check
 pnpm format       # biome format --write
 ```
 
-### Electron / Node ABI 切换
+### Electron / Node ABI 自动切换(PR A v2 / #36)
 
-`better-sqlite3` 和 `node-pty` 是 native module,Electron 和系统 Node 的 ABI(NODE_MODULE_VERSION)不同,共存需要切换:
+`better-sqlite3` 是经典 ABI-bound native module(`node-pty` 是 N-API,ABI-agnostic)。Electron 41.x 内嵌 `NODE_MODULE_VERSION 145`,系统 Node 是 137,binary 必须跟当前运行环境 ABI 一致才能 dlopen。
 
-| 场景 | 当前 ABI | 切换命令 |
-|---|---|---|
-| `pnpm install` 后默认 | Electron ABI | (无需操作,可直接 `pnpm dev`) |
-| 跑 `pnpm dev` / `pnpm build` | 需要 Electron ABI | `pnpm --filter @opentrad/desktop rebuild:electron` |
-| 跑 `pnpm test` / vitest | 需要 Node ABI | `pnpm --filter @opentrad/desktop rebuild:node` |
+**对开发者的体验**:`pnpm dev` 永远 just works,**不用手动 rebuild**。机制如下:
+
+- `apps/desktop/scripts/ensure-electron-abi.cjs` 是智能 ABI guard:
+  - 读 `apps/desktop/.electron-abi-sentinel.json`(本机状态,gitignored)记录的上次 rebuild 指纹
+  - 对比当前 Electron 版本 / abi / better-sqlite3 binary size
+  - 匹配 → **0 秒退出**(99% 启动)
+  - 不匹配 → spawn `electron-rebuild -f` 真改 binary,写新 sentinel(1-2 秒,1% 启动)
+- 这个脚本被 `predev` / `prebuild` / `postinstall` 三处调用,任何流向 dev/build 的路径都被守住
+
+**vitest 路径(切回 Node ABI)**:跑 `pnpm test` 前如果之前跑过 `pnpm dev`,binary 是 Electron ABI,vitest 加载会报 `NODE_MODULE_VERSION` 错。**手动切回**:
+
+```bash
+pnpm --filter @opentrad/desktop rebuild:node
+```
+
+之后再跑 `pnpm dev`,predev 会再切回 Electron ABI(自动)。
+
+### Smoke test
+
+```bash
+pnpm --filter @opentrad/desktop smoke
+```
+
+模拟 Electron 真 `require("better-sqlite3") + new Database(":memory:")`,catch ABI 错位 / native module 未编译等问题。CI 三平台跑同款 smoke。
+
+### 历史背景
+
+PR A v1(#34) 直接用 `postinstall: electron-rebuild`,但实测 pnpm install 在 monorepo workspace **already-up-to-date 时跳过所有 hook**(`pnpm@10` 行为),且 `electron-rebuild` 不带 `-f` **假成功不动 binary**。两个 bug 叠加导致 hands-off 路径炸。PR A v2(#36)用 sentinel + 多 hook 守 + CI smoke job 治本。详见 [retrospective-m1](https://github.com/open-trad/docs/blob/main/design/retrospective-m1.md)(M1 收官时撰写)。
 
 **典型报错信号**:加载 `better-sqlite3` 或 `node-pty` 时报 `NODE_MODULE_VERSION X vs Y`,跑对应的 rebuild 命令切换即可。CI fresh checkout 永远是干净状态,不会撞这个坑。
 

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -4,14 +4,17 @@
   "private": true,
   "main": "./out/main/index.js",
   "scripts": {
+    "predev": "node scripts/ensure-electron-abi.cjs",
     "dev": "electron-vite dev",
+    "prebuild": "node scripts/ensure-electron-abi.cjs",
     "build": "electron-vite build",
     "typecheck": "tsc --noEmit",
     "start": "electron-vite preview",
     "test": "vitest run",
-    "postinstall": "electron-rebuild -f -w better-sqlite3 -w node-pty",
+    "postinstall": "node scripts/ensure-electron-abi.cjs",
     "rebuild:electron": "electron-rebuild -f -w better-sqlite3 -w node-pty",
-    "rebuild:node": "pnpm rebuild better-sqlite3 node-pty"
+    "rebuild:node": "pnpm rebuild better-sqlite3 node-pty",
+    "smoke": "node scripts/smoke-electron-dlopen.cjs"
   },
   "dependencies": {
     "@opentrad/cc-adapter": "workspace:^",

--- a/apps/desktop/scripts/ensure-electron-abi.cjs
+++ b/apps/desktop/scripts/ensure-electron-abi.cjs
@@ -1,0 +1,135 @@
+#!/usr/bin/env node
+// 智能确保 better-sqlite3 binary 是当前 Electron 的 ABI（M1 PR A v2）。
+//
+// 背景：
+// - better-sqlite3 是经典 ABI-bound 模块（不是 N-API），编译时绑死 NODE_MODULE_VERSION
+// - pnpm install 默认走 prebuild-install / node-gyp，编出来是系统 Node ABI（137）
+// - Electron 41.x 需要 ABI 145，binary 不匹配时 dlopen 报错
+// - pnpm install 在 monorepo workspace already-up-to-date 时**跳过所有 install hook**
+//   （实测：pnpm@10 行为），所以单纯依赖 postinstall 不可靠
+// - electron-rebuild 不带 -f 会假成功（实测：报 Rebuild Complete 但 binary 不动）
+//
+// 修法：
+// - 本脚本在 predev / postinstall 都跑
+// - 用 sentinel 文件（apps/desktop/.electron-abi-sentinel.json）记录上次 rebuild 后的
+//   binary 指纹（size + Electron version + abi）
+// - 启动前 0 秒检查 sentinel 是否匹配；匹配跳过；不匹配才 spawn electron-rebuild -f
+// - 99% 启动场景 0 秒开销，1% ABI 切换场景 1-2 秒 rebuild
+//
+// node-pty 是 N-API，ABI-agnostic，不参与本检查。
+
+const { spawnSync } = require("node:child_process");
+const fs = require("node:fs");
+const path = require("node:path");
+
+const DESKTOP_DIR = path.resolve(__dirname, "..");
+const REPO_ROOT = path.resolve(DESKTOP_DIR, "..", "..");
+const SENTINEL_PATH = path.join(DESKTOP_DIR, ".electron-abi-sentinel.json");
+
+function findBetterSqliteBinary() {
+  // pnpm content-addressable layout：node_modules/.pnpm/better-sqlite3@<ver>/...
+  const pnpmDir = path.join(REPO_ROOT, "node_modules", ".pnpm");
+  if (!fs.existsSync(pnpmDir)) return null;
+  const entry = fs.readdirSync(pnpmDir).find((d) => d.startsWith("better-sqlite3@"));
+  if (!entry) return null;
+  const binary = path.join(
+    pnpmDir,
+    entry,
+    "node_modules",
+    "better-sqlite3",
+    "build",
+    "Release",
+    "better_sqlite3.node",
+  );
+  return fs.existsSync(binary) ? binary : null;
+}
+
+function getElectronInfo() {
+  // 直接从 electron 包 dist 读 abi_version + package.json version
+  const pnpmDir = path.join(REPO_ROOT, "node_modules", ".pnpm");
+  if (!fs.existsSync(pnpmDir)) return null;
+  const entry = fs.readdirSync(pnpmDir).find((d) => d.startsWith("electron@"));
+  if (!entry) return null;
+  const electronDir = path.join(pnpmDir, entry, "node_modules", "electron");
+  let version, abi;
+  try {
+    version = JSON.parse(fs.readFileSync(path.join(electronDir, "package.json"), "utf-8")).version;
+  } catch {
+    return null;
+  }
+  try {
+    abi = fs.readFileSync(path.join(electronDir, "abi_version"), "utf-8").trim();
+  } catch {
+    return null;
+  }
+  return { version, abi };
+}
+
+function readSentinel() {
+  if (!fs.existsSync(SENTINEL_PATH)) return null;
+  try {
+    return JSON.parse(fs.readFileSync(SENTINEL_PATH, "utf-8"));
+  } catch {
+    return null; // 损坏视为缺失
+  }
+}
+
+function writeSentinel(record) {
+  fs.writeFileSync(SENTINEL_PATH, `${JSON.stringify(record, null, 2)}\n`, "utf-8");
+}
+
+function fingerprint() {
+  const electron = getElectronInfo();
+  const binary = findBetterSqliteBinary();
+  if (!electron || !binary) return null;
+  const stat = fs.statSync(binary);
+  return {
+    electron: electron.version,
+    abi: electron.abi,
+    betterSqliteSize: stat.size,
+  };
+}
+
+function fingerprintsMatch(a, b) {
+  if (!a || !b) return false;
+  return a.electron === b.electron && a.abi === b.abi && a.betterSqliteSize === b.betterSqliteSize;
+}
+
+function rebuild() {
+  console.log("[ensure-electron-abi] ABI fingerprint mismatch → running electron-rebuild -f");
+  const result = spawnSync(
+    "pnpm",
+    ["exec", "electron-rebuild", "-f", "-w", "better-sqlite3", "-w", "node-pty"],
+    {
+      cwd: DESKTOP_DIR,
+      stdio: "inherit",
+    },
+  );
+  if (result.status !== 0) {
+    console.error("[ensure-electron-abi] electron-rebuild failed");
+    process.exit(result.status ?? 1);
+  }
+}
+
+function main() {
+  const current = fingerprint();
+  if (!current) {
+    // node_modules 还没装齐（pnpm install 进行中等罕见时序）→ 不阻塞,让 pnpm install 完成
+    console.log("[ensure-electron-abi] dependencies not ready, skipping");
+    return;
+  }
+
+  const sentinel = readSentinel();
+  if (fingerprintsMatch(sentinel, current)) {
+    // 99% 路径：sentinel 已对齐，0 秒退出
+    return;
+  }
+
+  rebuild();
+
+  // rebuild 后重新拿指纹，写 sentinel
+  const after = fingerprint();
+  if (after) writeSentinel(after);
+}
+
+main();

--- a/apps/desktop/scripts/ensure-electron-abi.cjs
+++ b/apps/desktop/scripts/ensure-electron-abi.cjs
@@ -97,16 +97,21 @@ function fingerprintsMatch(a, b) {
 
 function rebuild() {
   console.log("[ensure-electron-abi] ABI fingerprint mismatch → running electron-rebuild -f");
+  // Windows 上 spawn("pnpm") 需要 .cmd 后缀；用 shell:true 让 OS 自己解析。
+  // 参数都是固定字符串无 escape 风险。
   const result = spawnSync(
     "pnpm",
     ["exec", "electron-rebuild", "-f", "-w", "better-sqlite3", "-w", "node-pty"],
     {
       cwd: DESKTOP_DIR,
       stdio: "inherit",
+      shell: process.platform === "win32",
     },
   );
   if (result.status !== 0) {
-    console.error("[ensure-electron-abi] electron-rebuild failed");
+    console.error(
+      `[ensure-electron-abi] electron-rebuild failed (status=${result.status}, signal=${result.signal}, error=${result.error?.message ?? "none"})`,
+    );
     process.exit(result.status ?? 1);
   }
 }

--- a/apps/desktop/scripts/smoke-electron-dlopen.cjs
+++ b/apps/desktop/scripts/smoke-electron-dlopen.cjs
@@ -1,0 +1,61 @@
+#!/usr/bin/env node
+// Electron 真 dlopen smoke test（M1 PR A v2 / open-trad/opentrad#36）。
+//
+// 目的：catch hands-off 路径回归（pnpm install → pnpm dev 起 Electron）。
+// 主 ci.yml 的 lint/typecheck/test 永远跑系统 Node ABI 的 vitest，永远绿；
+// 这个 job 模拟用户真起 Electron 的代码路径，确保 better-sqlite3 在 Electron
+// ABI 下能真 dlopen + 跑 query。
+//
+// 用 ELECTRON_RUN_AS_NODE=1 让 electron 二进制以 Node 模式运行（不需要 GUI
+// display，三平台 CI runner 都能跑，不依赖 xvfb）。
+//
+// 失败信号：
+// - 退出码 ≠ 0
+// - Electron require("better-sqlite3") 报 NODE_MODULE_VERSION 错
+// - new Database(":memory:") 抛异常
+//
+// 这个 smoke 脚本 != 单元测试（vitest），是 CI / 本地的快速健康检查。
+
+const { spawnSync } = require("node:child_process");
+const path = require("node:path");
+
+const DESKTOP_DIR = path.resolve(__dirname, "..");
+const ELECTRON_BIN =
+  process.platform === "win32"
+    ? path.join(DESKTOP_DIR, "node_modules", ".bin", "electron.cmd")
+    : path.join(DESKTOP_DIR, "node_modules", ".bin", "electron");
+
+const TEST_CODE = `
+  const sqlite = require("better-sqlite3");
+  const db = new sqlite(":memory:");
+  db.exec("CREATE TABLE t(x INTEGER)");
+  db.exec("INSERT INTO t VALUES (42)");
+  const row = db.prepare("SELECT x FROM t").get();
+  if (row.x !== 42) {
+    console.error("smoke fail: unexpected row", row);
+    process.exit(2);
+  }
+  console.log("smoke OK: better-sqlite3 dlopen + query succeeded in Electron ABI=" + process.versions.modules + " electron=" + process.versions.electron);
+
+  const pty = require("node-pty");
+  if (typeof pty.spawn !== "function") {
+    console.error("smoke fail: node-pty missing spawn");
+    process.exit(3);
+  }
+  console.log("smoke OK: node-pty loaded (N-API, ABI-agnostic)");
+`;
+
+console.log(`[smoke] electron binary: ${ELECTRON_BIN}`);
+console.log("[smoke] running Electron with ELECTRON_RUN_AS_NODE=1 ...");
+
+const result = spawnSync(ELECTRON_BIN, ["-e", TEST_CODE], {
+  cwd: DESKTOP_DIR,
+  env: { ...process.env, ELECTRON_RUN_AS_NODE: "1" },
+  stdio: "inherit",
+});
+
+if (result.status !== 0) {
+  console.error(`[smoke] FAIL: exit code ${result.status}`);
+  process.exit(result.status ?? 1);
+}
+console.log("[smoke] PASS");

--- a/apps/desktop/scripts/smoke-electron-dlopen.cjs
+++ b/apps/desktop/scripts/smoke-electron-dlopen.cjs
@@ -9,14 +9,14 @@
 // 用 ELECTRON_RUN_AS_NODE=1 让 electron 二进制以 Node 模式运行（不需要 GUI
 // display，三平台 CI runner 都能跑，不依赖 xvfb）。
 //
-// 失败信号：
-// - 退出码 ≠ 0
-// - Electron require("better-sqlite3") 报 NODE_MODULE_VERSION 错
-// - new Database(":memory:") 抛异常
-//
-// 这个 smoke 脚本 != 单元测试（vitest），是 CI / 本地的快速健康检查。
+// 实现细节：
+// - Windows 上 spawn .cmd 需要 shell:true，但 shell:true + -e 多行字符串会被
+//   shell 切碎（实测：electron 报 "-e requires an argument"）。改写到临时
+//   .cjs 文件再 electron <file> 跑，绕过 shell 拼接问题。
 
 const { spawnSync } = require("node:child_process");
+const fs = require("node:fs");
+const os = require("node:os");
 const path = require("node:path");
 
 const DESKTOP_DIR = path.resolve(__dirname, "..");
@@ -26,40 +26,52 @@ const ELECTRON_BIN =
     : path.join(DESKTOP_DIR, "node_modules", ".bin", "electron");
 
 const TEST_CODE = `
-  const sqlite = require("better-sqlite3");
-  const db = new sqlite(":memory:");
-  db.exec("CREATE TABLE t(x INTEGER)");
-  db.exec("INSERT INTO t VALUES (42)");
-  const row = db.prepare("SELECT x FROM t").get();
-  if (row.x !== 42) {
-    console.error("smoke fail: unexpected row", row);
-    process.exit(2);
-  }
-  console.log("smoke OK: better-sqlite3 dlopen + query succeeded in Electron ABI=" + process.versions.modules + " electron=" + process.versions.electron);
+const sqlite = require("better-sqlite3");
+const db = new sqlite(":memory:");
+db.exec("CREATE TABLE t(x INTEGER)");
+db.exec("INSERT INTO t VALUES (42)");
+const row = db.prepare("SELECT x FROM t").get();
+if (row.x !== 42) {
+  console.error("smoke fail: unexpected row", row);
+  process.exit(2);
+}
+console.log("smoke OK: better-sqlite3 dlopen + query succeeded in Electron ABI=" + process.versions.modules + " electron=" + process.versions.electron);
 
-  const pty = require("node-pty");
-  if (typeof pty.spawn !== "function") {
-    console.error("smoke fail: node-pty missing spawn");
-    process.exit(3);
-  }
-  console.log("smoke OK: node-pty loaded (N-API, ABI-agnostic)");
+const pty = require("node-pty");
+if (typeof pty.spawn !== "function") {
+  console.error("smoke fail: node-pty missing spawn");
+  process.exit(3);
+}
+console.log("smoke OK: node-pty loaded (N-API, ABI-agnostic)");
 `;
 
+const tempScript = path.join(os.tmpdir(), `opentrad-smoke-${process.pid}.cjs`);
+fs.writeFileSync(tempScript, TEST_CODE, "utf-8");
+
 console.log(`[smoke] electron binary: ${ELECTRON_BIN}`);
+console.log(`[smoke] temp script: ${tempScript}`);
 console.log("[smoke] running Electron with ELECTRON_RUN_AS_NODE=1 ...");
 
-const result = spawnSync(ELECTRON_BIN, ["-e", TEST_CODE], {
-  cwd: DESKTOP_DIR,
-  env: { ...process.env, ELECTRON_RUN_AS_NODE: "1" },
-  stdio: "inherit",
-  // Windows 上 spawn .cmd 需要 shell:true（pnpm exec / node spawn 同款问题）
-  shell: process.platform === "win32",
-});
-
-if (result.status !== 0) {
-  console.error(
-    `[smoke] FAIL: exit code ${result.status}, signal=${result.signal}, error=${result.error?.message ?? "none"}`,
-  );
-  process.exit(result.status ?? 1);
+try {
+  const result = spawnSync(ELECTRON_BIN, [tempScript], {
+    cwd: DESKTOP_DIR,
+    env: { ...process.env, ELECTRON_RUN_AS_NODE: "1" },
+    stdio: "inherit",
+    // Windows 上 spawn .cmd 需要 shell:true。tempScript 路径只含合法字符（pid 数字），
+    // 无 escape 风险。
+    shell: process.platform === "win32",
+  });
+  if (result.status !== 0) {
+    console.error(
+      `[smoke] FAIL: exit code ${result.status}, signal=${result.signal}, error=${result.error?.message ?? "none"}`,
+    );
+    process.exit(result.status ?? 1);
+  }
+  console.log("[smoke] PASS");
+} finally {
+  try {
+    fs.unlinkSync(tempScript);
+  } catch {
+    // 静默
+  }
 }
-console.log("[smoke] PASS");

--- a/apps/desktop/scripts/smoke-electron-dlopen.cjs
+++ b/apps/desktop/scripts/smoke-electron-dlopen.cjs
@@ -52,10 +52,14 @@ const result = spawnSync(ELECTRON_BIN, ["-e", TEST_CODE], {
   cwd: DESKTOP_DIR,
   env: { ...process.env, ELECTRON_RUN_AS_NODE: "1" },
   stdio: "inherit",
+  // Windows 上 spawn .cmd 需要 shell:true（pnpm exec / node spawn 同款问题）
+  shell: process.platform === "win32",
 });
 
 if (result.status !== 0) {
-  console.error(`[smoke] FAIL: exit code ${result.status}`);
+  console.error(
+    `[smoke] FAIL: exit code ${result.status}, signal=${result.signal}, error=${result.error?.message ?? "none"}`,
+  );
   process.exit(result.status ?? 1);
 }
 console.log("[smoke] PASS");

--- a/apps/desktop/scripts/smoke-electron-dlopen.cjs
+++ b/apps/desktop/scripts/smoke-electron-dlopen.cjs
@@ -16,7 +16,6 @@
 
 const { spawnSync } = require("node:child_process");
 const fs = require("node:fs");
-const os = require("node:os");
 const path = require("node:path");
 
 const DESKTOP_DIR = path.resolve(__dirname, "..");
@@ -45,7 +44,9 @@ if (typeof pty.spawn !== "function") {
 console.log("smoke OK: node-pty loaded (N-API, ABI-agnostic)");
 `;
 
-const tempScript = path.join(os.tmpdir(), `opentrad-smoke-${process.pid}.cjs`);
+// 临时脚本必须放在 DESKTOP_DIR 内 —— Electron require 解析从脚本所在目录开始，
+// 必须要能找到 apps/desktop 的 node_modules（含 better-sqlite3 / node-pty 软链）。
+const tempScript = path.join(DESKTOP_DIR, `.smoke-tmp-${process.pid}.cjs`);
 fs.writeFileSync(tempScript, TEST_CODE, "utf-8");
 
 console.log(`[smoke] electron binary: ${ELECTRON_BIN}`);


### PR DESCRIPTION
修 [PR A #34](https://github.com/open-trad/opentrad/pull/34) 留下的两个真 bug,治本于 hands-off 路径回归。

## PR A v1 出了什么(铁证两层叠加)

### Bug X:pnpm install 在 monorepo workspace already-up-to-date 时跳过所有 hook

实测 \`pnpm@10\` 行为:跑过一次 install 后再跑 \`pnpm install\`,输出只有 \`Already up to date / Done in 104ms\`,**postinstall / preinstall / prepare 全不跑**。发起人 pull main 后 \`pnpm install\` 落入这个路径,PR A 写的 \`postinstall: electron-rebuild\` 永远不被触发,binary 仍是 prebuild-install 拿到的系统 Node ABI(137)。

### Bug Y:electron-rebuild 不带 -f 假成功不动 binary

实测:跑 \`electron-rebuild -w better-sqlite3 -w node-pty\`(无 \`-f\`),报 \`✔ Rebuild Complete\`,但 binary mtime / size 完全不变。发起人手动跑 \`npx electron-rebuild\` 中招(npx 解析的可能是老版本,且没传 \`-f\`)。

PR A v1 写的 \`-f\` 在 postinstall 里其实是对的,但 #X 让 hook 永远不跑。

## v2 修法:sentinel-based ensure 脚本 + 多 hook 守 + CI smoke job

### \`apps/desktop/scripts/ensure-electron-abi.cjs\`

智能 ABI guard:
- 读 \`apps/desktop/.electron-abi-sentinel.json\` 上次 rebuild 的指纹(Electron version + abi + better-sqlite3 binary size)
- 对比当前实测 → 匹配 **0 秒退出**(99% 启动路径)
- 不匹配 spawn \`electron-rebuild -f\` 真改 binary,写新 sentinel(**1-2 秒**,1% ABI 切换路径)

### \`apps/desktop/package.json\`:predev / prebuild / postinstall 三处都调

predev / prebuild 是关键——\`pnpm dev\` / \`pnpm build\` 永远会触发,**绕过 #X**。postinstall 在 fresh install(lockfile 真变)时也跑,补充保险。

### \`apps/desktop/scripts/smoke-electron-dlopen.cjs\`

模拟用户真起 Electron 的代码路径:用 \`ELECTRON_RUN_AS_NODE=1\` 让 electron 二进制以 Node 模式运行(**不需要 GUI display / xvfb,三平台一致**),跑 \`require("better-sqlite3") + new Database(":memory:") + INSERT + SELECT\` 真验证 dlopen 工作。

### \`.github/workflows/ci.yml\`:\`electron-abi-smoke\` 新 job

三平台 matrix 模拟 fresh checkout → \`pnpm install\` → \`ensure-electron-abi\` → \`smoke\`。catch 后续 PR 把 hands-off 路径搞炸——W1 主 check job 永远跑系统 Node ABI vitest 永远绿,盲区在此 job 治本(retrospective §五 "CI 守门" 原则延续)。

### \`.gitignore\`

\`apps/desktop/.electron-abi-sentinel.json\` 是本机状态,不进版本控制。

### \`CONTRIBUTING.md\`

更新 ABI 切换说明:dev 路径**完全自动化**(predev hook + sentinel),vitest 路径仍需手动 \`rebuild:node\`。同时记录 PR A v1 的根因,给未来 retrospective-m1 参考。

## 验证

### 本地完整 hands-off 模拟(铁证)

1. \`rm sentinel + rebuild:node\` → 切到 Node ABI(模拟 fresh install 默认状态)
2. 直接调 \`ensure-electron-abi.cjs\`:检测 mismatch + rebuild + 写 sentinel(**1 秒**)
3. 立即再调:**0 秒**命中跳过
4. \`ELECTRON_RUN_AS_NODE=1 electron -e 'new Database()'\`:**ABI=145,query OK**
5. \`pnpm --filter @opentrad/desktop smoke\` → PASS

### Monorepo 全套

- \`pnpm typecheck\`:8 packages 全过
- \`pnpm lint\`:clean
- \`pnpm test\`:154 tests 全过

### CI(本 PR 触发)

主 check job 三平台 + **新增 electron-abi-smoke job 三平台**,共 6 个 check 都需要绿。

## 配套 PR

PR B (#35,preload zod 拆分)已合到 main。两个 PR 都修 W1 抽查发现的 bug,**main 合本 PR 后 hands-off 跑通**:

\`\`\`
git pull → pnpm install → pnpm dev → 窗口出来 + window.api.cc 工作
\`\`\`

**中间不允许任何手动 rebuild**。CI smoke job 模拟同款路径,自动化保障。

Refs #34