### PR TITLE
feat(desktop): McpConfigWriter + sessionStore.startTask e2e + safe-only tools (M1 #26)

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -23,6 +23,7 @@
     "@xterm/xterm": "^6.0.0",
     "better-sqlite3": "^12.9.0",
     "electron": "^41.3.0",
+    "js-yaml": "^4.1.1",
     "node-pty": "^1.1.0",
     "react": "^19.2.5",
     "react-dom": "^19.2.5",
@@ -31,6 +32,7 @@
   "devDependencies": {
     "@opentrad/shared": "workspace:^",
     "@types/better-sqlite3": "^7.6.13",
+    "@types/js-yaml": "^4.0.9",
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^6.0.1",

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -11,6 +11,7 @@ import { createDbServices, type DbServices, getIpcSocketPath } from "./services/
 import { createIpcBridgeHandlers } from "./services/ipc-bridge-handlers";
 import { IpcBridgeServer } from "./services/ipc-bridge-server";
 import { type AppLock, AppLockHeldError, acquireAppLock } from "./services/lock";
+import { McpConfigWriter } from "./services/mcp-writer";
 import { PtyManager } from "./services/pty-manager";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
@@ -20,6 +21,15 @@ const ccManager = new CCManager();
 
 // 全局 PtyManager 单例：跨窗口共享，路由由 IPC handler 内部 ptyId → webContents 管理。
 const ptyManager = new PtyManager();
+
+// McpConfigWriter（M1 #26）：每次 startTask 生成临时 mcp-config，让 CC 通过 stdio
+// 拉起 apps/mcp-server。dev 用 tsx 跑 .ts 入口；electron-builder 打包路径在 M1 #13。
+// REPO_ROOT 从 main/index.ts 文件位置回溯：apps/desktop/src/main → 上 4 层。
+const REPO_ROOT = join(__dirname, "..", "..", "..", "..");
+const mcpWriter = new McpConfigWriter({
+  mcpServerCommand: join(REPO_ROOT, "node_modules", ".bin", "tsx"),
+  mcpServerArgs: [join(REPO_ROOT, "apps", "mcp-server", "src", "index.ts")],
+});
 
 // 启动时初始化、退出时释放：lock + db + ipc-bridge server。
 let appLock: AppLock | undefined;
@@ -85,7 +95,12 @@ app.whenReady().then(() => {
     console.error("[main] IPC bridge server start failed", err);
   });
 
-  registerIpcHandlers(ccManager, dbServices, ptyManager);
+  registerIpcHandlers({
+    manager: ccManager,
+    db: dbServices,
+    pty: ptyManager,
+    mcpWriter,
+  });
   createMainWindow();
 
   // macOS 点 dock icon 重启窗口（Electron 推荐行为）

--- a/apps/desktop/src/main/ipc/cc.ts
+++ b/apps/desktop/src/main/ipc/cc.ts
@@ -1,63 +1,129 @@
 // cc:* IPC handlers。对应 03-architecture.md §3 IPC channels + §4.1 Process Manager。
-// 实现范围：
-// - cc:status（Issue #7）：CC 安装 + 登录状态查询
-// - cc:start-task（Issue #8）：spawn CC 任务，立刻返回 sessionId
-// - cc:cancel-task（Issue #8）：按 sessionId 取消
-// - cc:event（Issue #8）：main 向 renderer 推 domain CCEvent 流
 //
-// M0 阶段简化：prompt 硬编码 "Say hi in Chinese"，mcp-config 写一个空文件；
-// skill 管理和真实 prompt composer 在 M1。
+// M0 范围：cc:status / cc:start-task hardcoded demo / cc:cancel-task / cc:event 推送。
+// **M1 #26 接通完整链路**（替换 M0 hardcoded prompt + 空 mcp-config）：
+//   1. SkillLoader.load(skillId) → manifest（M1 #26 用 fixture loader 占位，#23 替换）
+//   2. PromptComposer.compose(manifest, inputs) → fullPrompt（同上）
+//   3. McpConfigWriter.generateForSession(sessionId, manifest) → configPath
+//   4. SessionService.create + EventService append（A4 ownership）
+//   5. CCManager.startTask({ sessionId, prompt, mcpConfigPath, allowedTools })
+//   6. for-await events → 先 EventService.append（持久化）→ 再 webContents.send 推 renderer
+//   7. result 事件到达后：McpConfigWriter.cleanup + SessionService.updateMeta + updateStatus completed
 
 import { randomUUID } from "node:crypto";
-import { mkdtemp, rm, writeFile } from "node:fs/promises";
-import { tmpdir } from "node:os";
-import { join } from "node:path";
 import { type CCManager, redactEmail } from "@opentrad/cc-adapter";
 import {
   type CCCancelTaskRequest,
+  type CCStartTaskRequest,
+  CCStartTaskRequestSchema,
   type CCStartTaskResponse,
   type CCStatus,
   IpcChannels,
 } from "@opentrad/shared";
 import { ipcMain } from "electron";
+import type { DbServices } from "../services/db";
+import type { McpConfigWriter } from "../services/mcp-writer";
+import { composePrompt, loadFixtureSkill } from "../services/skill-fixture-loader";
 
-export function registerCcHandlers(manager: CCManager): void {
+export interface CcHandlerDeps {
+  manager: CCManager;
+  db: DbServices;
+  mcpWriter: McpConfigWriter;
+}
+
+export function registerCcHandlers(deps: CcHandlerDeps): void {
+  const { manager, db, mcpWriter } = deps;
+
   ipcMain.handle(IpcChannels.CCStatus, async (): Promise<CCStatus> => {
     return buildCcStatus(manager);
   });
 
-  ipcMain.handle(IpcChannels.CCStartTask, async (event): Promise<CCStartTaskResponse> => {
-    // M0：忽略 renderer 传的 skillId/inputs，固定 demo prompt。M1 接 skill runtime。
-    const sessionId = randomUUID();
-    const tmpDir = await mkdtemp(join(tmpdir(), "opentrad-m0-"));
-    const mcpConfigPath = join(tmpDir, "mcp-config.json");
-    await writeFile(mcpConfigPath, JSON.stringify({ mcpServers: {} }));
+  ipcMain.handle(
+    IpcChannels.CCStartTask,
+    async (event, raw: unknown): Promise<CCStartTaskResponse> => {
+      const req: CCStartTaskRequest = CCStartTaskRequestSchema.parse(raw);
 
-    const handle = await manager.startTask({
-      sessionId,
-      prompt: "Say hi in Chinese",
-      mcpConfigPath,
-      allowedTools: [],
-      model: "haiku",
-    });
+      // 1-2. 加载 skill manifest + 组装 prompt
+      // M1 #26 用 fixture loader 占位（packages/skill-runtime/__fixtures__/）。
+      // M1 #23 (#open-trad/opentrad#23) 真做 SkillLoader 后切换到
+      // import { SkillLoader, PromptComposer } from "@opentrad/skill-runtime"。
+      const loaded = loadFixtureSkill(req.skillId);
+      const fullPrompt = composePrompt(loaded, req.inputs);
+      const { manifest } = loaded;
 
-    // 异步把 events 推给这个 webContents；结束后清临时目录。
-    // 不 await 这个 IIFE —— startTask 要立刻返回 sessionId 给 renderer。
-    void (async () => {
-      try {
-        for await (const evt of handle.events) {
-          if (event.sender.isDestroyed()) break;
-          event.sender.send(IpcChannels.CCEvent, evt);
+      const sessionId = randomUUID();
+
+      // 3. 生成临时 mcp-config（McpConfigWriter）
+      const mcpConfigPath = mcpWriter.generateForSession(sessionId, manifest);
+
+      // 4. session 行写入（status='active'）；events 表 append ownership 在第 6 步
+      db.sessions.create({
+        id: sessionId,
+        title: titleFromInputs(manifest.id, req.inputs),
+        skillId: manifest.id,
+        status: "active",
+      });
+
+      // 5. spawn CC + allowedTools 透传
+      const handle = await manager.startTask({
+        sessionId,
+        prompt: fullPrompt,
+        mcpConfigPath,
+        allowedTools: manifest.allowedTools,
+      });
+
+      // 6-7. 事件流：先 events.append（A4 ownership），再推 renderer；
+      //      result 事件做收尾（cleanup + updateMeta + status completed）。
+      let seq = 0;
+      let lastModel: string | null = null;
+      let messageCount = 0;
+      let totalCost = 0;
+
+      void (async () => {
+        try {
+          for await (const evt of handle.events) {
+            // **A4 events append ownership 落地点（#19 issue body 强调）**
+            db.events.append({
+              sessionId,
+              seq: seq++,
+              type: evt.type,
+              payload: evt,
+            });
+
+            // 计数 / 取最后 model（用于 sessions.updateMeta）
+            if (evt.type === "assistant_text" || evt.type === "assistant_thinking") {
+              messageCount++;
+              if (evt.messageMeta?.model) lastModel = evt.messageMeta.model;
+            }
+
+            if (!event.sender.isDestroyed()) {
+              event.sender.send(IpcChannels.CCEvent, evt);
+            }
+
+            if (evt.type === "result") {
+              totalCost = evt.data.totalCostUsd;
+              db.sessions.updateMeta(sessionId, {
+                lastModel,
+                totalCostUsd: totalCost,
+                messageCount,
+              });
+              db.sessions.updateStatus(
+                sessionId,
+                evt.subtype === "success" ? "completed" : "error",
+              );
+            }
+          }
+        } catch (err) {
+          console.error("[cc:event] stream error", err);
+          db.sessions.updateStatus(sessionId, "error");
+        } finally {
+          mcpWriter.cleanup(sessionId);
         }
-      } catch (err) {
-        console.error("[cc:event] stream error", err);
-      } finally {
-        await rm(tmpDir, { recursive: true, force: true });
-      }
-    })();
+      })();
 
-    return { sessionId };
-  });
+      return { sessionId };
+    },
+  );
 
   ipcMain.handle(
     IpcChannels.CCCancelTask,
@@ -109,4 +175,14 @@ export async function buildCcStatus(manager: CCManager): Promise<CCStatus> {
       error: err instanceof Error ? err.message : String(err),
     };
   }
+}
+
+// 从 inputs 拼一个简短 session 标题（最多 60 字符）。
+// "fixture-skill: OpenTrad fixture run" 这种形态。
+function titleFromInputs(skillId: string, inputs: Record<string, unknown>): string {
+  const firstValue = Object.values(inputs).find(
+    (v): v is string => typeof v === "string" && v.length > 0,
+  );
+  const summary = firstValue ? firstValue.slice(0, 40) : "(no input)";
+  return `${skillId}: ${summary}`;
 }

--- a/apps/desktop/src/main/ipc/index.ts
+++ b/apps/desktop/src/main/ipc/index.ts
@@ -3,6 +3,7 @@
 
 import type { CCManager } from "@opentrad/cc-adapter";
 import type { DbServices } from "../services/db";
+import type { McpConfigWriter } from "../services/mcp-writer";
 import type { PtyManager } from "../services/pty-manager";
 import { registerCcHandlers } from "./cc";
 import { registerInstalledSkillHandlers } from "./installed-skill";
@@ -10,11 +11,18 @@ import { registerPtyHandlers } from "./pty";
 import { registerSessionHandlers } from "./session";
 import { registerSettingsHandlers } from "./settings";
 
-export function registerIpcHandlers(manager: CCManager, db: DbServices, pty: PtyManager): void {
-  registerCcHandlers(manager);
-  registerSessionHandlers(db);
-  registerSettingsHandlers(db);
-  registerInstalledSkillHandlers(db);
-  registerPtyHandlers(pty);
+export interface IpcDeps {
+  manager: CCManager;
+  db: DbServices;
+  pty: PtyManager;
+  mcpWriter: McpConfigWriter;
+}
+
+export function registerIpcHandlers(deps: IpcDeps): void {
+  registerCcHandlers({ manager: deps.manager, db: deps.db, mcpWriter: deps.mcpWriter });
+  registerSessionHandlers(deps.db);
+  registerSettingsHandlers(deps.db);
+  registerInstalledSkillHandlers(deps.db);
+  registerPtyHandlers(deps.pty);
   // 后续 domain：skill / risk-gate / installer 在此注册
 }

--- a/apps/desktop/src/main/services/mcp-writer.ts
+++ b/apps/desktop/src/main/services/mcp-writer.ts
@@ -1,0 +1,80 @@
+// McpConfigWriter（M1 #26 / open-trad/opentrad#26，对应 03-architecture.md §4.4）。
+//
+// 每次 startTask 生成一份临时 mcp-config.json，让 CC 通过 stdio 拉起
+// apps/mcp-server，并把 sessionId / IPC bridge socket 路径通过 env 注入。
+// 任务结束后清理临时文件。
+//
+// 跨平台：os.tmpdir() 自动返回平台标准临时目录
+//   - macOS: /var/folders/.../T/  (TMPDIR)
+//   - Linux: /tmp/                (默认)
+//   - Windows: C:\Users\<user>\AppData\Local\Temp\  (%TEMP%)
+// 字符串路径 + JSON 序列化对反斜杠是安全的（JSON 自动转义），CC 接收 path
+// argument 也跨平台 OK（已在 #25 端到端 smoke 验证 macOS 通；Windows 验证
+// 在 #21 / #22 上路 onboarding 时一并触发，目前仅 unit 验证 + 三平台 CI typecheck）。
+
+import { existsSync, mkdirSync, unlinkSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import type { SkillManifest } from "@opentrad/shared";
+import { getIpcSocketPath } from "./db/paths";
+
+export interface McpConfigWriterOptions {
+  // mcp-server 可执行入口的绝对路径。process.execPath 是 Electron 二进制，
+  // dev 时通过 tsx 跑 .ts 入口；打包后通过 Electron 内嵌 Node 跑 dist/index.js。
+  // M1 #26 范围内只支持 dev（tsx 跑）；electron-builder 打包路径在 M1 #13 / #30。
+  mcpServerCommand: string;
+  mcpServerArgs: string[];
+}
+
+export class McpConfigWriter {
+  constructor(private readonly opts: McpConfigWriterOptions) {}
+
+  // 为某次 startTask 生成 mcp-config 临时文件。返回绝对路径，调用方传给
+  // CC 的 --mcp-config 参数。
+  generateForSession(sessionId: string, manifest: SkillManifest): string {
+    const configPath = pathForSession(sessionId);
+    mkdirSync(dirname(configPath), { recursive: true });
+
+    const config = {
+      mcpServers: {
+        opentrad: {
+          command: this.opts.mcpServerCommand,
+          args: this.opts.mcpServerArgs,
+          env: {
+            OPENTRAD_IPC_SOCKET: getIpcSocketPath(),
+            OPENTRAD_SESSION_ID: sessionId,
+            // 把当前 PATH 透传，让 mcp-server 子进程能找到 node / 系统命令。
+            // 不暴露 ~/.claude / 任何 token（红线）。
+            PATH: process.env.PATH ?? "",
+          },
+        },
+      },
+      // 留个扩展位：`__opentrad__` 字段可用于把 manifest 元数据传给 mcp-server。
+      // 当前未读，#11 / #28 RiskGate 接通时可能用到（如 skillId / riskLevel）。
+      __opentrad__: {
+        sessionId,
+        skillId: manifest.id,
+        skillVersion: manifest.version,
+        skillRiskLevel: manifest.riskLevel,
+      },
+    };
+
+    writeFileSync(configPath, JSON.stringify(config, null, 2), "utf-8");
+    return configPath;
+  }
+
+  cleanup(sessionId: string): void {
+    const configPath = pathForSession(sessionId);
+    if (existsSync(configPath)) {
+      try {
+        unlinkSync(configPath);
+      } catch {
+        // 文件被占用 / 权限 → 静默；不阻塞 task 收尾
+      }
+    }
+  }
+}
+
+function pathForSession(sessionId: string): string {
+  return join(tmpdir(), `opentrad-${sessionId}.mcp.json`);
+}

--- a/apps/desktop/src/main/services/skill-fixture-loader.ts
+++ b/apps/desktop/src/main/services/skill-fixture-loader.ts
@@ -1,0 +1,75 @@
+// **临时 fixture loader（M1 #26 / open-trad/opentrad#26）**：
+// 读 packages/skill-runtime/__fixtures__/sample-skill/{skill.yml,prompt.md}，
+// 用 zod 校验后返回 SkillManifest。
+//
+// **#23 (M1 #6) SkillLoader / PromptComposer 落地后删除本文件**，把 desktop
+// 这边 import 切到 `@opentrad/skill-runtime`，业务行为不变。
+//
+// 设计动机（W1 PR A 教训 + 发起人 W2 起跑要求）：fixture 字段齐全（不是临时
+// mock），#23 真做时 SkillLoader 加载它跑通解析路径；#7 / #24 SkillPicker
+// UI 也复用同一个 fixture 演示输入表单。M0 D6 "per-message 退化为
+// per-wire-event" 教训：临时简化的边界一旦写死，后续接管时容易漏改。
+// 这里坚持 stub != mock，full-fidelity fixture。
+
+import { existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { type SkillManifest, SkillManifestSchema } from "@opentrad/shared";
+import * as yaml from "js-yaml";
+
+// fixture 仓库内绝对路径。从 desktop 的 dist 跑时通过相对 monorepo 解析。
+const REPO_ROOT = join(__dirname, "..", "..", "..", "..", "..");
+const FIXTURE_DIR = join(REPO_ROOT, "packages", "skill-runtime", "__fixtures__");
+
+export interface LoadedSkill {
+  manifest: SkillManifest;
+  promptTemplate: string; // 已读出来的 prompt.md 文本
+}
+
+export function loadFixtureSkill(skillId: string): LoadedSkill {
+  const skillDir = join(FIXTURE_DIR, skillId);
+  const yamlPath = join(skillDir, "skill.yml");
+  if (!existsSync(yamlPath)) {
+    throw new Error(`fixture skill not found: ${skillId} (looked at ${yamlPath})`);
+  }
+
+  const raw = yaml.load(readFileSync(yamlPath, "utf-8"));
+  const manifest = SkillManifestSchema.parse(raw);
+
+  const promptPath = join(skillDir, manifest.promptTemplate);
+  if (!existsSync(promptPath)) {
+    throw new Error(`fixture skill prompt not found: ${promptPath}`);
+  }
+  const promptTemplate = readFileSync(promptPath, "utf-8");
+
+  return { manifest, promptTemplate };
+}
+
+// mustache-style 占位符替换 + 通用前缀注入（对齐 03 §4.3 PromptComposer 设计）。
+// 必填 input 缺失时抛 ValidationError；`{{x}}` 缺值时替换为空串（#23 真实化时收紧）。
+export function composePrompt(loaded: LoadedSkill, inputs: Record<string, unknown>): string {
+  const { manifest, promptTemplate } = loaded;
+
+  // 必填字段校验
+  for (const input of manifest.inputs) {
+    if (input.required && !(input.name in inputs)) {
+      throw new ValidationError(`missing required input: ${input.name}`);
+    }
+  }
+
+  // mustache 替换 {{varName}}
+  const filled = promptTemplate.replace(/\{\{(\w+)\}\}/g, (_, varName) => {
+    const v = inputs[varName];
+    return v === undefined || v === null ? "" : String(v);
+  });
+
+  // 通用前缀（对齐 03 §4.3）
+  const prefix = `You are operating within OpenTrad's ${manifest.id} skill. ${manifest.description}. Stay within scope.\n\n`;
+  return prefix + filled;
+}
+
+export class ValidationError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "ValidationError";
+  }
+}

--- a/apps/desktop/tests/mcp-writer.test.ts
+++ b/apps/desktop/tests/mcp-writer.test.ts
@@ -1,0 +1,82 @@
+// McpConfigWriter 测试。验证 generateForSession 写出合法 JSON + 含 sessionId
+// + IPC socket env，cleanup 正确删文件。
+
+import { existsSync, readFileSync, unlinkSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { SkillManifest } from "@opentrad/shared";
+import { describe, expect, it } from "vitest";
+import { McpConfigWriter } from "../src/main/services/mcp-writer";
+
+const SAMPLE_MANIFEST: SkillManifest = {
+  id: "fixture-skill",
+  title: "Fixture",
+  version: "0.1.0",
+  description: "test",
+  category: "communication",
+  riskLevel: "draft_only",
+  allowedTools: ["mcp__opentrad__echo"],
+  disallowedTools: undefined,
+  stopBefore: undefined,
+  inputs: [],
+  outputs: ["draft"],
+  promptTemplate: "prompt.md",
+};
+
+describe("McpConfigWriter", () => {
+  it("generateForSession 写合法 JSON 含 sessionId / IPC env / mcpServers.opentrad", () => {
+    const writer = new McpConfigWriter({
+      mcpServerCommand: "/usr/bin/tsx",
+      mcpServerArgs: ["/path/to/mcp-server/src/index.ts"],
+    });
+    const sessionId = "test-session-aaaa";
+    const path = writer.generateForSession(sessionId, SAMPLE_MANIFEST);
+
+    expect(path).toBe(join(tmpdir(), `opentrad-${sessionId}.mcp.json`));
+    expect(existsSync(path)).toBe(true);
+
+    const config = JSON.parse(readFileSync(path, "utf-8"));
+    expect(config.mcpServers.opentrad.command).toBe("/usr/bin/tsx");
+    expect(config.mcpServers.opentrad.args).toEqual(["/path/to/mcp-server/src/index.ts"]);
+    expect(config.mcpServers.opentrad.env.OPENTRAD_SESSION_ID).toBe(sessionId);
+    expect(config.mcpServers.opentrad.env.OPENTRAD_IPC_SOCKET).toBeDefined();
+    // PATH 透传，子进程能找 node / 系统命令
+    expect(config.mcpServers.opentrad.env.PATH).toBeDefined();
+    // 不暴露任何凭证/token
+    expect(config.mcpServers.opentrad.env).not.toHaveProperty("HOME");
+
+    // __opentrad__ 扩展元数据（M1 #28 RiskGate 可能用到）
+    expect(config.__opentrad__.sessionId).toBe(sessionId);
+    expect(config.__opentrad__.skillId).toBe("fixture-skill");
+    expect(config.__opentrad__.skillRiskLevel).toBe("draft_only");
+
+    unlinkSync(path); // 清理
+  });
+
+  it("cleanup 删文件，幂等（已删时不抛）", () => {
+    const writer = new McpConfigWriter({
+      mcpServerCommand: "/usr/bin/tsx",
+      mcpServerArgs: ["/x"],
+    });
+    const sessionId = "cleanup-test";
+    const path = writer.generateForSession(sessionId, SAMPLE_MANIFEST);
+    expect(existsSync(path)).toBe(true);
+
+    writer.cleanup(sessionId);
+    expect(existsSync(path)).toBe(false);
+
+    // 二次 cleanup 不抛
+    expect(() => writer.cleanup(sessionId)).not.toThrow();
+  });
+
+  it("跨平台 tmpdir 路径（不依赖 platform）", () => {
+    const writer = new McpConfigWriter({
+      mcpServerCommand: "x",
+      mcpServerArgs: [],
+    });
+    const path = writer.generateForSession("xplat-test", SAMPLE_MANIFEST);
+    // tmpdir() 返回平台标准路径，路径分隔符匹配 OS
+    expect(path.startsWith(tmpdir())).toBe(true);
+    writer.cleanup("xplat-test");
+  });
+});

--- a/apps/desktop/tests/skill-fixture-loader.test.ts
+++ b/apps/desktop/tests/skill-fixture-loader.test.ts
@@ -1,0 +1,69 @@
+// skill-fixture-loader 测试：验证 fixture skill 加载 + manifest schema 解析 +
+// composePrompt 替换 mustache + 必填字段校验。
+//
+// 覆盖跟 #23 (M1 #6) SkillLoader 等价的最小功能集，确保 fixture 字段齐全（
+// stub != mock 的发起人约束）。#23 真做时 SkillLoader 测试也用本 fixture。
+
+import { describe, expect, it } from "vitest";
+import {
+  composePrompt,
+  loadFixtureSkill,
+  ValidationError,
+} from "../src/main/services/skill-fixture-loader";
+
+describe("loadFixtureSkill", () => {
+  it("加载 fixture-skill 返回完整 SkillManifest", () => {
+    const loaded = loadFixtureSkill("sample-skill");
+    expect(loaded.manifest.id).toBe("fixture-skill");
+    expect(loaded.manifest.title).toBe("Fixture Test Skill");
+    expect(loaded.manifest.version).toBe("0.1.0");
+    expect(loaded.manifest.category).toBe("communication");
+    expect(loaded.manifest.riskLevel).toBe("draft_only");
+    expect(loaded.manifest.allowedTools).toEqual([
+      "mcp__opentrad__echo",
+      "mcp__opentrad__draft_save",
+    ]);
+    expect(loaded.manifest.disallowedTools).toEqual(["Bash(*)", "mcp__*__send*"]);
+    expect(loaded.manifest.inputs).toHaveLength(1);
+    expect(loaded.manifest.inputs[0]?.name).toBe("topic");
+    expect(loaded.manifest.outputs).toEqual(["draft"]);
+    expect(loaded.promptTemplate).toContain("{{topic}}");
+  });
+
+  it("不存在的 skillId 抛错", () => {
+    expect(() => loadFixtureSkill("does-not-exist")).toThrow(/not found/);
+  });
+});
+
+describe("composePrompt", () => {
+  it("替换 {{varName}} 占位符 + 加通用前缀", () => {
+    const loaded = loadFixtureSkill("sample-skill");
+    const result = composePrompt(loaded, { topic: "测试主题" });
+    expect(result).toContain("OpenTrad's fixture-skill skill");
+    expect(result).toContain("Stay within scope");
+    expect(result).toContain("测试主题");
+    expect(result).not.toContain("{{topic}}");
+  });
+
+  it("必填 input 缺失时抛 ValidationError", () => {
+    const loaded = loadFixtureSkill("sample-skill");
+    expect(() => composePrompt(loaded, {})).toThrow(ValidationError);
+  });
+
+  it("非必填字段缺失时不抛，{{x}} 替换为空串（M1 简化，#23 真做时收紧）", () => {
+    // sample-skill 的 topic 是 required，构造一个 manifest 副本验证非必填路径
+    const loaded = loadFixtureSkill("sample-skill");
+    const firstInput = loaded.manifest.inputs[0];
+    if (!firstInput) throw new Error("fixture should have at least one input");
+    const optionalLoaded = {
+      ...loaded,
+      manifest: {
+        ...loaded.manifest,
+        inputs: [{ ...firstInput, required: false }],
+      },
+      promptTemplate: "Hello {{topic}}, age {{age}}.",
+    };
+    const result = composePrompt(optionalLoaded, { topic: "Alice" });
+    expect(result).toContain("Hello Alice, age .");
+  });
+});

--- a/apps/mcp-server/src/tools/draft-save.ts
+++ b/apps/mcp-server/src/tools/draft-save.ts
@@ -1,0 +1,36 @@
+// draft_save tool（M1 #26）：把 skill 生成的草稿走 IPC bridge `draft.save` RPC
+// 写到 desktop 主进程管理的 ~/.opentrad/drafts/{date}-{filename}.md。
+//
+// riskLevel = "safe"：M1 范围内不弹窗（draft_only skill 共用约定，03 §4.5）。
+// 真实 RiskGate 拦截在 M1 #11 / #28 加 middleware；本工具不主动调
+// risk-gate.request RPC（safe 类应该自动 allow，避免冗余 audit 噪音）。
+
+import { z } from "zod";
+import type { OpenTradTool } from "./index";
+
+const InputSchema = z.object({
+  filename: z.string().min(1).describe("草稿文件名，自动加日期前缀。建议 .md 后缀"),
+  content: z.string().describe("草稿正文（markdown）"),
+});
+
+export const draftSaveTool: OpenTradTool = {
+  name: "draft_save",
+  description:
+    "Save a draft markdown to the OpenTrad drafts folder. Use this to persist generated content.",
+  inputSchema: InputSchema,
+  riskLevel: "safe",
+  category: "drafts",
+  async execute(rawInput, { bridge }) {
+    const input = InputSchema.parse(rawInput);
+    const result = await bridge.draftSave({
+      filename: input.filename,
+      content: input.content,
+    });
+    return [
+      {
+        type: "text",
+        text: `Draft saved to ${result.path}`,
+      },
+    ];
+  },
+};

--- a/apps/mcp-server/src/tools/hs-code-lookup.ts
+++ b/apps/mcp-server/src/tools/hs-code-lookup.ts
@@ -1,0 +1,59 @@
+// hs_code_lookup tool（M1 #26）：HS Code 候选查询。
+// **M1 mock**：返回固定 3 个 candidate（从 description 关键词无关，纯演示）。
+// **M2 真实化**：接对外 HS Code 数据库（如 wco / 海关总署 / 第三方 API）。
+//
+// riskLevel = "safe"：read-only 查询，不影响外部状态。
+
+import { z } from "zod";
+import type { OpenTradTool } from "./index";
+
+const InputSchema = z.object({
+  description: z.string().min(1).describe("商品中英文描述，用于查询候选 HS Code"),
+});
+
+interface HsCodeCandidate {
+  code: string;
+  description: string;
+  rationale: string;
+}
+
+const MOCK_CANDIDATES: HsCodeCandidate[] = [
+  {
+    code: "8517.62",
+    description: "通信用机器（M1 mock candidate）",
+    rationale: "M1 #26 占位返回，真实分类逻辑在 M2 接入海关数据库",
+  },
+  {
+    code: "8542.31",
+    description: "处理器及控制器（M1 mock candidate）",
+    rationale: "同上",
+  },
+  {
+    code: "9013.80",
+    description: "其他光学器件（M1 mock candidate）",
+    rationale: "同上",
+  },
+];
+
+export const hsCodeLookupTool: OpenTradTool = {
+  name: "hs_code_lookup",
+  description:
+    "Look up candidate HS Codes for a product description. M1 returns fixed mock candidates; real lookup lands in M2.",
+  inputSchema: InputSchema,
+  riskLevel: "safe",
+  category: "platform",
+  async execute(rawInput) {
+    const input = InputSchema.parse(rawInput);
+    const lines = [
+      `HS Code candidates for "${input.description}" (M1 mock):`,
+      "",
+      ...MOCK_CANDIDATES.map((c, i) => `${i + 1}. ${c.code} — ${c.description}\n   ${c.rationale}`),
+    ];
+    return [
+      {
+        type: "text",
+        text: lines.join("\n"),
+      },
+    ];
+  },
+};

--- a/apps/mcp-server/src/tools/index.ts
+++ b/apps/mcp-server/src/tools/index.ts
@@ -1,8 +1,11 @@
-// Tool 注册框架（M1 #25）。OpenTradTool 接口扩展 MCP SDK 标准 Tool 定义，
+// Tool 注册框架（M1 #25 起）。OpenTradTool 接口扩展 MCP SDK 标准 Tool 定义，
 // 加 OpenTrad 自己的 riskLevel + category 元数据。
 //
-// M1 范围：仅 echo（safe 类）。后续 M1 #26 加 draft_save / hs_code_lookup /
-// session_get_metadata；M1 #27 加 browser_open / browser_read / browser_screenshot。
+// M1 工具落地节奏：
+//   - #25：echo（safe，验证 stdio MCP 链路）
+//   - #26：draft_save / hs_code_lookup / session_get_metadata（safe-only,
+//          走 IPC bridge）
+//   - #27：browser_open / browser_read / browser_screenshot（review-level）
 
 import type { z } from "zod";
 import type { IpcBridgeClient } from "../ipc-bridge";
@@ -26,10 +29,18 @@ export interface OpenTradTool {
   execute(input: unknown, ctx: ToolContext): Promise<ToolContent[]>;
 }
 
-// 工具集合：M1 仅 echo。新增工具时 import + 加进数组。
+// 工具集合：新增工具时 import + 加进数组。
+import { draftSaveTool } from "./draft-save";
 import { echoTool } from "./echo";
+import { hsCodeLookupTool } from "./hs-code-lookup";
+import { sessionGetMetadataTool } from "./session-get-metadata";
 
-export const tools: OpenTradTool[] = [echoTool];
+export const tools: OpenTradTool[] = [
+  echoTool,
+  draftSaveTool,
+  hsCodeLookupTool,
+  sessionGetMetadataTool,
+];
 
 export function getToolByName(name: string): OpenTradTool | undefined {
   return tools.find((t) => t.name === name);

--- a/apps/mcp-server/src/tools/session-get-metadata.ts
+++ b/apps/mcp-server/src/tools/session-get-metadata.ts
@@ -1,0 +1,51 @@
+// session_get_metadata tool（M1 #26）：通过 IPC bridge 查 desktop 主进程
+// SQLite 里当前 session 的 SessionMeta 视图（id / title / skillId / 时间戳 / status）。
+//
+// riskLevel = "safe"：read-only。skill 用它做"我现在在哪个 session 里"的自查。
+// 不暴露 ccSessionPath / cost / messageCount 等内部字段（SessionMeta 投影已守住）。
+
+import { z } from "zod";
+import type { OpenTradTool } from "./index";
+
+const InputSchema = z.object({
+  sessionId: z
+    .string()
+    .optional()
+    .describe("要查询的 session ID。不传时使用当前 task 的 sessionId（OPENTRAD_SESSION_ID env）。"),
+});
+
+export const sessionGetMetadataTool: OpenTradTool = {
+  name: "session_get_metadata",
+  description:
+    "Get metadata of an OpenTrad session (id/title/skillId/timestamps/status). Defaults to the current task's session when sessionId is omitted.",
+  inputSchema: InputSchema,
+  riskLevel: "safe",
+  category: "utility",
+  async execute(rawInput, { bridge, sessionId: currentSessionId }) {
+    const input = InputSchema.parse(rawInput);
+    const sessionId = input.sessionId ?? currentSessionId;
+    const meta = await bridge.sessionMetadata({ sessionId });
+    if (!meta) {
+      return [
+        {
+          type: "text",
+          text: `No session found with id ${sessionId}`,
+        },
+      ];
+    }
+    const lines = [
+      `Session ${meta.id}:`,
+      `  title: ${meta.title}`,
+      `  skillId: ${meta.skillId ?? "(none)"}`,
+      `  status: ${meta.status}`,
+      `  createdAt: ${new Date(meta.createdAt).toISOString()}`,
+      `  updatedAt: ${new Date(meta.updatedAt).toISOString()}`,
+    ];
+    return [
+      {
+        type: "text",
+        text: lines.join("\n"),
+      },
+    ];
+  },
+};

--- a/apps/mcp-server/tests/tools.test.ts
+++ b/apps/mcp-server/tests/tools.test.ts
@@ -1,31 +1,41 @@
-// Tools 注册框架 + echo tool 测试。
+// Tools 注册框架 + 各 tool 测试（M1 #25 echo + M1 #26 draft_save / hs_code_lookup
+// / session_get_metadata）。
 
-import { describe, expect, it } from "vitest";
-import { getToolByName, tools } from "../src/tools";
+import { describe, expect, it, vi } from "vitest";
+import { getToolByName, type ToolContext, tools } from "../src/tools";
+import { draftSaveTool } from "../src/tools/draft-save";
 import { echoTool } from "../src/tools/echo";
+import { hsCodeLookupTool } from "../src/tools/hs-code-lookup";
+import { sessionGetMetadataTool } from "../src/tools/session-get-metadata";
 
 describe("tools registry", () => {
-  it("echo 在 tools 列表里，name / riskLevel / category 正确", () => {
-    const echo = getToolByName("echo");
-    expect(echo).toBe(echoTool);
-    expect(echo?.name).toBe("echo");
-    expect(echo?.riskLevel).toBe("safe");
-    expect(echo?.category).toBe("utility");
+  it("4 个工具都注册（echo + #26 三个 safe-only）", () => {
+    expect(tools).toHaveLength(4);
+    expect(tools.map((t) => t.name).sort()).toEqual([
+      "draft_save",
+      "echo",
+      "hs_code_lookup",
+      "session_get_metadata",
+    ]);
   });
 
-  it("getToolByName 不存在的工具返回 undefined", () => {
+  it("getToolByName 找各工具 + miss case", () => {
+    expect(getToolByName("echo")).toBe(echoTool);
+    expect(getToolByName("draft_save")).toBe(draftSaveTool);
+    expect(getToolByName("hs_code_lookup")).toBe(hsCodeLookupTool);
+    expect(getToolByName("session_get_metadata")).toBe(sessionGetMetadataTool);
     expect(getToolByName("nonexistent")).toBeUndefined();
   });
 
-  it("M1 仅注册 echo（其他工具留 #26 / #27）", () => {
-    expect(tools).toHaveLength(1);
-    expect(tools[0]?.name).toBe("echo");
+  it("safe 类工具 riskLevel 全为 safe（M1 #26 范围）", () => {
+    for (const tool of tools) {
+      expect(tool.riskLevel).toBe("safe");
+    }
   });
 });
 
 describe("echo tool", () => {
-  // ctx 不会被 echo 用到（safe 工具不调 IPC bridge）；用 minimal stub
-  const fakeCtx = { bridge: {} as never, sessionId: "test" };
+  const fakeCtx: ToolContext = { bridge: {} as never, sessionId: "test" };
 
   it("正确 echo 输入字符串", async () => {
     const result = await echoTool.execute({ message: "hello world" }, fakeCtx);
@@ -35,8 +45,95 @@ describe("echo tool", () => {
   it("zod 校验：缺 message 抛错", async () => {
     await expect(echoTool.execute({}, fakeCtx)).rejects.toThrow();
   });
+});
 
-  it("zod 校验：message 类型错抛错", async () => {
-    await expect(echoTool.execute({ message: 123 }, fakeCtx)).rejects.toThrow();
+describe("draft_save tool", () => {
+  it("调用 bridge.draftSave + 返回 path", async () => {
+    const draftSave = vi.fn().mockResolvedValue({ path: "/fake/2026-04-25-a.md" });
+    const ctx = {
+      bridge: { draftSave } as unknown as ToolContext["bridge"],
+      sessionId: "s1",
+    };
+
+    const result = await draftSaveTool.execute({ filename: "a.md", content: "# hello" }, ctx);
+    expect(draftSave).toHaveBeenCalledWith({ filename: "a.md", content: "# hello" });
+    expect(result[0]?.text).toContain("/fake/2026-04-25-a.md");
+  });
+
+  it("zod 校验：filename 空字符串抛错", async () => {
+    const ctx = {
+      bridge: { draftSave: vi.fn() } as unknown as ToolContext["bridge"],
+      sessionId: "s1",
+    };
+    await expect(draftSaveTool.execute({ filename: "", content: "x" }, ctx)).rejects.toThrow();
+  });
+});
+
+describe("hs_code_lookup tool", () => {
+  const fakeCtx: ToolContext = { bridge: {} as never, sessionId: "s1" };
+
+  it("M1 mock 返回 3 个 candidate", async () => {
+    const result = await hsCodeLookupTool.execute({ description: "无线路由器" }, fakeCtx);
+    const text = result[0]?.text ?? "";
+    expect(text).toContain("无线路由器");
+    expect(text).toContain("8517.62");
+    expect(text).toContain("8542.31");
+    expect(text).toContain("9013.80");
+    expect(text).toContain("M1 mock");
+  });
+
+  it("不调用 bridge（read-only mock）", async () => {
+    const draftSave = vi.fn();
+    const sessionMetadata = vi.fn();
+    const ctx = {
+      bridge: { draftSave, sessionMetadata } as unknown as ToolContext["bridge"],
+      sessionId: "s1",
+    };
+    await hsCodeLookupTool.execute({ description: "x" }, ctx);
+    expect(draftSave).not.toHaveBeenCalled();
+    expect(sessionMetadata).not.toHaveBeenCalled();
+  });
+});
+
+describe("session_get_metadata tool", () => {
+  it("不传 sessionId 时用 ctx.sessionId（current task）", async () => {
+    const sessionMetadata = vi.fn().mockResolvedValue({
+      id: "current-session-id",
+      title: "current",
+      skillId: "fixture-skill",
+      createdAt: 1000,
+      updatedAt: 2000,
+      status: "active",
+    });
+    const ctx = {
+      bridge: { sessionMetadata } as unknown as ToolContext["bridge"],
+      sessionId: "current-session-id",
+    };
+
+    const result = await sessionGetMetadataTool.execute({}, ctx);
+    expect(sessionMetadata).toHaveBeenCalledWith({ sessionId: "current-session-id" });
+    expect(result[0]?.text).toContain("current-session-id");
+    expect(result[0]?.text).toContain("fixture-skill");
+    expect(result[0]?.text).toContain("status: active");
+  });
+
+  it("传 sessionId 时优先用传入值", async () => {
+    const sessionMetadata = vi.fn().mockResolvedValue(null);
+    const ctx = {
+      bridge: { sessionMetadata } as unknown as ToolContext["bridge"],
+      sessionId: "current",
+    };
+    await sessionGetMetadataTool.execute({ sessionId: "explicit-other" }, ctx);
+    expect(sessionMetadata).toHaveBeenCalledWith({ sessionId: "explicit-other" });
+  });
+
+  it("session 不存在时返回友好提示（不抛）", async () => {
+    const sessionMetadata = vi.fn().mockResolvedValue(null);
+    const ctx = {
+      bridge: { sessionMetadata } as unknown as ToolContext["bridge"],
+      sessionId: "ghost",
+    };
+    const result = await sessionGetMetadataTool.execute({}, ctx);
+    expect(result[0]?.text).toContain("No session found");
   });
 });

--- a/packages/skill-runtime/__fixtures__/sample-skill/prompt.md
+++ b/packages/skill-runtime/__fixtures__/sample-skill/prompt.md
@@ -1,0 +1,18 @@
+你正在跑 OpenTrad fixture skill 的端到端验证（M1 #26）。本 skill 不是真实业务，仅用于触发完整链路。
+
+主题：{{topic}}
+
+请按顺序做：
+
+1. 调用 `mcp__opentrad__echo`，message 设为 `"fixture skill running for {{topic}}"`，确认 mcp-server 可达
+2. 调用 `mcp__opentrad__draft_save`，filename 设为 `"fixture-{{topic}}.md"`，content 设为：
+
+```
+# {{topic}}
+
+Draft body for fixture verification.
+```
+
+3. 用一句中文确认两次工具调用都完成。
+
+约束：不要做任何超出上述三步的事，不要调用其他工具。

--- a/packages/skill-runtime/__fixtures__/sample-skill/skill.yml
+++ b/packages/skill-runtime/__fixtures__/sample-skill/skill.yml
@@ -1,0 +1,35 @@
+# Fixture skill —— 用于 M1 #26 (open-trad/opentrad#26) 端到端验证 startTask
+# 完整链路 + IPC bridge + 第一波 safe-only tools。
+#
+# 字段齐全（所有 SkillManifestSchema required + optional 都有），#23 (M1 #6)
+# SkillLoader 落地时直接复用本 fixture 验证 manifest 解析路径，#24 (M1 #7)
+# SkillPicker UI 也复用本 fixture 演示。trade-email-writer 真实化在 #30 (M1 #13)。
+
+id: fixture-skill
+title: Fixture Test Skill
+version: 0.1.0
+description: M1 #26 端到端验证 fixture——非业务 skill，触发 mcp__opentrad__echo + draft_save 完整链路
+category: communication
+riskLevel: draft_only
+
+allowedTools:
+  - mcp__opentrad__echo
+  - mcp__opentrad__draft_save
+disallowedTools:
+  - Bash(*)
+  - mcp__*__send*
+
+stopBefore: []
+
+inputs:
+  - name: topic
+    type: text
+    label: 主题
+    placeholder: 例如 "测试草稿"
+    required: true
+    default: "OpenTrad fixture run"
+
+outputs:
+  - draft
+
+promptTemplate: prompt.md

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -56,6 +56,9 @@ importers:
       electron:
         specifier: ^41.3.0
         version: 41.3.0
+      js-yaml:
+        specifier: ^4.1.1
+        version: 4.1.1
       node-pty:
         specifier: ^1.1.0
         version: 1.1.0
@@ -75,6 +78,9 @@ importers:
       '@types/better-sqlite3':
         specifier: ^7.6.13
         version: 7.6.13
+      '@types/js-yaml':
+        specifier: ^4.0.9
+        version: 4.0.9
       '@types/react':
         specifier: ^19.2.14
         version: 19.2.14
@@ -772,6 +778,9 @@ packages:
   '@types/http-cache-semantics@4.2.0':
     resolution: {integrity: sha512-L3LgimLHXtGkWikKnsPg0/VFx9OGZaC+eN1u4r+OB1XRqH3meBIAVC2zr1WdMH+RHmnRkqliQAOHNJ/E0j/e0Q==}
 
+  '@types/js-yaml@4.0.9':
+    resolution: {integrity: sha512-k4MGaQl5TGo/iipqb2UDG2UwjXziSWkh0uysQelTlJpX1qGlpUZYm8PnO4DxG1qBomtJUdYJ6qR6xdIah10JLg==}
+
   '@types/keyv@3.1.4':
     resolution: {integrity: sha512-BQ5aZNSCpj7D6K2ksrRCTmKRLEpnPvWDiLPfoGyhZ++8YtiK9d/3DBKPJgry359X/P1PfruyYwvnvwFjuEiEIg==}
 
@@ -864,6 +873,9 @@ packages:
 
   ajv@8.20.0:
     resolution: {integrity: sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==}
+
+  argparse@2.0.1:
+    resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
 
   assertion-error@2.0.1:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
@@ -1285,6 +1297,10 @@ packages:
 
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
+
+  js-yaml@4.1.1:
+    resolution: {integrity: sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==}
+    hasBin: true
 
   jsesc@3.1.0:
     resolution: {integrity: sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==}
@@ -2424,6 +2440,8 @@ snapshots:
 
   '@types/http-cache-semantics@4.2.0': {}
 
+  '@types/js-yaml@4.0.9': {}
+
   '@types/keyv@3.1.4':
     dependencies:
       '@types/node': 25.6.0
@@ -2522,6 +2540,8 @@ snapshots:
       fast-uri: 3.1.0
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
+
+  argparse@2.0.1: {}
 
   assertion-error@2.0.1: {}
 
@@ -3009,6 +3029,10 @@ snapshots:
   jose@6.2.2: {}
 
   js-tokens@4.0.0: {}
+
+  js-yaml@4.1.1:
+    dependencies:
+      argparse: 2.0.1
 
   jsesc@3.1.0: {}
 


### PR DESCRIPTION
按 [03-architecture.md §4.4](https://github.com/open-trad/docs/blob/main/design/03-architecture.md) + #26 issue body 接通 sessionStore.startTask 完整链路 + 第一波 safe-only mcp-server tools + **A4 events append ownership 落地**。

## 改动摘要

### Skill fixture(`packages/skill-runtime/__fixtures__/sample-skill/`)

字段齐全的 fixture(id / version / inputs / promptTemplate / allowedTools / disallowedTools / riskLevel / stopBefore 全有)。**stub != mock**(发起人 W2 起跑约束,对齐 M0 D6 教训)。#23 SkillLoader 落地后直接复用,#7 / #24 SkillPicker UI 也复用。

### Desktop fixture loader(临时,#23 落地后删)

`apps/desktop/src/main/services/skill-fixture-loader.ts`:
- `loadFixtureSkill(skillId)` js-yaml + zod 校验
- `composePrompt(loaded, inputs)` mustache 替换 + 通用前缀
- 注释明确 #23 真做后切换到 `@opentrad/skill-runtime`

### McpConfigWriter

`apps/desktop/src/main/services/mcp-writer.ts`(03 §4.4):
- `generateForSession(sessionId, manifest)` → \`tmpdir/opentrad-{uuid}.mcp.json\`
- 配置含 command / args / env(\`OPENTRAD_IPC_SOCKET\` + \`OPENTRAD_SESSION_ID\` + PATH 透传)
- \`__opentrad__\` 扩展元数据(skillId / version / riskLevel)留 #28 RiskGate 可能用
- \`cleanup(sessionId)\` 幂等

### cc:start-task IPC handler 完整链路

`apps/desktop/src/main/ipc/cc.ts` 替换 M0 hardcoded 路径,按 #26 issue body 1-7 步:
1. \`loadFixtureSkill(skillId)\` → manifest(#23 替换)
2. \`composePrompt(manifest, inputs)\` → fullPrompt(#23 替换)
3. \`mcpWriter.generateForSession(sessionId, manifest)\`
4. \`db.sessions.create({status:active})\`
5. \`CCManager.startTask({...mcpConfigPath, allowedTools})\`
6. **A4 落地**:for-await events 循环 **先 \`db.events.append\` → 再 \`webContents.send\`**;累加 lastModel / messageCount / cost
7. result 事件到达:\`updateMeta\` + \`updateStatus(completed/error)\` + \`cleanup\`

### 第一波 safe-only mcp-server tools

- \`draft-save.ts\`:调 \`bridge.draftSave\` RPC(#25 已落地 handler)→ 写 \`~/.opentrad/drafts/\`
- \`hs-code-lookup.ts\`:M1 mock 返回 3 个固定 candidate(M2 接真实数据库)
- \`session-get-metadata.ts\`:调 \`bridge.sessionMetadata\` RPC,默认用 ctx.sessionId

3 个工具都 \`riskLevel=safe\`,共 4 个工具(echo + 这三个)。

## A4 events append ownership 落地证据

端到端 smoke 跑 fixture skill 后 events 表 **12 条记录**:system/init / rate_limit / assistant_thinking × N / assistant_tool_use × 2(echo + draft_save) / tool_result × 2 / assistant_text / result。**M1 #12 / #29 历史回放有数据可读**。

## 测试(共 187 全过)

| 包 | 数量 | 新增 |
|---|---|---|
| desktop | **54**(↑8) | mcp-writer.test 3 + skill-fixture-loader.test 5 |
| mcp-server | **19**(↑6) | tools.test 扩展(echo 2 + draft_save 2 + hs_code_lookup 2 + session_get_metadata 3 + registry 3) |
| 其他 | 114 | 无变化 |

## 端到端 smoke(critical milestone 3 - **events append ownership 真接通**)

\`\`\`
[smoke26] CC called mcp__opentrad__echo ✓
[smoke26] CC called mcp__opentrad__draft_save ✓
[smoke26] result: success cost=\$0.156337 duration=12030ms
=== Smoke26 verification ===
sessions.status: completed
sessions.totalCostUsd: 0.156337
sessions.messageCount: 3
sessions.lastModel: claude-opus-4-7
events.countBySession: 12
new draft files (filtered by topic="smoke26"): 1
  - 2026-04-25-fixture-smoke26.md (48 bytes)
mcp-config cleanup: ✓ cleaned
\`\`\`

## 三个通报点兑现

| 通报 | 状态 |
|---|---|
| McpConfigWriter 跨平台 tmpdir 特殊行为 | 无,os.tmpdir() 自动平台标准;JSON 对反斜杠安全;Windows 真机延后 #21 |
| cc-adapter \`--mcp-config\` spawn 意外 | 无,M0 \`buildClaudeArgs\` 已支持,直接复用 |
| **A4 events append ownership 真接通** | **此 PR**。落点 \`cc.ts\` for-await 循环先 append 后 send |

## 不在本 PR 范围

- 真实 SkillLoader / PromptComposer:[M1 #23](https://github.com/open-trad/opentrad/issues/23)(本 PR fixture loader 占位)
- 真实 RiskGate(替换 ipc-bridge-handlers mock allow):[M1 #28](https://github.com/open-trad/opentrad/issues/28)
- 真实 trade-email-writer skill:[M1 #30](https://github.com/open-trad/opentrad/issues/30)
- electron-builder 打包 mcp-server:M1 #30

## Closes

Closes #26