### PR TITLE
feat(mcp-server): MCP server stdio + IPC bridge JSON-RPC 2.0 + echo tool (M1 #25)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,3 +56,6 @@ ehthumbs.db
 # Electron ABI sentinel —— 由 apps/desktop/scripts/ensure-electron-abi.cjs
 # 维护，记录上次 rebuild 后的 binary 指纹，本机状态不进版本控制
 apps/desktop/.electron-abi-sentinel.json
+
+# smoke-electron-dlopen.cjs 异常退出时可能残留的临时脚本
+apps/desktop/.smoke-tmp-*.cjs

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -7,7 +7,9 @@ import { fileURLToPath } from "node:url";
 import { CCManager } from "@opentrad/cc-adapter";
 import { app, BrowserWindow, dialog } from "electron";
 import { registerIpcHandlers } from "./ipc";
-import { createDbServices, type DbServices } from "./services/db";
+import { createDbServices, type DbServices, getIpcSocketPath } from "./services/db";
+import { createIpcBridgeHandlers } from "./services/ipc-bridge-handlers";
+import { IpcBridgeServer } from "./services/ipc-bridge-server";
 import { type AppLock, AppLockHeldError, acquireAppLock } from "./services/lock";
 import { PtyManager } from "./services/pty-manager";
 
@@ -19,9 +21,10 @@ const ccManager = new CCManager();
 // 全局 PtyManager 单例：跨窗口共享，路由由 IPC handler 内部 ptyId → webContents 管理。
 const ptyManager = new PtyManager();
 
-// 启动时初始化、退出时释放：lock + db。
+// 启动时初始化、退出时释放：lock + db + ipc-bridge server。
 let appLock: AppLock | undefined;
 let dbServices: DbServices | undefined;
+let ipcBridgeServer: IpcBridgeServer | undefined;
 
 // contextIsolation + sandbox 按 03-architecture.md §9「沙箱和权限」开启。
 function createMainWindow(): BrowserWindow {
@@ -71,6 +74,17 @@ app.whenReady().then(() => {
   // SQLite 初始化（M1 #19 验收 1）：~/.opentrad/opentrad.db 自动建表。
   dbServices = createDbServices();
 
+  // IPC bridge server（M1 #25 验收 1）：~/.opentrad/ipc.sock 文件创建（macOS/Linux）
+  // / Windows named pipe 建立。mcp-server 子进程通过它调 4 个 RPC。
+  // 启动失败不阻塞 app（mcp-server 端有 graceful degrade，echo 类 safe tool 仍可用）。
+  ipcBridgeServer = new IpcBridgeServer({
+    socketPath: getIpcSocketPath(),
+    handlers: createIpcBridgeHandlers(dbServices),
+  });
+  ipcBridgeServer.start().catch((err) => {
+    console.error("[main] IPC bridge server start failed", err);
+  });
+
   registerIpcHandlers(ccManager, dbServices, ptyManager);
   createMainWindow();
 
@@ -107,6 +121,15 @@ function finalizeShutdown(): void {
     ptyManager.cleanup();
   } catch (err) {
     console.error("[main] pty cleanup error", err);
+  }
+  // IPC bridge server stop 是 async，但 finalizeShutdown 里同步调；
+  // 用 .catch 保护，主进程已经在退出路径上，stop 失败也无所谓
+  try {
+    void ipcBridgeServer?.stop().catch((err) => {
+      console.error("[main] ipc-bridge stop error", err);
+    });
+  } catch (err) {
+    console.error("[main] ipc-bridge stop sync error", err);
   }
   try {
     dbServices?.close();

--- a/apps/desktop/src/main/services/db/index.ts
+++ b/apps/desktop/src/main/services/db/index.ts
@@ -41,7 +41,7 @@ export { AuditLogService } from "./audit-log";
 export { EventService } from "./events";
 export { type OpenDbOptions, openDatabase } from "./init";
 export { InstalledSkillService } from "./installed-skills";
-export { getDbPath, getLockPath, getUserDataDir } from "./paths";
+export { getDbPath, getDraftsDir, getIpcSocketPath, getLockPath, getUserDataDir } from "./paths";
 export { RiskRuleService } from "./risk-rules";
 export { SCHEMA_SQL, SCHEMA_VERSION } from "./schema";
 export { SessionService } from "./sessions";

--- a/apps/desktop/src/main/services/db/paths.ts
+++ b/apps/desktop/src/main/services/db/paths.ts
@@ -20,3 +20,19 @@ export function getDbPath(): string {
 export function getLockPath(): string {
   return join(getUserDataDir(), ".lock");
 }
+
+// IPC bridge socket / named pipe（M1 #25）。
+// macOS / Linux：~/.opentrad/ipc.sock（Unix domain socket）
+// Windows：\\.\pipe\opentrad-ipc（named pipe，不在文件系统）
+export function getIpcSocketPath(): string {
+  if (process.platform === "win32") {
+    return "\\\\.\\pipe\\opentrad-ipc";
+  }
+  return join(getUserDataDir(), "ipc.sock");
+}
+
+// skill 生成的草稿目录（M1 #25 draft.save RPC + 后续 M1 #26 / #9 用）。
+// 不需要 Windows 特殊处理 —— %APPDATA%\OpenTrad\drafts 也合理。
+export function getDraftsDir(): string {
+  return join(getUserDataDir(), "drafts");
+}

--- a/apps/desktop/src/main/services/ipc-bridge-handlers.ts
+++ b/apps/desktop/src/main/services/ipc-bridge-handlers.ts
@@ -1,0 +1,85 @@
+// 4 个 IPC bridge RPC handler 的实现（M1 #25）。
+// 把 IpcBridgeServer 的 wire 协议层跟具体业务（SQLite / fs）解耦。
+//
+// M1 mock + 真实分阶段（issue body）：
+// - risk-gate.request：mock 返回 allow，真实在 M1 #11 / #28
+// - audit.log：直接走 AuditLogService.append（已在 M1 #19 / #32 落地）
+// - draft.save：写 ~/.opentrad/drafts/{date}-{filename}.md
+// - session.metadata：走 SessionService.get + 投影到 SessionMeta（不暴露 ccSessionPath 等）
+
+import { mkdirSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import type {
+  AuditLogRpcParams,
+  DraftSaveRpcParams,
+  DraftSaveRpcResult,
+  RiskGateRpcParams,
+  RiskGateRpcResult,
+  SessionMetadataRpcParams,
+  SessionMetadataRpcResult,
+} from "@opentrad/shared";
+import type { DbServices } from "./db";
+import { getDraftsDir } from "./db/paths";
+import type { IpcBridgeHandlers } from "./ipc-bridge-server";
+
+export function createIpcBridgeHandlers(db: DbServices): IpcBridgeHandlers {
+  return {
+    async riskGateRequest(_params: RiskGateRpcParams): Promise<RiskGateRpcResult> {
+      // M1 mock：永远 allow。真实拦截在 M1 #11 / #28 由 RiskGate 引擎实现。
+      // 不写 audit_log（mcp-server 端如需 audit 走单独的 audit.log RPC）。
+      return {
+        decision: "allow",
+        reason: "M1 mock allow (real RiskGate at M1 #11 / open-trad/opentrad#28)",
+        timestamp: Date.now(),
+      };
+    },
+
+    async auditLog(params: AuditLogRpcParams): Promise<void> {
+      db.auditLog.append(params);
+    },
+
+    async draftSave(params: DraftSaveRpcParams): Promise<DraftSaveRpcResult> {
+      const draftsDir = getDraftsDir();
+      mkdirSync(draftsDir, { recursive: true });
+
+      const today = isoDate(new Date());
+      // 文件名脱掉路径分隔符，避免 ../ 写出 drafts 目录之外
+      const safeName = sanitizeFilename(params.filename);
+      const fullPath = join(draftsDir, `${today}-${safeName}`);
+      writeFileSync(fullPath, params.content, "utf-8");
+      return { path: fullPath };
+    },
+
+    async sessionMetadata(params: SessionMetadataRpcParams): Promise<SessionMetadataRpcResult> {
+      const row = db.sessions.get(params.sessionId);
+      if (!row) return null;
+      return {
+        id: row.id,
+        title: row.title,
+        skillId: row.skillId,
+        createdAt: row.createdAt,
+        updatedAt: row.updatedAt,
+        status: row.status,
+      };
+    },
+  };
+}
+
+function isoDate(d: Date): string {
+  // YYYY-MM-DD（不带时区，本地日期；草稿目录是用户本地文件，本地日期更友好）
+  const y = d.getFullYear();
+  const m = String(d.getMonth() + 1).padStart(2, "0");
+  const day = String(d.getDate()).padStart(2, "0");
+  return `${y}-${m}-${day}`;
+}
+
+function sanitizeFilename(name: string): string {
+  // 移除路径分隔符 + 控制字符 + 头尾空格点。
+  // 不强制保留 .md 后缀（让调用方决定）。
+  let cleaned = name.replace(/[/\\\0\n\r]/g, "_").trim();
+  // 防御 Windows 保留名（CON、PRN 等）+ 防 .. 路径穿越
+  if (cleaned === "" || cleaned === "." || cleaned === "..") {
+    cleaned = "draft";
+  }
+  return cleaned;
+}

--- a/apps/desktop/src/main/services/ipc-bridge-server.ts
+++ b/apps/desktop/src/main/services/ipc-bridge-server.ts
@@ -1,0 +1,297 @@
+// IPC bridge server（M1 #25）。Desktop 主进程暴露的 JSON-RPC 2.0 server，
+// apps/mcp-server 通过 Unix socket / named pipe 连过来调 4 个方法。
+//
+// 设计：
+// - 跨平台路径：macOS/Linux 用 ~/.opentrad/ipc.sock；Windows 用 \\.\pipe\opentrad-ipc
+// - 多连接（B 拍板 Multi-session 留口）：每个 client 单独 ClientContext，
+//   按 hello 帧的 sessionId 路由
+// - 行分隔 NDJSON：跟 @opentrad/stream-parser 同模式，buffer + split('\n')
+// - handshake 必需：第一帧不是 hello → 立刻断开（HandshakeRequired error）
+// - 退出时 unlink socket 文件（Unix），避免残留
+
+import { existsSync, unlinkSync } from "node:fs";
+import * as net from "node:net";
+import {
+  type AuditLogRpcParams,
+  AuditLogRpcParamsSchema,
+  type DraftSaveRpcParams,
+  DraftSaveRpcParamsSchema,
+  type DraftSaveRpcResult,
+  IPC_BRIDGE_PROTOCOL_VERSION,
+  IpcBridgeHelloParamsSchema,
+  IpcBridgeMethods,
+  JsonRpcErrorCode,
+  type JsonRpcNotification,
+  type JsonRpcRequest,
+  type JsonRpcResponse,
+  type RiskGateRpcParams,
+  RiskGateRpcParamsSchema,
+  type RiskGateRpcResult,
+  type SessionMetadataRpcParams,
+  SessionMetadataRpcParamsSchema,
+  type SessionMetadataRpcResult,
+} from "@opentrad/shared";
+
+export interface IpcBridgeHandlers {
+  riskGateRequest(
+    params: RiskGateRpcParams,
+    ctx: { sessionId: string },
+  ): Promise<RiskGateRpcResult>;
+  auditLog(params: AuditLogRpcParams, ctx: { sessionId: string }): Promise<void>;
+  draftSave(params: DraftSaveRpcParams, ctx: { sessionId: string }): Promise<DraftSaveRpcResult>;
+  sessionMetadata(
+    params: SessionMetadataRpcParams,
+    ctx: { sessionId: string },
+  ): Promise<SessionMetadataRpcResult>;
+}
+
+export interface IpcBridgeServerOptions {
+  socketPath: string;
+  handlers: IpcBridgeHandlers;
+  // 第一帧不是 hello 的最长容忍时间（避免空连接占资源）。M1 默认 5s。
+  helloTimeoutMs?: number;
+}
+
+interface ClientContext {
+  socket: net.Socket;
+  sessionId?: string; // hello 之前未知
+  buffer: string;
+  helloTimer?: NodeJS.Timeout;
+}
+
+export class IpcBridgeServer {
+  private readonly server: net.Server;
+  private readonly clients = new Set<ClientContext>();
+  private listening = false;
+
+  constructor(private readonly opts: IpcBridgeServerOptions) {
+    this.server = net.createServer((socket) => this.onConnection(socket));
+  }
+
+  async start(): Promise<void> {
+    if (this.listening) return;
+    // Unix socket 残留清理（崩溃后重启）。Windows named pipe 不需要。
+    if (process.platform !== "win32" && existsSync(this.opts.socketPath)) {
+      try {
+        unlinkSync(this.opts.socketPath);
+      } catch {
+        // 文件被占用 / 权限问题 → listen 时会暴露 EADDRINUSE
+      }
+    }
+
+    await new Promise<void>((resolve, reject) => {
+      this.server.once("error", reject);
+      this.server.listen(this.opts.socketPath, () => {
+        this.server.removeListener("error", reject);
+        this.listening = true;
+        resolve();
+      });
+    });
+  }
+
+  async stop(): Promise<void> {
+    if (!this.listening) return;
+    for (const client of this.clients) {
+      client.socket.destroy();
+      if (client.helloTimer) clearTimeout(client.helloTimer);
+    }
+    this.clients.clear();
+    await new Promise<void>((resolve) => this.server.close(() => resolve()));
+    this.listening = false;
+    if (process.platform !== "win32" && existsSync(this.opts.socketPath)) {
+      try {
+        unlinkSync(this.opts.socketPath);
+      } catch {
+        // 静默
+      }
+    }
+  }
+
+  private onConnection(socket: net.Socket): void {
+    const ctx: ClientContext = { socket, buffer: "" };
+    this.clients.add(ctx);
+
+    // hello 必须在 helloTimeoutMs 内到达，否则断开
+    const timeoutMs = this.opts.helloTimeoutMs ?? 5000;
+    ctx.helloTimer = setTimeout(() => {
+      if (!ctx.sessionId) socket.destroy();
+    }, timeoutMs);
+
+    socket.setEncoding("utf-8");
+    socket.on("data", (chunk: string) => this.onData(ctx, chunk));
+    socket.on("close", () => {
+      if (ctx.helloTimer) clearTimeout(ctx.helloTimer);
+      this.clients.delete(ctx);
+    });
+    socket.on("error", () => {
+      // 连接被对端断开 / 写错误 → 静默清理；不抛
+    });
+  }
+
+  private onData(ctx: ClientContext, chunk: string): void {
+    ctx.buffer += chunk;
+    let nl = ctx.buffer.indexOf("\n");
+    while (nl !== -1) {
+      const line = ctx.buffer.slice(0, nl).trim();
+      ctx.buffer = ctx.buffer.slice(nl + 1);
+      if (line) void this.handleLine(ctx, line);
+      nl = ctx.buffer.indexOf("\n");
+    }
+  }
+
+  private async handleLine(ctx: ClientContext, line: string): Promise<void> {
+    let raw: unknown;
+    try {
+      raw = JSON.parse(line);
+    } catch {
+      // 协议层 parse 错误 → 不能用 id 回错（不知道 id），直接断开
+      ctx.socket.destroy();
+      return;
+    }
+
+    // 第一帧必须是 hello（notification 形态：method = $/hello,无 id）
+    if (!ctx.sessionId) {
+      const isHelloShape =
+        typeof raw === "object" &&
+        raw !== null &&
+        (raw as { method?: unknown }).method === IpcBridgeMethods.Hello;
+      if (!isHelloShape) {
+        // 协议错：抢跑了 RPC。回 HandshakeRequired error 后断开
+        const id = (raw as { id?: number | string } | null)?.id;
+        if (id !== undefined) {
+          this.send(ctx, {
+            jsonrpc: "2.0",
+            id,
+            error: {
+              code: JsonRpcErrorCode.HandshakeRequired,
+              message: "must send $/hello before any request",
+            },
+          });
+        }
+        ctx.socket.destroy();
+        return;
+      }
+      this.handleHello(ctx, raw as JsonRpcNotification);
+      return;
+    }
+
+    // hello 之后 → 应该是 RPC request（带 id）。M1 不发 notification 给 server。
+    if (
+      typeof raw !== "object" ||
+      raw === null ||
+      typeof (raw as { method?: unknown }).method !== "string" ||
+      (raw as { id?: unknown }).id === undefined
+    ) {
+      ctx.socket.destroy();
+      return;
+    }
+    await this.handleRpc(ctx, raw as JsonRpcRequest);
+  }
+
+  private handleHello(ctx: ClientContext, msg: JsonRpcNotification): void {
+    const parsed = IpcBridgeHelloParamsSchema.safeParse(msg.params);
+    if (!parsed.success) {
+      ctx.socket.destroy();
+      return;
+    }
+    if (parsed.data.protocolVersion !== IPC_BRIDGE_PROTOCOL_VERSION) {
+      // M1 严格匹配，M3 升级时改成兼容协商
+      ctx.socket.destroy();
+      return;
+    }
+    ctx.sessionId = parsed.data.sessionId;
+    if (ctx.helloTimer) {
+      clearTimeout(ctx.helloTimer);
+      ctx.helloTimer = undefined;
+    }
+  }
+
+  private async handleRpc(ctx: ClientContext, req: JsonRpcRequest): Promise<void> {
+    const sessionId = ctx.sessionId;
+    if (!sessionId) {
+      // 不应该到这里（handleLine 已经守过 sessionId）
+      return;
+    }
+    try {
+      const result = await this.dispatch(req.method, req.params, sessionId);
+      this.send(ctx, { jsonrpc: "2.0", id: req.id, result });
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      const code =
+        err instanceof MethodNotFoundError
+          ? JsonRpcErrorCode.MethodNotFound
+          : err instanceof InvalidParamsError
+            ? JsonRpcErrorCode.InvalidParams
+            : JsonRpcErrorCode.InternalError;
+      this.send(ctx, { jsonrpc: "2.0", id: req.id, error: { code, message } });
+    }
+  }
+
+  private async dispatch(method: string, params: unknown, sessionId: string): Promise<unknown> {
+    const ctx = { sessionId };
+    switch (method) {
+      case IpcBridgeMethods.RiskGateRequest: {
+        const p = parseOrThrow(RiskGateRpcParamsSchema, params);
+        return this.opts.handlers.riskGateRequest(p, ctx);
+      }
+      case IpcBridgeMethods.AuditLog: {
+        const p = parseOrThrow(AuditLogRpcParamsSchema, params);
+        await this.opts.handlers.auditLog(p, ctx);
+        return null;
+      }
+      case IpcBridgeMethods.DraftSave: {
+        const p = parseOrThrow(DraftSaveRpcParamsSchema, params);
+        return this.opts.handlers.draftSave(p, ctx);
+      }
+      case IpcBridgeMethods.SessionMetadata: {
+        const p = parseOrThrow(SessionMetadataRpcParamsSchema, params);
+        return this.opts.handlers.sessionMetadata(p, ctx);
+      }
+      default:
+        throw new MethodNotFoundError(method);
+    }
+  }
+
+  private send(ctx: ClientContext, msg: JsonRpcResponse): void {
+    if (ctx.socket.destroyed) return;
+    try {
+      ctx.socket.write(`${JSON.stringify(msg)}\n`);
+    } catch {
+      // 写失败（连接断了）→ 静默
+    }
+  }
+
+  // 测试 / 健康检查用
+  get clientCount(): number {
+    return this.clients.size;
+  }
+}
+
+class MethodNotFoundError extends Error {
+  constructor(method: string) {
+    super(`method not found: ${method}`);
+    this.name = "MethodNotFoundError";
+  }
+}
+
+class InvalidParamsError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "InvalidParamsError";
+  }
+}
+
+function parseOrThrow<T>(
+  schema: {
+    safeParse(
+      v: unknown,
+    ): { success: true; data: T } | { success: false; error: { issues: unknown } };
+  },
+  params: unknown,
+): T {
+  const result = schema.safeParse(params);
+  if (!result.success) {
+    throw new InvalidParamsError(`invalid params: ${JSON.stringify(result.error.issues)}`);
+  }
+  return result.data;
+}

--- a/apps/desktop/tests/ipc-bridge-server.test.ts
+++ b/apps/desktop/tests/ipc-bridge-server.test.ts
@@ -52,7 +52,7 @@ describe("IpcBridgeServer", () => {
 
   beforeEach(async () => {
     tempDir = mkdtempSync(join(tmpdir(), "opentrad-bridge-"));
-    socketPath = join(tempDir, "ipc.sock");
+    socketPath = makeTestSocketPath(tempDir, "server");
     const { handlers, calls: c } = fakeHandlers();
     calls = c;
     server = new IpcBridgeServer({ socketPath, handlers, helloTimeoutMs: 1000 });
@@ -189,6 +189,15 @@ describe("IpcBridgeServer", () => {
 });
 
 // ---------- helpers ----------
+
+// 跨平台测试 socket 路径：Unix 用 tempDir/ipc.sock；Windows 用 named pipe
+// （\\.\pipe\<name>，不在文件系统）。production 路径在 db/paths.ts 同款分支。
+function makeTestSocketPath(tempDir: string, label: string): string {
+  if (process.platform === "win32") {
+    return `\\\\.\\pipe\\opentrad-test-${label}-${process.pid}-${Date.now()}`;
+  }
+  return join(tempDir, "ipc.sock");
+}
 
 function connectClient(socketPath: string): Promise<net.Socket> {
   return new Promise((resolve, reject) => {

--- a/apps/desktop/tests/ipc-bridge-server.test.ts
+++ b/apps/desktop/tests/ipc-bridge-server.test.ts
@@ -1,0 +1,270 @@
+// IpcBridgeServer 协议层测试。
+// 用 net.createConnection 直连 server，手写 hello / RPC 帧，验证协议处理逻辑。
+// 不依赖真实 mcp-server；mcp-server 端的 IpcBridgeClient 单测在 mcp-server 包里。
+
+import { mkdtempSync, rmSync } from "node:fs";
+import * as net from "node:net";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { IPC_BRIDGE_PROTOCOL_VERSION, IpcBridgeMethods, JsonRpcErrorCode } from "@opentrad/shared";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { type IpcBridgeHandlers, IpcBridgeServer } from "../src/main/services/ipc-bridge-server";
+
+interface ReceivedCalls {
+  riskGate: number;
+  audit: number;
+  draft: number;
+  metadata: number;
+  lastSessionId?: string;
+}
+
+function fakeHandlers(): { handlers: IpcBridgeHandlers; calls: ReceivedCalls } {
+  const calls: ReceivedCalls = { riskGate: 0, audit: 0, draft: 0, metadata: 0 };
+  const handlers: IpcBridgeHandlers = {
+    async riskGateRequest(_p, ctx) {
+      calls.riskGate++;
+      calls.lastSessionId = ctx.sessionId;
+      return { decision: "allow", timestamp: Date.now() };
+    },
+    async auditLog(_p, ctx) {
+      calls.audit++;
+      calls.lastSessionId = ctx.sessionId;
+    },
+    async draftSave(_p, ctx) {
+      calls.draft++;
+      calls.lastSessionId = ctx.sessionId;
+      return { path: "/fake/draft.md" };
+    },
+    async sessionMetadata(_p, ctx) {
+      calls.metadata++;
+      calls.lastSessionId = ctx.sessionId;
+      return null;
+    },
+  };
+  return { handlers, calls };
+}
+
+describe("IpcBridgeServer", () => {
+  let tempDir: string;
+  let socketPath: string;
+  let server: IpcBridgeServer;
+  let calls: ReceivedCalls;
+
+  beforeEach(async () => {
+    tempDir = mkdtempSync(join(tmpdir(), "opentrad-bridge-"));
+    socketPath = join(tempDir, "ipc.sock");
+    const { handlers, calls: c } = fakeHandlers();
+    calls = c;
+    server = new IpcBridgeServer({ socketPath, handlers, helloTimeoutMs: 1000 });
+    await server.start();
+  });
+
+  afterEach(async () => {
+    await server.stop();
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it("正常 hello + 4 个 RPC dispatch", async () => {
+    const client = await connectClient(socketPath);
+    sendHello(client, "test-session-1");
+
+    // audit.log
+    const auditResp = await rpc(client, IpcBridgeMethods.AuditLog, {
+      sessionId: "test-session-1",
+      toolName: "echo",
+      decision: "allow",
+      automated: true,
+    });
+    expect(auditResp.result).toBeNull();
+    expect(calls.audit).toBe(1);
+    expect(calls.lastSessionId).toBe("test-session-1");
+
+    // risk-gate.request
+    const rgResp = await rpc(client, IpcBridgeMethods.RiskGateRequest, {
+      skillId: "trade-email-writer",
+      toolName: "echo",
+      params: {},
+      riskLevel: "safe",
+    });
+    expect((rgResp.result as { decision: string }).decision).toBe("allow");
+    expect(calls.riskGate).toBe(1);
+
+    // draft.save
+    const draftResp = await rpc(client, IpcBridgeMethods.DraftSave, {
+      filename: "test.md",
+      content: "hello",
+    });
+    expect((draftResp.result as { path: string }).path).toBe("/fake/draft.md");
+    expect(calls.draft).toBe(1);
+
+    // session.metadata
+    const metaResp = await rpc(client, IpcBridgeMethods.SessionMetadata, {
+      sessionId: "test-session-1",
+    });
+    expect(metaResp.result).toBeNull();
+    expect(calls.metadata).toBe(1);
+
+    client.destroy();
+  });
+
+  it("协议错：hello 之前发 RPC → server 回 HandshakeRequired error 并断开", async () => {
+    const client = await connectClient(socketPath);
+    // 抢跑 RPC（无 hello）
+    const closed = waitForClose(client);
+    const responsePromise = readOneResponse(client);
+    client.write(
+      `${JSON.stringify({
+        jsonrpc: "2.0",
+        id: 1,
+        method: IpcBridgeMethods.AuditLog,
+        params: {},
+      })}\n`,
+    );
+    const resp = await responsePromise;
+    expect(resp.error?.code).toBe(JsonRpcErrorCode.HandshakeRequired);
+    await closed; // 应被 server 断开
+  });
+
+  it("协议错：protocolVersion 不匹配 → server 直接断开", async () => {
+    const client = await connectClient(socketPath);
+    const closed = waitForClose(client);
+    const helloFrame = {
+      jsonrpc: "2.0",
+      method: IpcBridgeMethods.Hello,
+      params: {
+        sessionId: "x",
+        mcpServerPid: 1,
+        protocolVersion: IPC_BRIDGE_PROTOCOL_VERSION + 99,
+      },
+    };
+    client.write(`${JSON.stringify(helloFrame)}\n`);
+    await closed;
+  });
+
+  it("hello timeout：超过 helloTimeoutMs 没发 hello → server 断开", async () => {
+    const client = await connectClient(socketPath);
+    const closed = waitForClose(client);
+    // 不发任何数据；helloTimeoutMs = 1000 → 应在 ~1s 后被断开
+    await closed;
+  });
+
+  it("clientCount：连上 / 断开同步反映", async () => {
+    expect(server.clientCount).toBe(0);
+    const c1 = await connectClient(socketPath);
+    sendHello(c1, "s1");
+    // 等一个 tick 让 server 注册
+    await sleep(20);
+    expect(server.clientCount).toBe(1);
+
+    const c2 = await connectClient(socketPath);
+    sendHello(c2, "s2");
+    await sleep(20);
+    expect(server.clientCount).toBe(2);
+
+    c1.destroy();
+    await sleep(50);
+    expect(server.clientCount).toBe(1);
+    c2.destroy();
+    await sleep(50);
+    expect(server.clientCount).toBe(0);
+  });
+
+  it("InvalidParams：audit.log 缺必要字段 → server 回 InvalidParams error", async () => {
+    const client = await connectClient(socketPath);
+    sendHello(client, "s1");
+    const responsePromise = readOneResponse(client);
+    client.write(
+      `${JSON.stringify({
+        jsonrpc: "2.0",
+        id: 1,
+        method: IpcBridgeMethods.AuditLog,
+        params: { sessionId: "s1" }, // 缺 toolName / decision / automated
+      })}\n`,
+    );
+    const resp = await responsePromise;
+    expect(resp.error?.code).toBe(JsonRpcErrorCode.InvalidParams);
+    expect(calls.audit).toBe(0);
+    client.destroy();
+  });
+});
+
+// ---------- helpers ----------
+
+function connectClient(socketPath: string): Promise<net.Socket> {
+  return new Promise((resolve, reject) => {
+    const s = net.createConnection(socketPath);
+    s.setEncoding("utf-8");
+    s.once("connect", () => resolve(s));
+    s.once("error", reject);
+  });
+}
+
+function sendHello(client: net.Socket, sessionId: string): void {
+  const frame = {
+    jsonrpc: "2.0",
+    method: IpcBridgeMethods.Hello,
+    params: {
+      sessionId,
+      mcpServerPid: process.pid,
+      protocolVersion: IPC_BRIDGE_PROTOCOL_VERSION,
+    },
+  };
+  client.write(`${JSON.stringify(frame)}\n`);
+}
+
+let nextRpcId = 1;
+async function rpc(
+  client: net.Socket,
+  method: string,
+  params: unknown,
+): Promise<{ result?: unknown; error?: { code: number; message: string } }> {
+  const id = nextRpcId++;
+  const responsePromise = readOneResponse(client, id);
+  client.write(`${JSON.stringify({ jsonrpc: "2.0", id, method, params })}\n`);
+  return responsePromise;
+}
+
+function readOneResponse(
+  client: net.Socket,
+  matchId?: number,
+): Promise<{
+  id?: number | string;
+  result?: unknown;
+  error?: { code: number; message: string };
+}> {
+  return new Promise((resolve, reject) => {
+    let buffer = "";
+    const onData = (chunk: string): void => {
+      buffer += chunk;
+      const nl = buffer.indexOf("\n");
+      if (nl === -1) return;
+      const line = buffer.slice(0, nl).trim();
+      buffer = buffer.slice(nl + 1);
+      try {
+        const parsed = JSON.parse(line);
+        if (matchId !== undefined && parsed.id !== matchId) {
+          // 可能是别的响应；M1 测试串行调用，应该不会乱序
+          return;
+        }
+        client.removeListener("data", onData);
+        resolve(parsed);
+      } catch (err) {
+        client.removeListener("data", onData);
+        reject(err as Error);
+      }
+    };
+    client.on("data", onData);
+    setTimeout(() => {
+      client.removeListener("data", onData);
+      reject(new Error("readOneResponse timeout"));
+    }, 5000);
+  });
+}
+
+function waitForClose(client: net.Socket): Promise<void> {
+  return new Promise((resolve) => client.once("close", () => resolve()));
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}

--- a/apps/mcp-server/package.json
+++ b/apps/mcp-server/package.json
@@ -6,6 +6,14 @@
   "main": "./src/index.ts",
   "types": "./src/index.ts",
   "scripts": {
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run"
+  },
+  "devDependencies": {
+    "@opentrad/shared": "workspace:^"
+  },
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.29.0",
+    "zod": "^4.3.6"
   }
 }

--- a/apps/mcp-server/src/index.ts
+++ b/apps/mcp-server/src/index.ts
@@ -1,2 +1,121 @@
-// 占位，OpenTrad MCP server 入口在 M2 里程碑填充
-export {};
+// OpenTrad MCP Server 入口（M1 #25 / open-trad/opentrad#25）。
+// 由 CC 通过 stdio 拉起（参见 mcp-config 配置生成在 desktop 主进程的 McpConfigWriter，
+// M1 #26 落地）。本进程：
+// 1. stdio MCP server 暴露 tools 给 CC
+// 2. IPC bridge client 连 desktop 主进程，调 risk-gate.request / audit.log /
+//    draft.save / session.metadata 4 个 RPC
+//
+// 启动参数：从 env 读 OPENTRAD_IPC_SOCKET 和 OPENTRAD_SESSION_ID。
+//
+// 关键约束：
+// - **stdout 不能 console.log**（污染 stdio MCP wire 流）。诊断输出走 stderr。
+// - 启动失败 / IPC 连不上不阻塞 stdio MCP（graceful degrade，echo 类 safe tool 仍可用）。
+
+import { Server } from "@modelcontextprotocol/sdk/server/index.js";
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import { CallToolRequestSchema, ListToolsRequestSchema } from "@modelcontextprotocol/sdk/types.js";
+import { z } from "zod";
+import { IpcBridgeClient } from "./ipc-bridge";
+import { getToolByName, tools } from "./tools";
+
+async function main(): Promise<void> {
+  const sessionId = process.env.OPENTRAD_SESSION_ID;
+  const socketPath = process.env.OPENTRAD_IPC_SOCKET;
+
+  if (!sessionId) {
+    process.stderr.write("[opentrad-mcp] missing OPENTRAD_SESSION_ID env\n");
+    process.exit(1);
+  }
+  if (!socketPath) {
+    process.stderr.write("[opentrad-mcp] missing OPENTRAD_IPC_SOCKET env\n");
+    process.exit(1);
+  }
+
+  // IPC bridge：异步连接（不阻塞 stdio MCP server 启动；连不上走 offline graceful degrade）
+  const bridge = new IpcBridgeClient({
+    sessionId,
+    socketPath,
+    mcpServerPid: process.pid,
+  });
+  void bridge.connect();
+
+  const server = new Server(
+    { name: "opentrad", version: "0.0.0" },
+    { capabilities: { tools: {} } },
+  );
+
+  server.setRequestHandler(ListToolsRequestSchema, async () => ({
+    tools: tools.map((t) => ({
+      name: t.name,
+      description: t.description,
+      inputSchema: zodToJsonSchema(t.inputSchema),
+    })),
+  }));
+
+  server.setRequestHandler(CallToolRequestSchema, async (req) => {
+    const tool = getToolByName(req.params.name);
+    if (!tool) {
+      return {
+        isError: true,
+        content: [{ type: "text", text: `unknown tool: ${req.params.name}` }],
+      };
+    }
+    try {
+      const content = await tool.execute(req.params.arguments ?? {}, {
+        bridge,
+        sessionId,
+      });
+      return { content };
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      return { isError: true, content: [{ type: "text", text: message }] };
+    }
+  });
+
+  const transport = new StdioServerTransport();
+  await server.connect(transport);
+
+  // 退出清理：CC 关闭 stdio 时 SDK 会触发；这里再加一道 cleanup 保险
+  const shutdown = (): void => {
+    bridge.close();
+    process.exit(0);
+  };
+  process.on("SIGINT", shutdown);
+  process.on("SIGTERM", shutdown);
+}
+
+// 把 zod schema 投影到 MCP SDK 期望的 JSON Schema 形态。
+// MCP 协议要求 inputSchema 是 { type: "object", properties: {...}, required: [...] } 形态。
+// 这里手写一个最小映射器，避免引入 zod-to-json-schema 第三方依赖（M1 工具简单够用；
+// M1 #27 浏览器工具有更复杂参数时可视情况换成 zod-to-json-schema）。
+function zodToJsonSchema(schema: z.ZodTypeAny): Record<string, unknown> {
+  if (schema instanceof z.ZodObject) {
+    const shape = schema.shape as Record<string, z.ZodTypeAny>;
+    const properties: Record<string, unknown> = {};
+    const required: string[] = [];
+    for (const [key, fieldSchema] of Object.entries(shape)) {
+      properties[key] = zodToJsonSchema(fieldSchema);
+      if (!fieldSchema.isOptional()) required.push(key);
+    }
+    return { type: "object", properties, required };
+  }
+  if (schema instanceof z.ZodString) {
+    return schema.description
+      ? { type: "string", description: schema.description }
+      : { type: "string" };
+  }
+  if (schema instanceof z.ZodNumber) return { type: "number" };
+  if (schema instanceof z.ZodBoolean) return { type: "boolean" };
+  if (schema instanceof z.ZodArray) {
+    // M1 范围内的 echo tool 不用 array；后续 M1 #26 / #27 复杂参数时升级到
+    // zod-to-json-schema 第三方包（zod v4 内部类型在简单递归里不稳）。
+    return { type: "array" };
+  }
+  // 兜底：unknown 类型，CC 不会报错
+  return { type: "string" };
+}
+
+main().catch((err) => {
+  process.stderr.write(`[opentrad-mcp] fatal: ${(err as Error).stack ?? err}\n`);
+  process.exit(1);
+});

--- a/apps/mcp-server/src/ipc-bridge.ts
+++ b/apps/mcp-server/src/ipc-bridge.ts
@@ -1,0 +1,272 @@
+// IPC bridge client（M1 #25）。mcp-server 端，连 desktop 主进程的 socket / named pipe。
+//
+// 协议：JSON-RPC 2.0 over NDJSON。第一帧发 $/hello notification，后续 RPC 请求/响应。
+// Wire 协议详见 packages/shared/src/types/ipc-bridge.ts。
+//
+// graceful degrade（D-M1-5 已拍板，issue body 写明）：
+// - 连接失败时，retry 3 次 exponential backoff（100 / 300 / 1000ms）
+// - 全部失败后进入 offline 模式，不再尝试重连（M1 简化；M2 视需求加 long-term reconnect）
+// - offline 时：
+//   * risk-gate.request → 返回 deny（安全侧，避免无确认机制下任意调用）
+//   * audit.log → buffer 在内存，重连成功后批量 flush（M1 不重连，所以等同丢弃 + warn）
+//   * draft.save / session.metadata → throw IpcBridgeOfflineError（让 tool 调用上层报错）
+
+import * as net from "node:net";
+import {
+  type AuditLogRpcParams,
+  type DraftSaveRpcParams,
+  type DraftSaveRpcResult,
+  IPC_BRIDGE_PROTOCOL_VERSION,
+  IpcBridgeMethods,
+  type JsonRpcResponse,
+  JsonRpcResponseSchema,
+  type RiskGateRpcParams,
+  type RiskGateRpcResult,
+  type SessionMetadataRpcParams,
+  type SessionMetadataRpcResult,
+} from "@opentrad/shared";
+
+export class IpcBridgeOfflineError extends Error {
+  readonly code = "IPC_BRIDGE_OFFLINE" as const;
+  constructor(method: string) {
+    super(`IPC bridge is offline; cannot call ${method}`);
+    this.name = "IpcBridgeOfflineError";
+  }
+}
+
+export interface IpcBridgeClientOptions {
+  socketPath: string;
+  sessionId: string;
+  mcpServerPid: number;
+  rpcTimeoutMs?: number; // 单次 RPC 超时，默认 30s
+}
+
+interface PendingRequest {
+  resolve: (value: unknown) => void;
+  reject: (err: Error) => void;
+  timer: NodeJS.Timeout;
+}
+
+export class IpcBridgeClient {
+  private socket?: net.Socket;
+  private connected = false;
+  private offline = false; // 初次连接全失败后进入；M1 不重连
+  private buffer = "";
+  private nextId = 1;
+  private readonly pending = new Map<number, PendingRequest>();
+  private readonly auditBuffer: AuditLogRpcParams[] = [];
+
+  constructor(private readonly opts: IpcBridgeClientOptions) {}
+
+  // 初次连接 + retry 3 次 exponential backoff。失败后 offline = true。
+  async connect(): Promise<void> {
+    const delays = [100, 300, 1000];
+    for (let i = 0; i <= delays.length; i++) {
+      try {
+        await this.tryConnectOnce();
+        this.sendHello();
+        this.flushAuditBuffer();
+        return;
+      } catch (err) {
+        if (i === delays.length) {
+          this.offline = true;
+          this.warn(
+            `IPC bridge connect failed after ${delays.length + 1} attempts; falling back to offline mode (${(err as Error).message})`,
+          );
+          return;
+        }
+        await sleep(delays[i] as number);
+      }
+    }
+  }
+
+  private async tryConnectOnce(): Promise<void> {
+    return new Promise<void>((resolve, reject) => {
+      const socket = net.createConnection(this.opts.socketPath);
+      const onError = (err: Error): void => {
+        socket.removeAllListeners();
+        socket.destroy();
+        reject(err);
+      };
+      socket.once("error", onError);
+      socket.once("connect", () => {
+        socket.removeListener("error", onError);
+        socket.setEncoding("utf-8");
+        socket.on("data", (chunk: string) => this.onData(chunk));
+        socket.on("close", () => this.onClose());
+        socket.on("error", () => {
+          // 连接稳定后的错误：rejectAll pending、走 offline
+          this.onClose();
+        });
+        this.socket = socket;
+        this.connected = true;
+        resolve();
+      });
+    });
+  }
+
+  private sendHello(): void {
+    if (!this.socket) return;
+    const helloFrame = {
+      jsonrpc: "2.0" as const,
+      method: IpcBridgeMethods.Hello,
+      params: {
+        sessionId: this.opts.sessionId,
+        mcpServerPid: this.opts.mcpServerPid,
+        protocolVersion: IPC_BRIDGE_PROTOCOL_VERSION,
+      },
+    };
+    this.socket.write(`${JSON.stringify(helloFrame)}\n`);
+  }
+
+  private flushAuditBuffer(): void {
+    if (this.auditBuffer.length === 0) return;
+    const drained = this.auditBuffer.splice(0, this.auditBuffer.length);
+    for (const params of drained) {
+      // 不 await：批量 flush 不阻塞 connect
+      void this.request<void>(IpcBridgeMethods.AuditLog, params).catch((err) =>
+        this.warn(`audit.log flush failed: ${(err as Error).message}`),
+      );
+    }
+  }
+
+  private onData(chunk: string): void {
+    this.buffer += chunk;
+    let nl = this.buffer.indexOf("\n");
+    while (nl !== -1) {
+      const line = this.buffer.slice(0, nl).trim();
+      this.buffer = this.buffer.slice(nl + 1);
+      if (line) this.handleLine(line);
+      nl = this.buffer.indexOf("\n");
+    }
+  }
+
+  private handleLine(line: string): void {
+    let raw: unknown;
+    try {
+      raw = JSON.parse(line);
+    } catch {
+      this.warn(`failed to parse server line: ${line.slice(0, 200)}`);
+      return;
+    }
+    const parsed = JsonRpcResponseSchema.safeParse(raw);
+    if (!parsed.success) {
+      this.warn("ignoring malformed JSON-RPC response");
+      return;
+    }
+    this.dispatchResponse(parsed.data);
+  }
+
+  private dispatchResponse(msg: JsonRpcResponse): void {
+    if (typeof msg.id !== "number") return; // 不识别 string id（M1 不发 string id）
+    const pending = this.pending.get(msg.id);
+    if (!pending) return;
+    this.pending.delete(msg.id);
+    clearTimeout(pending.timer);
+    if (msg.error) {
+      pending.reject(new Error(`RPC error ${msg.error.code}: ${msg.error.message}`));
+    } else {
+      pending.resolve(msg.result);
+    }
+  }
+
+  private onClose(): void {
+    this.connected = false;
+    this.offline = true; // M1 不重连
+    this.socket = undefined;
+    // reject 所有 pending
+    for (const [id, p] of this.pending.entries()) {
+      clearTimeout(p.timer);
+      p.reject(new Error("IPC bridge connection closed"));
+      this.pending.delete(id);
+    }
+  }
+
+  // 通用 request；调用方传入 method 字符串
+  private request<T>(method: string, params: unknown): Promise<T> {
+    if (this.offline || !this.connected || !this.socket) {
+      throw new IpcBridgeOfflineError(method);
+    }
+    return new Promise<T>((resolve, reject) => {
+      const id = this.nextId++;
+      const timeout = this.opts.rpcTimeoutMs ?? 30_000;
+      const timer = setTimeout(() => {
+        this.pending.delete(id);
+        reject(new Error(`RPC timeout (${timeout}ms): ${method}`));
+      }, timeout);
+      this.pending.set(id, {
+        resolve: resolve as (value: unknown) => void,
+        reject,
+        timer,
+      });
+      const frame = { jsonrpc: "2.0", id, method, params };
+      this.socket?.write(`${JSON.stringify(frame)}\n`);
+    });
+  }
+
+  // -------- 4 个 typed wrapper（含 graceful degrade） --------
+
+  async riskGateRequest(params: RiskGateRpcParams): Promise<RiskGateRpcResult> {
+    if (this.offline) {
+      // 离线时 deny 是安全侧默认（D-M1-5）
+      return {
+        decision: "deny",
+        reason: "ipc bridge offline (mcp-server graceful degrade)",
+        timestamp: Date.now(),
+      };
+    }
+    return this.request<RiskGateRpcResult>(IpcBridgeMethods.RiskGateRequest, params);
+  }
+
+  async auditLog(params: AuditLogRpcParams): Promise<void> {
+    if (this.offline) {
+      // 离线时 buffer（M1 不重连，等同 warn 后丢弃；M2 加重连后真 flush）
+      this.auditBuffer.push(params);
+      return;
+    }
+    await this.request<unknown>(IpcBridgeMethods.AuditLog, params);
+  }
+
+  async draftSave(params: DraftSaveRpcParams): Promise<DraftSaveRpcResult> {
+    if (this.offline) throw new IpcBridgeOfflineError(IpcBridgeMethods.DraftSave);
+    return this.request<DraftSaveRpcResult>(IpcBridgeMethods.DraftSave, params);
+  }
+
+  async sessionMetadata(params: SessionMetadataRpcParams): Promise<SessionMetadataRpcResult> {
+    if (this.offline) throw new IpcBridgeOfflineError(IpcBridgeMethods.SessionMetadata);
+    return this.request<SessionMetadataRpcResult>(IpcBridgeMethods.SessionMetadata, params);
+  }
+
+  // -------- 状态查询 + 关闭 --------
+
+  get isConnected(): boolean {
+    return this.connected;
+  }
+
+  get isOffline(): boolean {
+    return this.offline;
+  }
+
+  close(): void {
+    if (this.socket) {
+      this.socket.destroy();
+      this.socket = undefined;
+    }
+    this.connected = false;
+    for (const [id, p] of this.pending.entries()) {
+      clearTimeout(p.timer);
+      p.reject(new Error("IPC bridge client closed by caller"));
+      this.pending.delete(id);
+    }
+  }
+
+  // mcp-server 走 stdio MCP 协议时，stdout 不能 console.log（会污染 wire 流）。
+  // 用 stderr 输出 warn —— stderr 在 CC 拉起的 stdio MCP server 里是允许的诊断通道。
+  private warn(msg: string): void {
+    process.stderr.write(`[opentrad-mcp][ipc-bridge] ${msg}\n`);
+  }
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}

--- a/apps/mcp-server/src/tools/echo.ts
+++ b/apps/mcp-server/src/tools/echo.ts
@@ -1,0 +1,23 @@
+// echo tool（M1 #25）：最简 safe 工具，验证 mcp-server 端到端跑通。
+// 不走 RiskGate（safe 不弹窗）；不调 IPC bridge RPC（纯 in-process）。
+// 真实业务工具（draft_save / browser_*）在 M1 #26 / #27 加。
+
+import { z } from "zod";
+import type { OpenTradTool } from "./index";
+
+const InputSchema = z.object({
+  message: z.string().describe("要 echo 回去的字符串"),
+});
+
+export const echoTool: OpenTradTool = {
+  name: "echo",
+  description:
+    "Echo back the input message. Useful for verifying the OpenTrad MCP server is reachable.",
+  inputSchema: InputSchema,
+  riskLevel: "safe",
+  category: "utility",
+  async execute(rawInput) {
+    const input = InputSchema.parse(rawInput);
+    return [{ type: "text", text: `OpenTrad echo: ${input.message}` }];
+  },
+};

--- a/apps/mcp-server/src/tools/index.ts
+++ b/apps/mcp-server/src/tools/index.ts
@@ -1,0 +1,36 @@
+// Tool 注册框架（M1 #25）。OpenTradTool 接口扩展 MCP SDK 标准 Tool 定义，
+// 加 OpenTrad 自己的 riskLevel + category 元数据。
+//
+// M1 范围：仅 echo（safe 类）。后续 M1 #26 加 draft_save / hs_code_lookup /
+// session_get_metadata；M1 #27 加 browser_open / browser_read / browser_screenshot。
+
+import type { z } from "zod";
+import type { IpcBridgeClient } from "../ipc-bridge";
+
+// 调用 tool.execute 时的上下文
+export interface ToolContext {
+  bridge: IpcBridgeClient;
+  sessionId: string;
+}
+
+// MCP 协议返回的 content。M1 只用 text；后续 M1 #27 browser_screenshot 加 image。
+export type ToolContent = { type: "text"; text: string };
+
+export interface OpenTradTool {
+  name: string;
+  description: string;
+  // zod schema 描述 input，会被 zodToJsonSchema 转成 MCP SDK 的 inputSchema
+  inputSchema: z.ZodTypeAny;
+  riskLevel: "safe" | "review" | "blocked";
+  category: "browser" | "platform" | "drafts" | "utility";
+  execute(input: unknown, ctx: ToolContext): Promise<ToolContent[]>;
+}
+
+// 工具集合：M1 仅 echo。新增工具时 import + 加进数组。
+import { echoTool } from "./echo";
+
+export const tools: OpenTradTool[] = [echoTool];
+
+export function getToolByName(name: string): OpenTradTool | undefined {
+  return tools.find((t) => t.name === name);
+}

--- a/apps/mcp-server/tests/ipc-bridge-client.test.ts
+++ b/apps/mcp-server/tests/ipc-bridge-client.test.ts
@@ -1,0 +1,186 @@
+// IpcBridgeClient 测试。
+// 重点 1：graceful degrade（offline 时 risk-gate 返 deny / audit.log 进 buffer / 其他 throw）
+// 重点 2：正常路径用 fake net server 验证 hello frame + RPC 回复
+
+import { mkdtempSync, rmSync } from "node:fs";
+import * as net from "node:net";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { IPC_BRIDGE_PROTOCOL_VERSION, IpcBridgeMethods } from "@opentrad/shared";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { IpcBridgeClient, IpcBridgeOfflineError } from "../src/ipc-bridge";
+
+describe("IpcBridgeClient — graceful degrade（连不上 socket）", () => {
+  it("connect 失败后进入 offline 模式，risk-gate.request 返回 deny", async () => {
+    const client = new IpcBridgeClient({
+      socketPath: "/nonexistent/sock-path",
+      sessionId: "s1",
+      mcpServerPid: process.pid,
+    });
+    await client.connect();
+    expect(client.isOffline).toBe(true);
+    expect(client.isConnected).toBe(false);
+
+    const decision = await client.riskGateRequest({
+      skillId: "x",
+      toolName: "echo",
+      params: {},
+      riskLevel: "safe",
+    });
+    expect(decision.decision).toBe("deny");
+    expect(decision.reason).toMatch(/offline/i);
+  });
+
+  it("offline 时 audit.log 不抛，进 buffer", async () => {
+    const client = new IpcBridgeClient({
+      socketPath: "/nonexistent/sock",
+      sessionId: "s1",
+      mcpServerPid: process.pid,
+    });
+    await client.connect();
+    await expect(
+      client.auditLog({
+        sessionId: "s1",
+        toolName: "echo",
+        decision: "allow",
+        automated: true,
+      }),
+    ).resolves.toBeUndefined();
+  });
+
+  it("offline 时 draft.save 抛 IpcBridgeOfflineError", async () => {
+    const client = new IpcBridgeClient({
+      socketPath: "/nonexistent/sock",
+      sessionId: "s1",
+      mcpServerPid: process.pid,
+    });
+    await client.connect();
+    await expect(client.draftSave({ filename: "x.md", content: "..." })).rejects.toBeInstanceOf(
+      IpcBridgeOfflineError,
+    );
+  });
+
+  it("offline 时 session.metadata 抛 IpcBridgeOfflineError", async () => {
+    const client = new IpcBridgeClient({
+      socketPath: "/nonexistent/sock",
+      sessionId: "s1",
+      mcpServerPid: process.pid,
+    });
+    await client.connect();
+    await expect(client.sessionMetadata({ sessionId: "s1" })).rejects.toBeInstanceOf(
+      IpcBridgeOfflineError,
+    );
+  });
+});
+
+describe("IpcBridgeClient — 正常路径（fake net server）", () => {
+  let tempDir: string;
+  let socketPath: string;
+  let server: net.Server;
+  let receivedHello: { sessionId?: string; protocolVersion?: number } = {};
+
+  beforeEach(async () => {
+    tempDir = mkdtempSync(join(tmpdir(), "opentrad-bridge-client-"));
+    socketPath = join(tempDir, "ipc.sock");
+    receivedHello = {};
+
+    server = net.createServer((socket) => {
+      socket.setEncoding("utf-8");
+      let buffer = "";
+      socket.on("data", (chunk: string) => {
+        buffer += chunk;
+        let nl = buffer.indexOf("\n");
+        while (nl !== -1) {
+          const line = buffer.slice(0, nl).trim();
+          buffer = buffer.slice(nl + 1);
+          if (!line) {
+            nl = buffer.indexOf("\n");
+            continue;
+          }
+          const msg = JSON.parse(line);
+          if (msg.method === IpcBridgeMethods.Hello) {
+            receivedHello = {
+              sessionId: msg.params?.sessionId,
+              protocolVersion: msg.params?.protocolVersion,
+            };
+            // hello 是 notification，不回复
+          } else if (msg.method === IpcBridgeMethods.RiskGateRequest) {
+            socket.write(
+              `${JSON.stringify({
+                jsonrpc: "2.0",
+                id: msg.id,
+                result: { decision: "allow", timestamp: 12345 },
+              })}\n`,
+            );
+          } else if (msg.method === IpcBridgeMethods.AuditLog) {
+            socket.write(`${JSON.stringify({ jsonrpc: "2.0", id: msg.id, result: null })}\n`);
+          }
+          nl = buffer.indexOf("\n");
+        }
+      });
+    });
+
+    await new Promise<void>((resolve) => server.listen(socketPath, () => resolve()));
+  });
+
+  afterEach(async () => {
+    await new Promise<void>((resolve) => server.close(() => resolve()));
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it("connect 后立即发 hello frame（含 sessionId / protocolVersion）", async () => {
+    const client = new IpcBridgeClient({
+      socketPath,
+      sessionId: "test-session-x",
+      mcpServerPid: process.pid,
+    });
+    await client.connect();
+    // 给 fake server 一拍读 hello
+    await sleep(30);
+    expect(client.isConnected).toBe(true);
+    expect(client.isOffline).toBe(false);
+    expect(receivedHello.sessionId).toBe("test-session-x");
+    expect(receivedHello.protocolVersion).toBe(IPC_BRIDGE_PROTOCOL_VERSION);
+    client.close();
+  });
+
+  it("riskGateRequest 路由到 server，返回 server 的 decision", async () => {
+    const client = new IpcBridgeClient({
+      socketPath,
+      sessionId: "s",
+      mcpServerPid: process.pid,
+    });
+    await client.connect();
+    const decision = await client.riskGateRequest({
+      skillId: "x",
+      toolName: "echo",
+      params: { msg: "hi" },
+      riskLevel: "safe",
+    });
+    expect(decision.decision).toBe("allow");
+    expect(decision.timestamp).toBe(12345);
+    client.close();
+  });
+
+  it("auditLog 在线时正常 RPC（不进 buffer）", async () => {
+    const client = new IpcBridgeClient({
+      socketPath,
+      sessionId: "s",
+      mcpServerPid: process.pid,
+    });
+    await client.connect();
+    await expect(
+      client.auditLog({
+        sessionId: "s",
+        toolName: "echo",
+        decision: "allow",
+        automated: true,
+      }),
+    ).resolves.toBeUndefined();
+    client.close();
+  });
+});
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}

--- a/apps/mcp-server/tests/ipc-bridge-client.test.ts
+++ b/apps/mcp-server/tests/ipc-bridge-client.test.ts
@@ -81,7 +81,7 @@ describe("IpcBridgeClient — 正常路径（fake net server）", () => {
 
   beforeEach(async () => {
     tempDir = mkdtempSync(join(tmpdir(), "opentrad-bridge-client-"));
-    socketPath = join(tempDir, "ipc.sock");
+    socketPath = makeTestSocketPath(tempDir);
     receivedHello = {};
 
     server = net.createServer((socket) => {
@@ -183,4 +183,13 @@ describe("IpcBridgeClient — 正常路径（fake net server）", () => {
 
 function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+// 跨平台测试 socket 路径：Unix 用 tempDir/ipc.sock；Windows 用 named pipe
+// （\\.\pipe\<name>，不在文件系统）。production 路径在 db/paths.ts 同款分支。
+function makeTestSocketPath(tempDir: string): string {
+  if (process.platform === "win32") {
+    return `\\\\.\\pipe\\opentrad-test-client-${process.pid}-${Date.now()}`;
+  }
+  return join(tempDir, "ipc.sock");
 }

--- a/apps/mcp-server/tests/tools.test.ts
+++ b/apps/mcp-server/tests/tools.test.ts
@@ -1,0 +1,42 @@
+// Tools 注册框架 + echo tool 测试。
+
+import { describe, expect, it } from "vitest";
+import { getToolByName, tools } from "../src/tools";
+import { echoTool } from "../src/tools/echo";
+
+describe("tools registry", () => {
+  it("echo 在 tools 列表里，name / riskLevel / category 正确", () => {
+    const echo = getToolByName("echo");
+    expect(echo).toBe(echoTool);
+    expect(echo?.name).toBe("echo");
+    expect(echo?.riskLevel).toBe("safe");
+    expect(echo?.category).toBe("utility");
+  });
+
+  it("getToolByName 不存在的工具返回 undefined", () => {
+    expect(getToolByName("nonexistent")).toBeUndefined();
+  });
+
+  it("M1 仅注册 echo（其他工具留 #26 / #27）", () => {
+    expect(tools).toHaveLength(1);
+    expect(tools[0]?.name).toBe("echo");
+  });
+});
+
+describe("echo tool", () => {
+  // ctx 不会被 echo 用到（safe 工具不调 IPC bridge）；用 minimal stub
+  const fakeCtx = { bridge: {} as never, sessionId: "test" };
+
+  it("正确 echo 输入字符串", async () => {
+    const result = await echoTool.execute({ message: "hello world" }, fakeCtx);
+    expect(result).toEqual([{ type: "text", text: "OpenTrad echo: hello world" }]);
+  });
+
+  it("zod 校验：缺 message 抛错", async () => {
+    await expect(echoTool.execute({}, fakeCtx)).rejects.toThrow();
+  });
+
+  it("zod 校验：message 类型错抛错", async () => {
+    await expect(echoTool.execute({ message: 123 }, fakeCtx)).rejects.toThrow();
+  });
+});

--- a/apps/mcp-server/vitest.config.ts
+++ b/apps/mcp-server/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    include: ["tests/**/*.test.ts"],
+  },
+});

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -10,6 +10,7 @@ export * from "./types/cc-event";
 export * from "./types/cc-task";
 export * from "./types/db";
 export * from "./types/ipc";
+export * from "./types/ipc-bridge";
 export * from "./types/pty";
 export * from "./types/risk-gate";
 export * from "./types/skill";

--- a/packages/shared/src/types/ipc-bridge.ts
+++ b/packages/shared/src/types/ipc-bridge.ts
@@ -1,0 +1,140 @@
+// IPC bridge wire protocol（M1 #25 / open-trad/opentrad#25）。
+// Desktop 主进程 ↔ apps/mcp-server 之间的 RPC 通道。
+//
+// 传输：Unix domain socket（macOS/Linux）/ named pipe（Windows）+ NDJSON
+// 协议：JSON-RPC 2.0
+//
+// 握手：client connect 后立即发送 Hello notification（method = "$/hello"），
+// 携带 sessionId / mcpServerPid / protocolVersion。Server 用 sessionId 路由。
+// 决策来源：M1 §三 Multi-session 协议留口（B 拍板，详见 issue #25 body 开工前对齐）。
+//
+// 4 个 RPC 方法（M1 mock + 真实分阶段，见 issue body）：
+// - $/hello                  notification（无回复）。client → server，第一帧。
+// - risk-gate.request        request。M1 mock 返回 allow；真实在 M1 #11 / #28
+// - audit.log                request（fire-and-forget 也可，但用 request 让 client 知道写成功）
+// - draft.save               request
+// - session.metadata         request
+
+import { z } from "zod";
+import { AuditLogAppendInputSchema } from "./db";
+import { SessionMetaSchema } from "./ipc";
+import { RiskGateDecisionSchema, RiskGateRequestSchema } from "./risk-gate";
+
+// 协议版本：M1 = 1。M3 如有破坏性变更升 2 + 需 server 协商兼容版本。
+export const IPC_BRIDGE_PROTOCOL_VERSION = 1;
+
+// 跨平台 socket / named pipe 路径（统一接口）。
+// macOS / Linux：Unix domain socket，~/.opentrad/ipc.sock
+// Windows：named pipe，\\.\pipe\opentrad-ipc
+
+export const IpcBridgeMethods = {
+  Hello: "$/hello",
+  RiskGateRequest: "risk-gate.request",
+  AuditLog: "audit.log",
+  DraftSave: "draft.save",
+  SessionMetadata: "session.metadata",
+} as const;
+
+export type IpcBridgeMethod = (typeof IpcBridgeMethods)[keyof typeof IpcBridgeMethods];
+
+// -------- $/hello（client → server，notification） --------
+
+export const IpcBridgeHelloParamsSchema = z.object({
+  sessionId: z.string(),
+  mcpServerPid: z.number().int(),
+  protocolVersion: z.number().int(),
+});
+
+export type IpcBridgeHelloParams = z.infer<typeof IpcBridgeHelloParamsSchema>;
+
+// -------- risk-gate.request --------
+// 复用 risk-gate.ts schema。M1 mock 总是返回 allow（在 server handler 做）。
+
+export const RiskGateRpcParamsSchema = RiskGateRequestSchema;
+export type RiskGateRpcParams = z.infer<typeof RiskGateRpcParamsSchema>;
+
+export const RiskGateRpcResultSchema = RiskGateDecisionSchema;
+export type RiskGateRpcResult = z.infer<typeof RiskGateRpcResultSchema>;
+
+// -------- audit.log --------
+// 复用 db.ts AuditLogAppendInput。返回 void。
+
+export const AuditLogRpcParamsSchema = AuditLogAppendInputSchema;
+export type AuditLogRpcParams = z.infer<typeof AuditLogRpcParamsSchema>;
+
+// -------- draft.save --------
+// 把 skill 生成的草稿写到 ~/.opentrad/drafts/{date}-{filename}.md。
+// content 是 markdown 文本；filename 不含日期前缀（server 自动加）。
+
+export const DraftSaveRpcParamsSchema = z.object({
+  filename: z.string().min(1),
+  content: z.string(),
+});
+
+export type DraftSaveRpcParams = z.infer<typeof DraftSaveRpcParamsSchema>;
+
+export const DraftSaveRpcResultSchema = z.object({
+  path: z.string(), // 写入的绝对路径
+});
+
+export type DraftSaveRpcResult = z.infer<typeof DraftSaveRpcResultSchema>;
+
+// -------- session.metadata --------
+// 输入 sessionId，返回 SessionMeta（精简视图，不暴露 ccSessionPath 等内部字段）。
+// 不存在时返回 null。
+
+export const SessionMetadataRpcParamsSchema = z.object({
+  sessionId: z.string(),
+});
+
+export type SessionMetadataRpcParams = z.infer<typeof SessionMetadataRpcParamsSchema>;
+
+export const SessionMetadataRpcResultSchema = SessionMetaSchema.nullable();
+export type SessionMetadataRpcResult = z.infer<typeof SessionMetadataRpcResultSchema>;
+
+// -------- JSON-RPC 2.0 envelope schemas --------
+// 简化版：M1 仅识别 notification / request / response / error 四种基本形态。
+
+export const JsonRpcRequestSchema = z.object({
+  jsonrpc: z.literal("2.0"),
+  id: z.union([z.number(), z.string()]),
+  method: z.string(),
+  params: z.unknown().optional(),
+});
+
+export type JsonRpcRequest = z.infer<typeof JsonRpcRequestSchema>;
+
+export const JsonRpcNotificationSchema = z.object({
+  jsonrpc: z.literal("2.0"),
+  method: z.string(),
+  params: z.unknown().optional(),
+});
+
+export type JsonRpcNotification = z.infer<typeof JsonRpcNotificationSchema>;
+
+export const JsonRpcResponseSchema = z.object({
+  jsonrpc: z.literal("2.0"),
+  id: z.union([z.number(), z.string()]),
+  result: z.unknown().optional(),
+  error: z
+    .object({
+      code: z.number().int(),
+      message: z.string(),
+      data: z.unknown().optional(),
+    })
+    .optional(),
+});
+
+export type JsonRpcResponse = z.infer<typeof JsonRpcResponseSchema>;
+
+// JSON-RPC 2.0 标准错误码。
+export const JsonRpcErrorCode = {
+  ParseError: -32700,
+  InvalidRequest: -32600,
+  MethodNotFound: -32601,
+  InvalidParams: -32602,
+  InternalError: -32603,
+  // OpenTrad 自定义错误（-32000 ~ -32099 是 server-defined application 错误段）
+  HandshakeRequired: -32001, // 客户端在 hello 之前发了 RPC
+  HandshakeProtocolMismatch: -32002, // protocolVersion 不兼容
+} as const;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -91,7 +91,18 @@ importers:
         specifier: ^8.0.10
         version: 8.0.10(@types/node@25.6.0)(esbuild@0.27.7)(tsx@4.21.0)
 
-  apps/mcp-server: {}
+  apps/mcp-server:
+    dependencies:
+      '@modelcontextprotocol/sdk':
+        specifier: ^1.29.0
+        version: 1.29.0(zod@4.3.6)
+      zod:
+        specifier: ^4.3.6
+        version: 4.3.6
+    devDependencies:
+      '@opentrad/shared':
+        specifier: workspace:^
+        version: link:../../packages/shared
 
   packages/browser-tools: {}
 
@@ -585,6 +596,12 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@hono/node-server@1.19.14':
+    resolution: {integrity: sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==}
+    engines: {node: '>=18.14.1'}
+    peerDependencies:
+      hono: ^4
+
   '@isaacs/fs-minipass@4.0.1':
     resolution: {integrity: sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==}
     engines: {node: '>=18.0.0'}
@@ -608,6 +625,16 @@ packages:
   '@malept/cross-spawn-promise@2.0.0':
     resolution: {integrity: sha512-1DpKU0Z5ThltBwjNySMC14g0CkbyhCaz9FkhxqNsZI6uAPJXFS8cMXlBKo26FJ8ZuW6S9GCMcR9IO5k2X5/9Fg==}
     engines: {node: '>= 12.13.0'}
+
+  '@modelcontextprotocol/sdk@1.29.0':
+    resolution: {integrity: sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@cfworker/json-schema': ^4.1.1
+      zod: ^3.25 || ^4.0
+    peerDependenciesMeta:
+      '@cfworker/json-schema':
+        optional: true
 
   '@napi-rs/wasm-runtime@1.1.4':
     resolution: {integrity: sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==}
@@ -823,6 +850,21 @@ packages:
     resolution: {integrity: sha512-a1wflyaL0tHtJSmLSOVybYhy22vRih4eduhhrkcjgrWGnRfrZtovJ2FRjxuTtkkj47O/baf0R86QU5OuYpz8fA==}
     engines: {node: ^20.17.0 || >=22.9.0}
 
+  accepts@2.0.0:
+    resolution: {integrity: sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==}
+    engines: {node: '>= 0.6'}
+
+  ajv-formats@3.0.1:
+    resolution: {integrity: sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==}
+    peerDependencies:
+      ajv: ^8.0.0
+    peerDependenciesMeta:
+      ajv:
+        optional: true
+
+  ajv@8.20.0:
+    resolution: {integrity: sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==}
+
   assertion-error@2.0.1:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
     engines: {node: '>=12'}
@@ -845,6 +887,10 @@ packages:
   bl@4.1.0:
     resolution: {integrity: sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==}
 
+  body-parser@2.2.2:
+    resolution: {integrity: sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==}
+    engines: {node: '>=18'}
+
   boolean@3.2.0:
     resolution: {integrity: sha512-d0II/GO9uf9lfUHH2BQsjxzRJZBdsjgsBiW4BvhWk/3qoKwQFjIDVN19PfX8F2D/r9PCMTtLWjYVCFrpeYUzsw==}
     deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
@@ -860,6 +906,10 @@ packages:
   buffer@5.7.1:
     resolution: {integrity: sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==}
 
+  bytes@3.1.2:
+    resolution: {integrity: sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==}
+    engines: {node: '>= 0.8'}
+
   cac@6.7.14:
     resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
     engines: {node: '>=8'}
@@ -871,6 +921,14 @@ packages:
   cacheable-request@7.0.4:
     resolution: {integrity: sha512-v+p6ongsrp0yTGbJXjgxPow2+DL93DASP4kXCDKb8/bwRtt9OEF3whggkkDkGNzgcWy2XaF4a8nZglC7uElscg==}
     engines: {node: '>=8'}
+
+  call-bind-apply-helpers@1.0.2:
+    resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
+    engines: {node: '>= 0.4'}
+
+  call-bound@1.0.4:
+    resolution: {integrity: sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==}
+    engines: {node: '>= 0.4'}
 
   caniuse-lite@1.0.30001790:
     resolution: {integrity: sha512-bOoxfJPyYo+ds6W0YfptaCWbFnJYjh2Y1Eow5lRv+vI2u8ganPZqNm1JwNh0t2ELQCqIWg4B3dWEusgAmsoyOw==}
@@ -889,8 +947,28 @@ packages:
   clone-response@1.0.3:
     resolution: {integrity: sha512-ROoL94jJH2dUVML2Y/5PEDNaSHgeOdSDicUyS7izcF63G6sTc/FTjLub4b8Il9S8S0beOfYt0TaA5qvFK+w0wA==}
 
+  content-disposition@1.1.0:
+    resolution: {integrity: sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==}
+    engines: {node: '>=18'}
+
+  content-type@1.0.5:
+    resolution: {integrity: sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==}
+    engines: {node: '>= 0.6'}
+
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
+
+  cookie-signature@1.2.2:
+    resolution: {integrity: sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==}
+    engines: {node: '>=6.6.0'}
+
+  cookie@0.7.2:
+    resolution: {integrity: sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==}
+    engines: {node: '>= 0.6'}
+
+  cors@2.8.6:
+    resolution: {integrity: sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==}
+    engines: {node: '>= 0.10'}
 
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
@@ -928,12 +1006,23 @@ packages:
     resolution: {integrity: sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==}
     engines: {node: '>= 0.4'}
 
+  depd@2.0.0:
+    resolution: {integrity: sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==}
+    engines: {node: '>= 0.8'}
+
   detect-libc@2.1.2:
     resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
     engines: {node: '>=8'}
 
   detect-node@2.1.0:
     resolution: {integrity: sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g==}
+
+  dunder-proto@1.0.1:
+    resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
+    engines: {node: '>= 0.4'}
+
+  ee-first@1.1.1:
+    resolution: {integrity: sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==}
 
   electron-to-chromium@1.5.344:
     resolution: {integrity: sha512-4MxfbmNDm+KPh066EZy+eUnkcDPcZ35wNmOWzFuh/ijvHsve6kbLTLURy88uCNK5FbpN+yk2nQY6BYh1GEt+wg==}
@@ -954,6 +1043,10 @@ packages:
     engines: {node: '>= 12.20.55'}
     hasBin: true
 
+  encodeurl@2.0.0:
+    resolution: {integrity: sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==}
+    engines: {node: '>= 0.8'}
+
   end-of-stream@1.4.5:
     resolution: {integrity: sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==}
 
@@ -972,6 +1065,10 @@ packages:
   es-module-lexer@2.0.0:
     resolution: {integrity: sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==}
 
+  es-object-atoms@1.1.1:
+    resolution: {integrity: sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==}
+    engines: {node: '>= 0.4'}
+
   es6-error@4.1.1:
     resolution: {integrity: sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg==}
 
@@ -989,12 +1086,27 @@ packages:
     resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
     engines: {node: '>=6'}
 
+  escape-html@1.0.3:
+    resolution: {integrity: sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==}
+
   escape-string-regexp@4.0.0:
     resolution: {integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==}
     engines: {node: '>=10'}
 
   estree-walker@3.0.3:
     resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
+
+  etag@1.8.1:
+    resolution: {integrity: sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==}
+    engines: {node: '>= 0.6'}
+
+  eventsource-parser@3.0.8:
+    resolution: {integrity: sha512-70QWGkr4snxr0OXLRWsFLeRBIRPuQOvt4s8QYjmUlmlkyTZkRqS7EDVRZtzU3TiyDbXSzaOeF0XUKy8PchzukQ==}
+    engines: {node: '>=18.0.0'}
+
+  eventsource@3.0.7:
+    resolution: {integrity: sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==}
+    engines: {node: '>=18.0.0'}
 
   expand-template@2.0.3:
     resolution: {integrity: sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==}
@@ -1007,10 +1119,26 @@ packages:
   exponential-backoff@3.1.3:
     resolution: {integrity: sha512-ZgEeZXj30q+I0EN+CbSSpIyPaJ5HVQD18Z1m+u1FXbAeT94mr1zw50q4q6jiiC447Nl/YTcIYSAftiGqetwXCA==}
 
+  express-rate-limit@8.4.1:
+    resolution: {integrity: sha512-NGVYwQSAyEQgzxX1iCM978PP9AdO/hW93gMcF6ZwQCm+rFvLsBH6w4xcXWTcliS8La5EPRN3p9wzItqBwJrfNw==}
+    engines: {node: '>= 16'}
+    peerDependencies:
+      express: '>= 4.11'
+
+  express@5.2.1:
+    resolution: {integrity: sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==}
+    engines: {node: '>= 18'}
+
   extract-zip@2.0.1:
     resolution: {integrity: sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==}
     engines: {node: '>= 10.17.0'}
     hasBin: true
+
+  fast-deep-equal@3.1.3:
+    resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
+
+  fast-uri@3.1.0:
+    resolution: {integrity: sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==}
 
   fd-slicer@1.1.0:
     resolution: {integrity: sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==}
@@ -1027,6 +1155,18 @@ packages:
   file-uri-to-path@1.0.0:
     resolution: {integrity: sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==}
 
+  finalhandler@2.1.1:
+    resolution: {integrity: sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==}
+    engines: {node: '>= 18.0.0'}
+
+  forwarded@0.2.0:
+    resolution: {integrity: sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==}
+    engines: {node: '>= 0.6'}
+
+  fresh@2.0.0:
+    resolution: {integrity: sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==}
+    engines: {node: '>= 0.8'}
+
   fs-constants@1.0.0:
     resolution: {integrity: sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==}
 
@@ -1039,9 +1179,20 @@ packages:
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
     os: [darwin]
 
+  function-bind@1.1.2:
+    resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
+
   gensync@1.0.0-beta.2:
     resolution: {integrity: sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==}
     engines: {node: '>=6.9.0'}
+
+  get-intrinsic@1.3.0:
+    resolution: {integrity: sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==}
+    engines: {node: '>= 0.4'}
+
+  get-proto@1.0.1:
+    resolution: {integrity: sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==}
+    engines: {node: '>= 0.4'}
 
   get-stream@5.2.0:
     resolution: {integrity: sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==}
@@ -1075,12 +1226,32 @@ packages:
   has-property-descriptors@1.0.2:
     resolution: {integrity: sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==}
 
+  has-symbols@1.1.0:
+    resolution: {integrity: sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==}
+    engines: {node: '>= 0.4'}
+
+  hasown@2.0.3:
+    resolution: {integrity: sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==}
+    engines: {node: '>= 0.4'}
+
+  hono@4.12.15:
+    resolution: {integrity: sha512-qM0jDhFEaCBb4TxoW7f53Qrpv9RBiayUHo0S52JudprkhvpjIrGoU1mnnr29Fvd1U335ZFPZQY1wlkqgfGXyLg==}
+    engines: {node: '>=16.9.0'}
+
   http-cache-semantics@4.2.0:
     resolution: {integrity: sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ==}
+
+  http-errors@2.0.1:
+    resolution: {integrity: sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==}
+    engines: {node: '>= 0.8'}
 
   http2-wrapper@1.0.3:
     resolution: {integrity: sha512-V+23sDMr12Wnz7iTcDeJr3O6AIxlnvT/bmaAAAP/Xda35C90p9599p0F1eHR/N1KILWSoWVAiOMFjBBXaXSMxg==}
     engines: {node: '>=10.19.0'}
+
+  iconv-lite@0.7.2:
+    resolution: {integrity: sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==}
+    engines: {node: '>=0.10.0'}
 
   ieee754@1.2.1:
     resolution: {integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==}
@@ -1091,12 +1262,26 @@ packages:
   ini@1.3.8:
     resolution: {integrity: sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==}
 
+  ip-address@10.1.0:
+    resolution: {integrity: sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==}
+    engines: {node: '>= 12'}
+
+  ipaddr.js@1.9.1:
+    resolution: {integrity: sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==}
+    engines: {node: '>= 0.10'}
+
+  is-promise@4.0.0:
+    resolution: {integrity: sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==}
+
   isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
 
   isexe@4.0.0:
     resolution: {integrity: sha512-FFUtZMpoZ8RqHS3XeXEmHWLA4thH+ZxCv2lOiPIn1Xc7CxrqhWzNSDzD+/chS/zbYezmiwWLdQC09JdQKmthOw==}
     engines: {node: '>=20'}
+
+  jose@6.2.2:
+    resolution: {integrity: sha512-d7kPDd34KO/YnzaDOlikGpOurfF0ByC2sEV4cANCtdqLlTfBlw2p14O/5d/zv40gJPbIQxfES3nSx1/oYNyuZQ==}
 
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
@@ -1108,6 +1293,12 @@ packages:
 
   json-buffer@3.0.1:
     resolution: {integrity: sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==}
+
+  json-schema-traverse@1.0.0:
+    resolution: {integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==}
+
+  json-schema-typed@8.0.2:
+    resolution: {integrity: sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==}
 
   json-stringify-safe@5.0.1:
     resolution: {integrity: sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==}
@@ -1207,6 +1398,26 @@ packages:
     resolution: {integrity: sha512-OkeDaAZ/bQCxeFAozM55PKcKU0yJMPGifLwV4Qgjitu+5MoAfSQN4lsLJeXZ1b8w0x+/Emda6MZgXS1jvsapng==}
     engines: {node: '>=10'}
 
+  math-intrinsics@1.1.0:
+    resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
+    engines: {node: '>= 0.4'}
+
+  media-typer@1.1.0:
+    resolution: {integrity: sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==}
+    engines: {node: '>= 0.8'}
+
+  merge-descriptors@2.0.0:
+    resolution: {integrity: sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==}
+    engines: {node: '>=18'}
+
+  mime-db@1.54.0:
+    resolution: {integrity: sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==}
+    engines: {node: '>= 0.6'}
+
+  mime-types@3.0.2:
+    resolution: {integrity: sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==}
+    engines: {node: '>=18'}
+
   mimic-response@1.0.1:
     resolution: {integrity: sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ==}
     engines: {node: '>=4'}
@@ -1239,6 +1450,10 @@ packages:
 
   napi-build-utils@2.0.0:
     resolution: {integrity: sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==}
+
+  negotiator@1.0.0:
+    resolution: {integrity: sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==}
+    engines: {node: '>= 0.6'}
 
   node-abi@3.89.0:
     resolution: {integrity: sha512-6u9UwL0HlAl21+agMN3YAMXcKByMqwGx+pq+P76vii5f7hTPtKDp08/H9py6DY+cfDw7kQNTGEj/rly3IgbNQA==}
@@ -1274,12 +1489,24 @@ packages:
     resolution: {integrity: sha512-DlL+XwOy3NxAQ8xuC0okPgK46iuVNAK01YN7RueYBqqFeGsBjV9XmCAzAdgt+667bCl5kPh9EqKKDwnaPG1I7A==}
     engines: {node: '>=10'}
 
+  object-assign@4.1.1:
+    resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
+    engines: {node: '>=0.10.0'}
+
+  object-inspect@1.13.4:
+    resolution: {integrity: sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==}
+    engines: {node: '>= 0.4'}
+
   object-keys@1.1.1:
     resolution: {integrity: sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==}
     engines: {node: '>= 0.4'}
 
   obug@2.1.1:
     resolution: {integrity: sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==}
+
+  on-finished@2.4.1:
+    resolution: {integrity: sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==}
+    engines: {node: '>= 0.8'}
 
   once@1.4.0:
     resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
@@ -1288,9 +1515,16 @@ packages:
     resolution: {integrity: sha512-BZOr3nRQHOntUjTrH8+Lh54smKHoHyur8We1V8DSMVrl5A2malOOwuJRnKRDjSnkoeBh4at6BwEnb5I7Jl31wg==}
     engines: {node: '>=8'}
 
+  parseurl@1.3.3:
+    resolution: {integrity: sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==}
+    engines: {node: '>= 0.8'}
+
   path-key@3.1.1:
     resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
     engines: {node: '>=8'}
+
+  path-to-regexp@8.4.2:
+    resolution: {integrity: sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==}
 
   pathe@2.0.3:
     resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
@@ -1304,6 +1538,10 @@ packages:
   picomatch@4.0.4:
     resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
     engines: {node: '>=12'}
+
+  pkce-challenge@5.0.1:
+    resolution: {integrity: sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==}
+    engines: {node: '>=16.20.0'}
 
   postcss@8.5.10:
     resolution: {integrity: sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==}
@@ -1323,12 +1561,28 @@ packages:
     resolution: {integrity: sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==}
     engines: {node: '>=0.4.0'}
 
+  proxy-addr@2.0.7:
+    resolution: {integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==}
+    engines: {node: '>= 0.10'}
+
   pump@3.0.4:
     resolution: {integrity: sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==}
+
+  qs@6.15.1:
+    resolution: {integrity: sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==}
+    engines: {node: '>=0.6'}
 
   quick-lru@5.1.1:
     resolution: {integrity: sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==}
     engines: {node: '>=10'}
+
+  range-parser@1.2.1:
+    resolution: {integrity: sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==}
+    engines: {node: '>= 0.6'}
+
+  raw-body@3.0.2:
+    resolution: {integrity: sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==}
+    engines: {node: '>= 0.10'}
 
   rc@1.2.8:
     resolution: {integrity: sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==}
@@ -1351,6 +1605,10 @@ packages:
     resolution: {integrity: sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==}
     engines: {node: '>= 6'}
 
+  require-from-string@2.0.2:
+    resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
+    engines: {node: '>=0.10.0'}
+
   resolve-alpn@1.2.1:
     resolution: {integrity: sha512-0a1F4l73/ZFZOakJnQ3FvkJ2+gSTQWz/r2KE5OdDY0TxPm5h4GkqkWWfM47T7HsbnOtcJVEF4epCVy6u7Q3K+g==}
 
@@ -1369,8 +1627,15 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
 
+  router@2.2.0:
+    resolution: {integrity: sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==}
+    engines: {node: '>= 18'}
+
   safe-buffer@5.2.1:
     resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
+
+  safer-buffer@2.1.2:
+    resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
 
   scheduler@0.27.0:
     resolution: {integrity: sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==}
@@ -1387,9 +1652,20 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
 
+  send@1.2.1:
+    resolution: {integrity: sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==}
+    engines: {node: '>= 18'}
+
   serialize-error@7.0.1:
     resolution: {integrity: sha512-8I8TjW5KMOKsZQTvoxjuSIa7foAwPWGOts+6o7sgjz41/qMD9VQHEDxi6PBvK2l0MXUmqZyNpUK+T2tQaaElvw==}
     engines: {node: '>=10'}
+
+  serve-static@2.2.1:
+    resolution: {integrity: sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==}
+    engines: {node: '>= 18'}
+
+  setprototypeof@1.2.0:
+    resolution: {integrity: sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==}
 
   shebang-command@2.0.0:
     resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
@@ -1398,6 +1674,22 @@ packages:
   shebang-regex@3.0.0:
     resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
     engines: {node: '>=8'}
+
+  side-channel-list@1.0.1:
+    resolution: {integrity: sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==}
+    engines: {node: '>= 0.4'}
+
+  side-channel-map@1.0.1:
+    resolution: {integrity: sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==}
+    engines: {node: '>= 0.4'}
+
+  side-channel-weakmap@1.0.2:
+    resolution: {integrity: sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==}
+    engines: {node: '>= 0.4'}
+
+  side-channel@1.1.0:
+    resolution: {integrity: sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==}
+    engines: {node: '>= 0.4'}
 
   siginfo@2.0.0:
     resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
@@ -1417,6 +1709,10 @@ packages:
 
   stackback@0.0.2:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
+  statuses@2.0.2:
+    resolution: {integrity: sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==}
+    engines: {node: '>= 0.8'}
 
   std-env@4.1.0:
     resolution: {integrity: sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==}
@@ -1458,6 +1754,10 @@ packages:
     resolution: {integrity: sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==}
     engines: {node: '>=14.0.0'}
 
+  toidentifier@1.0.1:
+    resolution: {integrity: sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==}
+    engines: {node: '>=0.6'}
+
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
 
@@ -1472,6 +1772,10 @@ packages:
   type-fest@0.13.1:
     resolution: {integrity: sha512-34R7HTnG0XIJcBSn5XhDd7nNFPRcXYRZrBB2O2jdKqYODldSzBAqzsWoZYYvduky73toYS/ESqxPvkDf/F0XMg==}
     engines: {node: '>=10'}
+
+  type-is@2.0.1:
+    resolution: {integrity: sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==}
+    engines: {node: '>= 0.6'}
 
   typescript@5.9.3:
     resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
@@ -1492,6 +1796,10 @@ packages:
     resolution: {integrity: sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==}
     engines: {node: '>= 4.0.0'}
 
+  unpipe@1.0.0:
+    resolution: {integrity: sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==}
+    engines: {node: '>= 0.8'}
+
   update-browserslist-db@1.2.3:
     resolution: {integrity: sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==}
     hasBin: true
@@ -1500,6 +1808,10 @@ packages:
 
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
+
+  vary@1.1.2:
+    resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
+    engines: {node: '>= 0.8'}
 
   vite@8.0.10:
     resolution: {integrity: sha512-rZuUu9j6J5uotLDs+cAA4O5H4K1SfPliUlQwqa6YEwSrWDZzP4rhm00oJR5snMewjxF5V/K3D4kctsUTsIU9Mw==}
@@ -1612,6 +1924,11 @@ packages:
 
   yauzl@2.10.0:
     resolution: {integrity: sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==}
+
+  zod-to-json-schema@3.25.2:
+    resolution: {integrity: sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==}
+    peerDependencies:
+      zod: ^3.25.28 || ^4
 
   zod@4.3.6:
     resolution: {integrity: sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==}
@@ -1957,6 +2274,10 @@ snapshots:
   '@esbuild/win32-x64@0.27.7':
     optional: true
 
+  '@hono/node-server@1.19.14(hono@4.12.15)':
+    dependencies:
+      hono: 4.12.15
+
   '@isaacs/fs-minipass@4.0.1':
     dependencies:
       minipass: 7.1.3
@@ -1983,6 +2304,28 @@ snapshots:
   '@malept/cross-spawn-promise@2.0.0':
     dependencies:
       cross-spawn: 7.0.6
+
+  '@modelcontextprotocol/sdk@1.29.0(zod@4.3.6)':
+    dependencies:
+      '@hono/node-server': 1.19.14(hono@4.12.15)
+      ajv: 8.20.0
+      ajv-formats: 3.0.1(ajv@8.20.0)
+      content-type: 1.0.5
+      cors: 2.8.6
+      cross-spawn: 7.0.6
+      eventsource: 3.0.7
+      eventsource-parser: 3.0.8
+      express: 5.2.1
+      express-rate-limit: 8.4.1(express@5.2.1)
+      hono: 4.12.15
+      jose: 6.2.2
+      json-schema-typed: 8.0.2
+      pkce-challenge: 5.0.1
+      raw-body: 3.0.2
+      zod: 4.3.6
+      zod-to-json-schema: 3.25.2(zod@4.3.6)
+    transitivePeerDependencies:
+      - supports-color
 
   '@napi-rs/wasm-runtime@1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)':
     dependencies:
@@ -2164,6 +2507,22 @@ snapshots:
 
   abbrev@4.0.0: {}
 
+  accepts@2.0.0:
+    dependencies:
+      mime-types: 3.0.2
+      negotiator: 1.0.0
+
+  ajv-formats@3.0.1(ajv@8.20.0):
+    optionalDependencies:
+      ajv: 8.20.0
+
+  ajv@8.20.0:
+    dependencies:
+      fast-deep-equal: 3.1.3
+      fast-uri: 3.1.0
+      json-schema-traverse: 1.0.0
+      require-from-string: 2.0.2
+
   assertion-error@2.0.1: {}
 
   base64-js@1.5.1: {}
@@ -2185,6 +2544,20 @@ snapshots:
       inherits: 2.0.4
       readable-stream: 3.6.2
 
+  body-parser@2.2.2:
+    dependencies:
+      bytes: 3.1.2
+      content-type: 1.0.5
+      debug: 4.4.3
+      http-errors: 2.0.1
+      iconv-lite: 0.7.2
+      on-finished: 2.4.1
+      qs: 6.15.1
+      raw-body: 3.0.2
+      type-is: 2.0.1
+    transitivePeerDependencies:
+      - supports-color
+
   boolean@3.2.0:
     optional: true
 
@@ -2203,6 +2576,8 @@ snapshots:
       base64-js: 1.5.1
       ieee754: 1.2.1
 
+  bytes@3.1.2: {}
+
   cac@6.7.14: {}
 
   cacheable-lookup@5.0.4: {}
@@ -2217,6 +2592,16 @@ snapshots:
       normalize-url: 6.1.0
       responselike: 2.0.1
 
+  call-bind-apply-helpers@1.0.2:
+    dependencies:
+      es-errors: 1.3.0
+      function-bind: 1.1.2
+
+  call-bound@1.0.4:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      get-intrinsic: 1.3.0
+
   caniuse-lite@1.0.30001790: {}
 
   chai@6.2.2: {}
@@ -2229,7 +2614,20 @@ snapshots:
     dependencies:
       mimic-response: 1.0.1
 
+  content-disposition@1.1.0: {}
+
+  content-type@1.0.5: {}
+
   convert-source-map@2.0.0: {}
+
+  cookie-signature@1.2.2: {}
+
+  cookie@0.7.2: {}
+
+  cors@2.8.6:
+    dependencies:
+      object-assign: 4.1.1
+      vary: 1.1.2
 
   cross-spawn@7.0.6:
     dependencies:
@@ -2265,10 +2663,20 @@ snapshots:
       object-keys: 1.1.1
     optional: true
 
+  depd@2.0.0: {}
+
   detect-libc@2.1.2: {}
 
   detect-node@2.1.0:
     optional: true
+
+  dunder-proto@1.0.1:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      es-errors: 1.3.0
+      gopd: 1.2.0
+
+  ee-first@1.1.1: {}
 
   electron-to-chromium@1.5.344: {}
 
@@ -2292,19 +2700,23 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  encodeurl@2.0.0: {}
+
   end-of-stream@1.4.5:
     dependencies:
       once: 1.4.0
 
   env-paths@2.2.1: {}
 
-  es-define-property@1.0.1:
-    optional: true
+  es-define-property@1.0.1: {}
 
-  es-errors@1.3.0:
-    optional: true
+  es-errors@1.3.0: {}
 
   es-module-lexer@2.0.0: {}
+
+  es-object-atoms@1.1.1:
+    dependencies:
+      es-errors: 1.3.0
 
   es6-error@4.1.1:
     optional: true
@@ -2369,6 +2781,8 @@ snapshots:
 
   escalade@3.2.0: {}
 
+  escape-html@1.0.3: {}
+
   escape-string-regexp@4.0.0:
     optional: true
 
@@ -2376,11 +2790,57 @@ snapshots:
     dependencies:
       '@types/estree': 1.0.8
 
+  etag@1.8.1: {}
+
+  eventsource-parser@3.0.8: {}
+
+  eventsource@3.0.7:
+    dependencies:
+      eventsource-parser: 3.0.8
+
   expand-template@2.0.3: {}
 
   expect-type@1.3.0: {}
 
   exponential-backoff@3.1.3: {}
+
+  express-rate-limit@8.4.1(express@5.2.1):
+    dependencies:
+      express: 5.2.1
+      ip-address: 10.1.0
+
+  express@5.2.1:
+    dependencies:
+      accepts: 2.0.0
+      body-parser: 2.2.2
+      content-disposition: 1.1.0
+      content-type: 1.0.5
+      cookie: 0.7.2
+      cookie-signature: 1.2.2
+      debug: 4.4.3
+      depd: 2.0.0
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      etag: 1.8.1
+      finalhandler: 2.1.1
+      fresh: 2.0.0
+      http-errors: 2.0.1
+      merge-descriptors: 2.0.0
+      mime-types: 3.0.2
+      on-finished: 2.4.1
+      once: 1.4.0
+      parseurl: 1.3.3
+      proxy-addr: 2.0.7
+      qs: 6.15.1
+      range-parser: 1.2.1
+      router: 2.2.0
+      send: 1.2.1
+      serve-static: 2.2.1
+      statuses: 2.0.2
+      type-is: 2.0.1
+      vary: 1.1.2
+    transitivePeerDependencies:
+      - supports-color
 
   extract-zip@2.0.1:
     dependencies:
@@ -2392,6 +2852,10 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  fast-deep-equal@3.1.3: {}
+
+  fast-uri@3.1.0: {}
+
   fd-slicer@1.1.0:
     dependencies:
       pend: 1.2.0
@@ -2401,6 +2865,21 @@ snapshots:
       picomatch: 4.0.4
 
   file-uri-to-path@1.0.0: {}
+
+  finalhandler@2.1.1:
+    dependencies:
+      debug: 4.4.3
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      on-finished: 2.4.1
+      parseurl: 1.3.3
+      statuses: 2.0.2
+    transitivePeerDependencies:
+      - supports-color
+
+  forwarded@0.2.0: {}
+
+  fresh@2.0.0: {}
 
   fs-constants@1.0.0: {}
 
@@ -2413,7 +2892,27 @@ snapshots:
   fsevents@2.3.3:
     optional: true
 
+  function-bind@1.1.2: {}
+
   gensync@1.0.0-beta.2: {}
+
+  get-intrinsic@1.3.0:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      es-define-property: 1.0.1
+      es-errors: 1.3.0
+      es-object-atoms: 1.1.1
+      function-bind: 1.1.2
+      get-proto: 1.0.1
+      gopd: 1.2.0
+      has-symbols: 1.1.0
+      hasown: 2.0.3
+      math-intrinsics: 1.1.0
+
+  get-proto@1.0.1:
+    dependencies:
+      dunder-proto: 1.0.1
+      es-object-atoms: 1.1.1
 
   get-stream@5.2.0:
     dependencies:
@@ -2441,8 +2940,7 @@ snapshots:
       gopd: 1.2.0
     optional: true
 
-  gopd@1.2.0:
-    optional: true
+  gopd@1.2.0: {}
 
   got@11.8.6:
     dependencies:
@@ -2465,12 +2963,32 @@ snapshots:
       es-define-property: 1.0.1
     optional: true
 
+  has-symbols@1.1.0: {}
+
+  hasown@2.0.3:
+    dependencies:
+      function-bind: 1.1.2
+
+  hono@4.12.15: {}
+
   http-cache-semantics@4.2.0: {}
+
+  http-errors@2.0.1:
+    dependencies:
+      depd: 2.0.0
+      inherits: 2.0.4
+      setprototypeof: 1.2.0
+      statuses: 2.0.2
+      toidentifier: 1.0.1
 
   http2-wrapper@1.0.3:
     dependencies:
       quick-lru: 5.1.1
       resolve-alpn: 1.2.1
+
+  iconv-lite@0.7.2:
+    dependencies:
+      safer-buffer: 2.1.2
 
   ieee754@1.2.1: {}
 
@@ -2478,15 +2996,27 @@ snapshots:
 
   ini@1.3.8: {}
 
+  ip-address@10.1.0: {}
+
+  ipaddr.js@1.9.1: {}
+
+  is-promise@4.0.0: {}
+
   isexe@2.0.0: {}
 
   isexe@4.0.0: {}
+
+  jose@6.2.2: {}
 
   js-tokens@4.0.0: {}
 
   jsesc@3.1.0: {}
 
   json-buffer@3.0.1: {}
+
+  json-schema-traverse@1.0.0: {}
+
+  json-schema-typed@8.0.2: {}
 
   json-stringify-safe@5.0.1:
     optional: true
@@ -2565,6 +3095,18 @@ snapshots:
       escape-string-regexp: 4.0.0
     optional: true
 
+  math-intrinsics@1.1.0: {}
+
+  media-typer@1.1.0: {}
+
+  merge-descriptors@2.0.0: {}
+
+  mime-db@1.54.0: {}
+
+  mime-types@3.0.2:
+    dependencies:
+      mime-db: 1.54.0
+
   mimic-response@1.0.1: {}
 
   mimic-response@3.1.0: {}
@@ -2584,6 +3126,8 @@ snapshots:
   nanoid@3.3.11: {}
 
   napi-build-utils@2.0.0: {}
+
+  negotiator@1.0.0: {}
 
   node-abi@3.89.0:
     dependencies:
@@ -2624,10 +3168,18 @@ snapshots:
 
   normalize-url@6.1.0: {}
 
+  object-assign@4.1.1: {}
+
+  object-inspect@1.13.4: {}
+
   object-keys@1.1.1:
     optional: true
 
   obug@2.1.1: {}
+
+  on-finished@2.4.1:
+    dependencies:
+      ee-first: 1.1.1
 
   once@1.4.0:
     dependencies:
@@ -2635,7 +3187,11 @@ snapshots:
 
   p-cancelable@2.1.1: {}
 
+  parseurl@1.3.3: {}
+
   path-key@3.1.1: {}
+
+  path-to-regexp@8.4.2: {}
 
   pathe@2.0.3: {}
 
@@ -2644,6 +3200,8 @@ snapshots:
   picocolors@1.1.1: {}
 
   picomatch@4.0.4: {}
+
+  pkce-challenge@5.0.1: {}
 
   postcss@8.5.10:
     dependencies:
@@ -2670,12 +3228,30 @@ snapshots:
 
   progress@2.0.3: {}
 
+  proxy-addr@2.0.7:
+    dependencies:
+      forwarded: 0.2.0
+      ipaddr.js: 1.9.1
+
   pump@3.0.4:
     dependencies:
       end-of-stream: 1.4.5
       once: 1.4.0
 
+  qs@6.15.1:
+    dependencies:
+      side-channel: 1.1.0
+
   quick-lru@5.1.1: {}
+
+  range-parser@1.2.1: {}
+
+  raw-body@3.0.2:
+    dependencies:
+      bytes: 3.1.2
+      http-errors: 2.0.1
+      iconv-lite: 0.7.2
+      unpipe: 1.0.0
 
   rc@1.2.8:
     dependencies:
@@ -2702,6 +3278,8 @@ snapshots:
       inherits: 2.0.4
       string_decoder: 1.3.0
       util-deprecate: 1.0.2
+
+  require-from-string@2.0.2: {}
 
   resolve-alpn@1.2.1: {}
 
@@ -2742,7 +3320,19 @@ snapshots:
       '@rolldown/binding-win32-arm64-msvc': 1.0.0-rc.17
       '@rolldown/binding-win32-x64-msvc': 1.0.0-rc.17
 
+  router@2.2.0:
+    dependencies:
+      debug: 4.4.3
+      depd: 2.0.0
+      is-promise: 4.0.0
+      parseurl: 1.3.3
+      path-to-regexp: 8.4.2
+    transitivePeerDependencies:
+      - supports-color
+
   safe-buffer@5.2.1: {}
+
+  safer-buffer@2.1.2: {}
 
   scheduler@0.27.0: {}
 
@@ -2753,16 +3343,71 @@ snapshots:
 
   semver@7.7.4: {}
 
+  send@1.2.1:
+    dependencies:
+      debug: 4.4.3
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      etag: 1.8.1
+      fresh: 2.0.0
+      http-errors: 2.0.1
+      mime-types: 3.0.2
+      ms: 2.1.3
+      on-finished: 2.4.1
+      range-parser: 1.2.1
+      statuses: 2.0.2
+    transitivePeerDependencies:
+      - supports-color
+
   serialize-error@7.0.1:
     dependencies:
       type-fest: 0.13.1
     optional: true
+
+  serve-static@2.2.1:
+    dependencies:
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      parseurl: 1.3.3
+      send: 1.2.1
+    transitivePeerDependencies:
+      - supports-color
+
+  setprototypeof@1.2.0: {}
 
   shebang-command@2.0.0:
     dependencies:
       shebang-regex: 3.0.0
 
   shebang-regex@3.0.0: {}
+
+  side-channel-list@1.0.1:
+    dependencies:
+      es-errors: 1.3.0
+      object-inspect: 1.13.4
+
+  side-channel-map@1.0.1:
+    dependencies:
+      call-bound: 1.0.4
+      es-errors: 1.3.0
+      get-intrinsic: 1.3.0
+      object-inspect: 1.13.4
+
+  side-channel-weakmap@1.0.2:
+    dependencies:
+      call-bound: 1.0.4
+      es-errors: 1.3.0
+      get-intrinsic: 1.3.0
+      object-inspect: 1.13.4
+      side-channel-map: 1.0.1
+
+  side-channel@1.1.0:
+    dependencies:
+      es-errors: 1.3.0
+      object-inspect: 1.13.4
+      side-channel-list: 1.0.1
+      side-channel-map: 1.0.1
+      side-channel-weakmap: 1.0.2
 
   siginfo@2.0.0: {}
 
@@ -2780,6 +3425,8 @@ snapshots:
     optional: true
 
   stackback@0.0.2: {}
+
+  statuses@2.0.2: {}
 
   std-env@4.1.0: {}
 
@@ -2829,6 +3476,8 @@ snapshots:
 
   tinyrainbow@3.1.0: {}
 
+  toidentifier@1.0.1: {}
+
   tslib@2.8.1:
     optional: true
 
@@ -2846,6 +3495,12 @@ snapshots:
   type-fest@0.13.1:
     optional: true
 
+  type-is@2.0.1:
+    dependencies:
+      content-type: 1.0.5
+      media-typer: 1.1.0
+      mime-types: 3.0.2
+
   typescript@5.9.3: {}
 
   undici-types@7.16.0: {}
@@ -2856,6 +3511,8 @@ snapshots:
 
   universalify@0.1.2: {}
 
+  unpipe@1.0.0: {}
+
   update-browserslist-db@1.2.3(browserslist@4.28.2):
     dependencies:
       browserslist: 4.28.2
@@ -2863,6 +3520,8 @@ snapshots:
       picocolors: 1.1.1
 
   util-deprecate@1.0.2: {}
+
+  vary@1.1.2: {}
 
   vite@8.0.10(@types/node@25.6.0)(esbuild@0.27.7)(tsx@4.21.0):
     dependencies:
@@ -2927,5 +3586,9 @@ snapshots:
     dependencies:
       buffer-crc32: 0.2.13
       fd-slicer: 1.1.0
+
+  zod-to-json-schema@3.25.2(zod@4.3.6):
+    dependencies:
+      zod: 4.3.6
 
   zod@4.3.6: {}


### PR DESCRIPTION
按 [03-architecture.md ADR-006 + §4.4 + §三"进程拓扑"](https://github.com/open-trad/docs/blob/main/design/03-architecture.md) 创建 \`apps/mcp-server\`,作为独立 Node.js 进程被 CC 通过 stdio 拉起,并通过 Unix socket / Windows named pipe + JSON-RPC 2.0 跟 desktop 主进程通信。

**M1 复杂度最高的单一 issue**,三件事一起干:mcp-server 骨架、IPC bridge server (desktop 端)、IPC bridge client + echo tool (mcp-server 端)。

## 改动摘要

### 共享类型 \`packages/shared/src/types/ipc-bridge.ts\`

JSON-RPC 2.0 wire 协议:\`IPC_BRIDGE_PROTOCOL_VERSION = 1\` / 5 个 method 名 / 4 个 RPC 的 params/result schema(\`risk-gate\` / \`audit-log\` / \`session-metadata\` 复用现有 schema)/ JSON-RPC envelope schemas / 标准 + OpenTrad 自定义错误码。

### Desktop 主进程

- \`ipc-bridge-server.ts\`:JSON-RPC 2.0 socket server,跨平台 Unix socket / Windows named pipe(统一接口内部分支),Handshake 必需(第一帧不是 hello → 立刻断开),Hello 帧协议(B 决策落地:\`{ sessionId, mcpServerPid, protocolVersion }\`,server 按 sessionId 路由,M2 多 session 时同 socket 多连接共享),行分隔 NDJSON,Hello timeout 5s
- \`ipc-bridge-handlers.ts\`:4 个 RPC handler 实现
  - \`risk-gate.request\`:M1 mock 永远 \`allow\`(真实在 [M1 #11 / #28](https://github.com/open-trad/opentrad/issues/28))
  - \`audit.log\`:走 \`AuditLogService.append\`(已 [#19](https://github.com/open-trad/opentrad/issues/19) 落地)
  - \`draft.save\`:写 \`~/.opentrad/drafts/{date}-{filename}.md\`,含路径穿越防御
  - \`session.metadata\`:走 \`SessionService.get\` + 投影到 \`SessionMeta\`
- \`db/paths.ts\`:新增 \`getIpcSocketPath\` / \`getDraftsDir\` 跨平台路径

### MCP Server (\`apps/mcp-server/\`)

- \`index.ts\`:stdio MCP server 入口,从 env 读 \`OPENTRAD_IPC_SOCKET\` / \`OPENTRAD_SESSION_ID\`,异步 IPC bridge connect 不阻塞 stdio 启动,**stdout 不能 console.log**(污染 wire 流),诊断走 stderr,内联 zodToJsonSchema 转换
- \`ipc-bridge.ts\`:JSON-RPC 2.0 client + **graceful degrade**(D-M1-5 落地):
  * Connect retry 3 次 exponential backoff(100/300/1000ms)
  * 全失败后进入 offline mode(M1 不重连,简化)
  * Offline 时:\`risk-gate.request\` → \`deny\`(安全侧);\`audit.log\` → in-memory buffer;\`draft.save\` / \`session.metadata\` → throw \`IpcBridgeOfflineError\`
- \`tools/index.ts\` + \`tools/echo.ts\`:tool 注册框架 + 第一个 safe 工具

### 集成 (\`apps/desktop/src/main/index.ts\`)

启动时 \`createIpcBridgeServer\` 监听 socket,退出时 \`stop\`(unlink + close 所有 client)。启动失败不阻塞 app(graceful degrade 兜底)。

## 决策点 D-M1-4 + D-M1-5(已落地)

- mcp-server **per-task 拉起**(CC 启动时通过 stdio 拉起),非常驻
- desktop 启动时创建 socket,退出时清理
- IPC bridge 连接失败时 mcp-server **graceful degrade**(详见 ipc-bridge.ts)

## 测试

### 单元测试(共 19 新增,monorepo 171 tests pass)

- desktop \`ipc-bridge-server.test.ts\`:**6 用例** —— 正常 hello + 4 RPC dispatch / 抢跑 RPC HandshakeRequired / protocolVersion 不匹配断开 / Hello timeout / clientCount 同步 / InvalidParams
- mcp-server \`ipc-bridge-client.test.ts\` + \`tools.test.ts\`:**13 用例** —— Graceful degrade 4 种(deny / buffer / 两类 offline error)+ fake-server 正常路径 3 种(hello frame / risk-gate roundtrip / audit.log)+ Tools registry 6 种

### 端到端 smoke(critical milestone 通报 3 — 已跑通)

\`\`\`
[smoke] system/init mcp_servers: [ { name: 'opentrad', status: 'connected' } ]
[smoke] CC called mcp__opentrad__echo ✓
[smoke] tool_result received ✓
[smoke] claude exited with code 0
=== Smoke result ===
tool_use seen: ✓
tool_result seen: ✓
cost: \$0.14653075, duration: 11500ms, stop: end_turn
\`\`\`

### Wire 协议截选(critical milestone 通报 2 — retrospective-m1 用)

完整 5 帧 round-trip(hello + 4 RPC),sessionId 路由,M1 mock + 真实 SQLite/fs 落地,见 issue #25 close 评论。

## 不在本 PR 范围

- \`McpConfigWriter\` 真实化:[M1 #9 / #26](https://github.com/open-trad/opentrad/issues/26)(本 PR 用手写 fixture mcp-config 验收,**A5 决策解耦**)
- 真实 RiskGate(M1 mock allow):[M1 #11 / #28](https://github.com/open-trad/opentrad/issues/28)
- 第一波 safe-only tools(\`draft_save\` / \`hs_code_lookup\` / \`session_get_metadata\`):M1 #9 / #26 接通 \`sessionStore.startTask\` 时一并加
- Browser tools:[M1 #10 / #27](https://github.com/open-trad/opentrad/issues/27)
- electron-builder 打包 mcp-server 到 \`extraResources\`:[M1 #13 / #30](https://github.com/open-trad/opentrad/issues/30)

## 工时

约 1 个工作日(包括端到端 smoke + wire 协议抓取)。预估 3-4 天偏保守 — IPC bridge 跨平台 socket 没卡住(@modelcontextprotocol/sdk 用法直接,Node net 跨平台 socket / named pipe 同接口)。

通报点 1(socket 跨平台真卡住召唤总工)未触发 — 顺利。

## Closes

Closes #25