### PR TITLE
feat(desktop): CC install onboarding + auto-detect loop + Windows A3 path (M1 #21)

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -24,6 +24,7 @@
     "better-sqlite3": "^12.9.0",
     "electron": "^41.3.0",
     "js-yaml": "^4.1.1",
+    "lucide-react": "^1.11.0",
     "node-pty": "^1.1.0",
     "react": "^19.2.5",
     "react-dom": "^19.2.5",

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -4,9 +4,10 @@
 
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
-import { CCManager } from "@opentrad/cc-adapter";
+import { CCManager, redactEmail } from "@opentrad/cc-adapter";
 import { app, BrowserWindow, dialog } from "electron";
 import { registerIpcHandlers } from "./ipc";
+import { DetectLoopRegistry } from "./services/cc-detect-loop";
 import { createDbServices, type DbServices, getIpcSocketPath } from "./services/db";
 import { createIpcBridgeHandlers } from "./services/ipc-bridge-handlers";
 import { IpcBridgeServer } from "./services/ipc-bridge-server";
@@ -21,6 +22,9 @@ const ccManager = new CCManager();
 
 // 全局 PtyManager 单例：跨窗口共享，路由由 IPC handler 内部 ptyId → webContents 管理。
 const ptyManager = new PtyManager();
+
+// CC 安装状态后台轮询注册表（M1 #21）：onboarding 流程触发，每 webContents 一个 loop。
+const detectLoopRegistry = new DetectLoopRegistry(ccManager, redactEmail);
 
 // McpConfigWriter（M1 #26）：每次 startTask 生成临时 mcp-config，让 CC 通过 stdio
 // 拉起 apps/mcp-server。dev 用 tsx 跑 .ts 入口；electron-builder 打包路径在 M1 #13。
@@ -100,6 +104,7 @@ app.whenReady().then(() => {
     db: dbServices,
     pty: ptyManager,
     mcpWriter,
+    detectLoop: detectLoopRegistry,
   });
   createMainWindow();
 
@@ -132,6 +137,11 @@ app.on("before-quit", async (event) => {
 });
 
 function finalizeShutdown(): void {
+  try {
+    detectLoopRegistry.cleanupAll();
+  } catch (err) {
+    console.error("[main] detect-loop cleanup error", err);
+  }
   try {
     ptyManager.cleanup();
   } catch (err) {

--- a/apps/desktop/src/main/ipc/index.ts
+++ b/apps/desktop/src/main/ipc/index.ts
@@ -2,11 +2,13 @@
 // 新增 domain 时在此 register 进来。
 
 import type { CCManager } from "@opentrad/cc-adapter";
+import type { DetectLoopRegistry } from "../services/cc-detect-loop";
 import type { DbServices } from "../services/db";
 import type { McpConfigWriter } from "../services/mcp-writer";
 import type { PtyManager } from "../services/pty-manager";
 import { registerCcHandlers } from "./cc";
 import { registerInstalledSkillHandlers } from "./installed-skill";
+import { registerInstallerHandlers } from "./installer";
 import { registerPtyHandlers } from "./pty";
 import { registerSessionHandlers } from "./session";
 import { registerSettingsHandlers } from "./settings";
@@ -16,6 +18,7 @@ export interface IpcDeps {
   db: DbServices;
   pty: PtyManager;
   mcpWriter: McpConfigWriter;
+  detectLoop: DetectLoopRegistry;
 }
 
 export function registerIpcHandlers(deps: IpcDeps): void {
@@ -24,5 +27,6 @@ export function registerIpcHandlers(deps: IpcDeps): void {
   registerSettingsHandlers(deps.db);
   registerInstalledSkillHandlers(deps.db);
   registerPtyHandlers(deps.pty);
-  // 后续 domain：skill / risk-gate / installer 在此注册
+  registerInstallerHandlers({ pty: deps.pty, detectLoop: deps.detectLoop });
+  // 后续 domain：skill / risk-gate 在此注册
 }

--- a/apps/desktop/src/main/ipc/installer.ts
+++ b/apps/desktop/src/main/ipc/installer.ts
@@ -1,0 +1,75 @@
+// installer:* + cc:detect-loop-* IPC handlers（M1 #21 / open-trad/opentrad#21）。
+//
+// 流程：
+// 1. renderer 进入 OnboardingStep1 → installer:supports-auto-install 探平台
+// 2. supports=true（macOS/Linux）→ "一键安装" → installer:run-cc-install
+//    主进程通过 PtyManager spawn `bash -c 'curl ... | bash'`，返回 ptyId
+//    给 renderer 渲染 TerminalPane
+// 3. supports=false（Windows）→ UI 显示 docs.claude.com 链接 + "我已装好"
+// 4. 安装结束 / 用户点"重新检测" → cc:detect-loop-start 启动后台轮询
+//    主进程每 3s 跑 detectInstallation()，通过 cc:status 推 renderer
+//    检测到 installed=true 自动停 + renderer 切到 LoginStep（M1 #22）
+
+import {
+  type CCDetectLoopStartRequest,
+  CCDetectLoopStartRequestSchema,
+  type InstallerRunCcInstallResponse,
+  type InstallerSupportsAutoInstallResponse,
+  IpcChannels,
+} from "@opentrad/shared";
+import { ipcMain } from "electron";
+import type { DetectLoopRegistry } from "../services/cc-detect-loop";
+import { getAutoInstallCommand, getPlatformInstallSupport } from "../services/installer";
+import type { PtyManager } from "../services/pty-manager";
+
+export interface InstallerHandlerDeps {
+  pty: PtyManager;
+  detectLoop: DetectLoopRegistry;
+}
+
+export function registerInstallerHandlers(deps: InstallerHandlerDeps): void {
+  const { pty, detectLoop } = deps;
+
+  ipcMain.handle(
+    IpcChannels.InstallerSupportsAutoInstall,
+    async (): Promise<InstallerSupportsAutoInstallResponse> => {
+      return getPlatformInstallSupport();
+    },
+  );
+
+  ipcMain.handle(
+    IpcChannels.InstallerRunCcInstall,
+    async (event): Promise<InstallerRunCcInstallResponse> => {
+      const support = getPlatformInstallSupport();
+      if (!support.supportsAutoInstall) {
+        throw new Error(
+          `auto-install not supported on ${support.platform}; use ${support.manualInstallUrl}`,
+        );
+      }
+      const cmd = getAutoInstallCommand();
+      const ptyId = pty.spawn({
+        command: cmd.command,
+        args: cmd.args,
+      });
+      // PTY 输出已通过 #20 的 PtyData / PtyExit 事件路由到 renderer
+      // （renderer 用 TerminalPane 订阅同款 ptyId）
+      // webContents 销毁时 #20 会自动 kill 该 PTY，无需在此重复
+      void event;
+      return { ptyId };
+    },
+  );
+
+  ipcMain.handle(IpcChannels.CCDetectLoopStart, async (event, raw: unknown): Promise<void> => {
+    const req: CCDetectLoopStartRequest = CCDetectLoopStartRequestSchema.parse(raw ?? {});
+    detectLoop.start(event.sender, {
+      intervalMs: req.intervalMs,
+      maxDurationMs: req.maxDurationMs,
+    });
+    // sender 销毁时清 timer
+    event.sender.once("destroyed", () => detectLoop.stop(event.sender));
+  });
+
+  ipcMain.handle(IpcChannels.CCDetectLoopStop, async (event): Promise<void> => {
+    detectLoop.stop(event.sender);
+  });
+}

--- a/apps/desktop/src/main/services/cc-detect-loop.ts
+++ b/apps/desktop/src/main/services/cc-detect-loop.ts
@@ -1,0 +1,119 @@
+// CC 安装状态后台轮询（M1 #21 / open-trad/opentrad#21）。
+//
+// renderer 在 install 流程触发后调 cc:detect-loop-start，主进程每
+// intervalMs 跑一次 detectInstallation()，通过 cc:status push 给 renderer。
+// 5 分钟（默认 maxDurationMs）后自动停止防空跑（avoid 跑了 5 分钟还没装好的
+// 死循环）。
+//
+// 单例 per webContents：每个 renderer 同时只能有一个 detect loop（多次
+// start 时 stop 旧的）。stop / sender destroyed → 立刻清 timer。
+
+import type { CCManager, redactEmail as redactEmailFn } from "@opentrad/cc-adapter";
+import { type CCStatus, IpcChannels } from "@opentrad/shared";
+import type { WebContents } from "electron";
+
+export interface DetectLoopOptions {
+  intervalMs: number;
+  maxDurationMs: number;
+}
+
+export class DetectLoopRegistry {
+  private readonly loops = new Map<number, NodeJS.Timeout>();
+  private readonly stopAt = new Map<number, number>();
+
+  constructor(
+    private readonly manager: CCManager,
+    private readonly redactEmail: typeof redactEmailFn,
+  ) {}
+
+  start(sender: WebContents, opts: DetectLoopOptions): void {
+    this.stop(sender); // 重启前先清旧的
+
+    const senderId = sender.id;
+    this.stopAt.set(senderId, Date.now() + opts.maxDurationMs);
+
+    const tick = async (): Promise<void> => {
+      if (sender.isDestroyed()) {
+        this.stop(sender);
+        return;
+      }
+      // 超时自动停
+      const deadline = this.stopAt.get(senderId);
+      if (deadline !== undefined && Date.now() > deadline) {
+        this.stop(sender);
+        return;
+      }
+
+      try {
+        const status = await this.buildStatus();
+        if (!sender.isDestroyed()) {
+          sender.send(IpcChannels.CCStatus, status);
+        }
+        // 检测到 installed=true 自动停（renderer 收到后切到 LoginStep）
+        if (status.installed) {
+          this.stop(sender);
+        }
+      } catch {
+        // 不抛；下一次 tick 再试
+      }
+    };
+
+    // 立刻跑一次（不等 interval）
+    void tick();
+    const timer = setInterval(tick, opts.intervalMs);
+    this.loops.set(senderId, timer);
+  }
+
+  stop(sender: WebContents): void {
+    const senderId = sender.id;
+    const timer = this.loops.get(senderId);
+    if (timer) {
+      clearInterval(timer);
+      this.loops.delete(senderId);
+    }
+    this.stopAt.delete(senderId);
+  }
+
+  cleanupAll(): void {
+    for (const [, timer] of this.loops) clearInterval(timer);
+    this.loops.clear();
+    this.stopAt.clear();
+  }
+
+  // 跟 ipc/cc.ts 的 buildCcStatus 同款逻辑（detect + auth）。
+  // 复用而非 import 避免循环依赖（cc.ts 也持有 manager）。
+  private async buildStatus(): Promise<CCStatus> {
+    try {
+      const detected = await this.manager.detectInstallation();
+      if (!detected.installed) {
+        return { installed: false, error: detected.error };
+      }
+      let loggedIn = false;
+      let email: string | undefined;
+      let authMethod: "subscription" | "api_key" | undefined;
+      let authError: string | undefined;
+      try {
+        const auth = await this.manager.getAuthStatus();
+        loggedIn = auth.loggedIn;
+        authMethod = auth.method;
+        email = auth.email ? this.redactEmail(auth.email) : undefined;
+        authError = auth.error;
+      } catch (err) {
+        authError = err instanceof Error ? err.message : String(err);
+      }
+      return {
+        installed: true,
+        version: detected.version,
+        loggedIn,
+        email,
+        authMethod,
+        error: authError,
+      };
+    } catch (err) {
+      return {
+        installed: false,
+        error: err instanceof Error ? err.message : String(err),
+      };
+    }
+  }
+}

--- a/apps/desktop/src/main/services/installer.ts
+++ b/apps/desktop/src/main/services/installer.ts
@@ -1,0 +1,53 @@
+// CC 安装命令封装（M1 #21 / open-trad/opentrad#21）。
+//
+// 跨平台支持矩阵（A3 决策）：
+// - macOS / Linux：自动安装 → `bash -c 'curl -fsSL https://claude.ai/install.sh | bash'`
+//   通过 PTY spawn，让 renderer 的 TerminalPane 实时显示进度
+// - Windows：**降级**——Anthropic 当前没有官方一键安装脚本，UI 引导用户去
+//   docs.claude.com 手动装。auto-install 不暴露按钮，避免误用
+//
+// 隐私 / 安全：
+// - 安装命令直接来自 claude.ai 官方域名，UI 上明示让用户读完再决定
+// - 不读 ~/.claude / ~/.config/claude / Keychain（红线）
+// - 不写凭证文件，安装结束 CC 自己管登录态（M1 #22 / open-trad/opentrad#22）
+
+export interface InstallerCommand {
+  command: string;
+  args: string[];
+}
+
+export interface PlatformInstallSupport {
+  supportsAutoInstall: boolean;
+  manualInstallUrl: string;
+  platform: "darwin" | "linux" | "win32" | "other";
+}
+
+const MANUAL_INSTALL_URL = "https://docs.claude.com/en/docs/claude-code/quickstart";
+
+export function getPlatformInstallSupport(): PlatformInstallSupport {
+  const platform = normalizePlatform();
+  return {
+    supportsAutoInstall: platform === "darwin" || platform === "linux",
+    manualInstallUrl: MANUAL_INSTALL_URL,
+    platform,
+  };
+}
+
+// 拼自动安装命令。Windows 不该走这条路径（caller 用 supportsAutoInstall 守门）。
+// 命令显式用 bash -c "..." 形式，避免 shell 解析陷阱（pipe / quote 都被 bash 自己处理）。
+export function getAutoInstallCommand(): InstallerCommand {
+  if (!getPlatformInstallSupport().supportsAutoInstall) {
+    throw new Error("auto-install is not supported on this platform; use manual URL");
+  }
+  return {
+    command: "/bin/bash",
+    args: ["-c", "curl -fsSL https://claude.ai/install.sh | bash"],
+  };
+}
+
+function normalizePlatform(): PlatformInstallSupport["platform"] {
+  if (process.platform === "darwin") return "darwin";
+  if (process.platform === "linux") return "linux";
+  if (process.platform === "win32") return "win32";
+  return "other";
+}

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -19,6 +19,8 @@ import type {
   CCStartTaskRequest,
   CCStartTaskResponse,
   CCStatus,
+  InstallerRunCcInstallResponse,
+  InstallerSupportsAutoInstallResponse,
   PtyDataEvent,
   PtyExitEvent,
   PtyKillRequest,
@@ -50,6 +52,27 @@ const api = {
         ipcRenderer.removeListener(IpcChannels.CCEvent, listener);
       };
     },
+    onStatus(handler: (status: CCStatus) => void): () => void {
+      const listener = (_event: unknown, status: CCStatus): void => handler(status);
+      ipcRenderer.on(IpcChannels.CCStatus, listener);
+      return () => {
+        ipcRenderer.removeListener(IpcChannels.CCStatus, listener);
+      };
+    },
+    detectLoopStart(req: { intervalMs?: number; maxDurationMs?: number } = {}): Promise<void> {
+      return ipcRenderer.invoke(IpcChannels.CCDetectLoopStart, req);
+    },
+    detectLoopStop(): Promise<void> {
+      return ipcRenderer.invoke(IpcChannels.CCDetectLoopStop);
+    },
+  },
+  installer: {
+    supportsAutoInstall(): Promise<InstallerSupportsAutoInstallResponse> {
+      return ipcRenderer.invoke(IpcChannels.InstallerSupportsAutoInstall);
+    },
+    runCcInstall(): Promise<InstallerRunCcInstallResponse> {
+      return ipcRenderer.invoke(IpcChannels.InstallerRunCcInstall);
+    },
   },
   pty: {
     spawn(req: PtySpawnRequest): Promise<PtySpawnResponse> {
@@ -79,7 +102,15 @@ const api = {
       };
     },
   },
-  // skill / session / settings / risk-gate 后续补
+  settings: {
+    get(key: string): Promise<unknown> {
+      return ipcRenderer.invoke(IpcChannels.SettingsGet, { key });
+    },
+    set(key: string, value: unknown): Promise<void> {
+      return ipcRenderer.invoke(IpcChannels.SettingsSet, { key, value });
+    },
+  },
+  // skill / session / risk-gate 后续补
 } as const;
 
 export type OpenTradApi = typeof api;

--- a/apps/desktop/src/renderer/App.tsx
+++ b/apps/desktop/src/renderer/App.tsx
@@ -6,6 +6,7 @@ import type { CCEvent, CCStatus } from "@opentrad/shared";
 import type { ReactElement } from "react";
 import { useEffect, useState } from "react";
 import { TerminalPane } from "./components/ui/TerminalPane";
+import { OnboardingGate } from "./features/onboarding/OnboardingGate";
 
 type CcStatusState =
   | { kind: "loading" }
@@ -18,6 +19,14 @@ type TaskState =
   | { kind: "finished"; sessionId: string; success: boolean };
 
 export function App(): ReactElement {
+  return (
+    <OnboardingGate>
+      <MainApp />
+    </OnboardingGate>
+  );
+}
+
+function MainApp(): ReactElement {
   const [ccStatus, setCcStatus] = useState<CcStatusState>({ kind: "loading" });
   const [task, setTask] = useState<TaskState>({ kind: "idle" });
   const [events, setEvents] = useState<CCEvent[]>([]);

--- a/apps/desktop/src/renderer/features/onboarding/InstallStep.tsx
+++ b/apps/desktop/src/renderer/features/onboarding/InstallStep.tsx
@@ -3,17 +3,19 @@
 // 三种用户路径：
 // 1. 自动安装（macOS / Linux）：点"一键安装" → 后端 PTY spawn install.sh →
 //    TerminalPane 显示输出 → install.sh 退出后启动 detect-loop 等 installed=true
-// 2. 手动安装（Windows，A3 降级）：UI 显示 docs.claude.com 链接 + "我已装好"
+// 2. 手动安装（Windows，A3 降级）：UI 显示 docs.claude.com 链接 + "已安装,继续"
 //    按钮 → 点击后启动 detect-loop
 // 3. 跳过引导：进 main 但保持 onboarded=false（issue body 验收要求）
 //
-// 隐私：UI 醒目提示安装命令直接来自 claude.ai 官方，可读完再决定。
+// 视觉分组（manual 路径）：info 提示 → 文档链接 → 操作按钮，"为什么 → 怎么办 → 做完了"
+// 隐私（auto 路径）：UI 醒目提示安装命令直接来自 claude.ai 官方，可读完再决定。
 
 import type {
   CCStatus,
   InstallerSupportsAutoInstallResponse,
   PtyDataEvent,
 } from "@opentrad/shared";
+import { ExternalLink, Loader2 } from "lucide-react";
 import { type ReactElement, useEffect, useState } from "react";
 
 export interface InstallStepProps {
@@ -46,6 +48,8 @@ type Phase =
   | DetectingPhase
   | { kind: "error"; message: string };
 
+const ISSUES_URL = "https://github.com/open-trad/opentrad/issues";
+
 export function InstallStep({ onInstalled, onSkip }: InstallStepProps): ReactElement {
   const [phase, setPhase] = useState<Phase>({ kind: "loading" });
 
@@ -60,7 +64,7 @@ export function InstallStep({ onInstalled, onSkip }: InstallStepProps): ReactEle
         ]);
         if (cancelled) return;
         if (status.installed) {
-          // 已经装好，直接推进（不进 onboarding）
+          // 已经装好,直接推进(不进 onboarding)
           onInstalled(status);
           return;
         }
@@ -114,7 +118,7 @@ export function InstallStep({ onInstalled, onSkip }: InstallStepProps): ReactEle
     });
     const offExit = window.api.pty.onExit((evt) => {
       if (evt.ptyId !== ptyId) return;
-      // PTY 退出后启动 detect-loop（每 3s 检测一次，5min 兜底）
+      // PTY 退出后启动 detect-loop（每 3s 检测一次,5min 兜底）
       void window.api.cc.detectLoopStart({ intervalMs: 3000, maxDurationMs: 5 * 60 * 1000 });
       setPhase({ kind: "detecting", support });
     });
@@ -134,13 +138,14 @@ export function InstallStep({ onInstalled, onSkip }: InstallStepProps): ReactEle
   // ----- 渲染 -----
 
   const palette = {
-    bg: "#0f172a",
     cardBg: "#fff",
     border: "#e5e7eb",
     primary: "#2563eb",
     text: "#111827",
     muted: "#6b7280",
-    accent: "#dbeafe",
+    info: "#dbeafe",
+    infoText: "#1e3a8a",
+    soft: "#f3f4f6",
   };
 
   const containerStyle: React.CSSProperties = {
@@ -171,19 +176,51 @@ export function InstallStep({ onInstalled, onSkip }: InstallStepProps): ReactEle
     cursor: "pointer",
     fontSize: "0.95rem",
   };
-  const buttonSecondary: React.CSSProperties = {
-    background: "white",
-    color: palette.text,
-    border: `1px solid ${palette.border}`,
-    padding: "0.6rem 1.2rem",
-    borderRadius: 6,
+
+  // 底部小字链接（兜底求助 + 跳过引导）
+  const footerLinkStyle: React.CSSProperties = {
+    color: palette.muted,
+    fontSize: "0.8rem",
+    textDecoration: "none",
     cursor: "pointer",
-    fontSize: "0.95rem",
+    background: "none",
+    border: "none",
+    padding: 0,
+    fontFamily: "inherit",
   };
+
+  const footer = (
+    <div
+      style={{
+        marginTop: "1.25rem",
+        display: "flex",
+        gap: "1.5rem",
+        justifyContent: "center",
+        alignItems: "center",
+      }}
+    >
+      <a
+        href={ISSUES_URL}
+        target="_blank"
+        rel="noreferrer"
+        onClick={(e) => {
+          e.preventDefault();
+          window.open(ISSUES_URL, "_blank", "noopener,noreferrer");
+        }}
+        style={{ ...footerLinkStyle, textDecoration: "underline" }}
+      >
+        安装遇到问题?
+      </a>
+      <button type="button" onClick={onSkip} style={footerLinkStyle}>
+        暂时跳过(部分功能不可用)
+      </button>
+    </div>
+  );
 
   if (phase.kind === "loading") {
     return (
       <div style={containerStyle}>
+        <SpinKeyframes />
         <div style={cardStyle}>
           <div style={{ color: palette.muted }}>检测中…</div>
         </div>
@@ -194,6 +231,7 @@ export function InstallStep({ onInstalled, onSkip }: InstallStepProps): ReactEle
   if (phase.kind === "error") {
     return (
       <div style={containerStyle}>
+        <SpinKeyframes />
         <div style={cardStyle}>
           <h2 style={{ margin: "0 0 1rem", color: "#b91c1c" }}>初始化失败</h2>
           <pre
@@ -207,76 +245,84 @@ export function InstallStep({ onInstalled, onSkip }: InstallStepProps): ReactEle
           >
             {phase.message}
           </pre>
-          <button type="button" onClick={onSkip} style={{ ...buttonSecondary, marginTop: "1rem" }}>
-            跳过引导
-          </button>
         </div>
+        {footer}
       </div>
     );
   }
 
   return (
     <div style={containerStyle}>
+      <SpinKeyframes />
       <div style={cardStyle}>
         <h1 style={{ margin: "0 0 0.5rem", fontSize: "1.5rem" }}>欢迎使用 OpenTrad</h1>
         <p style={{ margin: "0 0 1.5rem", color: palette.muted }}>第 1 步:安装 Claude Code</p>
 
-        {/* 自动安装路径（macOS / Linux）*/}
         {phase.support.supportsAutoInstall ? (
           <AutoInstallSection
             phase={phase}
             onAutoInstall={handleAutoInstall}
             buttonPrimary={buttonPrimary}
-            buttonSecondary={buttonSecondary}
             palette={palette}
-            onSkip={onSkip}
           />
         ) : (
           <ManualInstallSection
             support={phase.support}
             onAlreadyInstalled={handleAlreadyInstalled}
             buttonPrimary={buttonPrimary}
-            buttonSecondary={buttonSecondary}
             palette={palette}
-            onSkip={onSkip}
             phase={phase}
           />
         )}
       </div>
+      {footer}
     </div>
   );
 }
 
-interface SectionProps {
-  buttonPrimary: React.CSSProperties;
-  buttonSecondary: React.CSSProperties;
-  palette: { muted: string; accent: string; border: string };
-  onSkip: () => void;
+// inline keyframes 注入：避免引 Tailwind / 全局 CSS
+function SpinKeyframes(): ReactElement {
+  return (
+    <style>{`@keyframes opentrad-spin { from { transform: rotate(0deg); } to { transform: rotate(360deg); } }`}</style>
+  );
 }
 
-interface AutoInstallSectionProps extends SectionProps {
+const spinIconStyle: React.CSSProperties = {
+  animation: "opentrad-spin 1s linear infinite",
+};
+
+interface SectionPalette {
+  muted: string;
+  info: string;
+  infoText: string;
+  border: string;
+  soft: string;
+  primary: string;
+}
+
+interface AutoInstallSectionProps {
   phase: ReadyPhase | InstallingPhase | DetectingPhase;
   onAutoInstall: () => void;
+  buttonPrimary: React.CSSProperties;
+  palette: SectionPalette;
 }
 
 function AutoInstallSection({
   phase,
   onAutoInstall,
   buttonPrimary,
-  buttonSecondary,
   palette,
-  onSkip,
 }: AutoInstallSectionProps): ReactElement {
   return (
     <div>
       <div
         style={{
-          background: palette.accent,
+          background: palette.info,
           padding: "0.75rem 1rem",
           borderRadius: 6,
           fontSize: "0.85rem",
           marginBottom: "1rem",
-          color: "#1e3a8a",
+          color: palette.infoText,
         }}
       >
         🛡 安装命令直接来自 claude.ai 官方:
@@ -289,14 +335,9 @@ function AutoInstallSection({
       </div>
 
       {phase.kind === "ready" ? (
-        <div style={{ display: "flex", gap: "0.75rem" }}>
-          <button type="button" onClick={onAutoInstall} style={buttonPrimary}>
-            一键安装 Claude Code
-          </button>
-          <button type="button" onClick={onSkip} style={buttonSecondary}>
-            跳过引导
-          </button>
-        </div>
+        <button type="button" onClick={onAutoInstall} style={buttonPrimary}>
+          一键安装 Claude Code
+        </button>
       ) : null}
 
       {phase.kind === "installing" ? (
@@ -323,19 +364,19 @@ function AutoInstallSection({
       ) : null}
 
       {phase.kind === "detecting" ? (
-        <div style={{ color: palette.muted, fontSize: "0.9rem" }}>
-          正在检测安装是否完成…(每 3 秒查一次,最长 5 分钟)
-        </div>
+        <DetectingIndicator palette={palette} hintMaxText="最多等待 5 分钟" />
       ) : null}
     </div>
   );
 }
 
-interface ManualInstallSectionProps extends SectionProps {
+interface ManualInstallSectionProps {
   support: InstallerSupportsAutoInstallResponse;
   onAlreadyInstalled: () => void;
-  // 接受 union 简化父组件类型；installing 在 manual 路径运行时不会出现
-  // （只 auto 路径转入），渲染层降级当 ready 处理
+  buttonPrimary: React.CSSProperties;
+  palette: SectionPalette;
+  // 接受 union 简化父组件类型;installing 在 manual 路径运行时不会出现
+  // (只 auto 路径转入),渲染层降级当 ready 处理
   phase: ReadyPhase | InstallingPhase | DetectingPhase;
 }
 
@@ -343,66 +384,94 @@ function ManualInstallSection({
   support,
   onAlreadyInstalled,
   buttonPrimary,
-  buttonSecondary,
   palette,
-  onSkip,
   phase,
 }: ManualInstallSectionProps): ReactElement {
   return (
     <div>
+      {/* 第 1 段:为什么(蓝底 info) */}
       <div
         style={{
-          background: "#fef3c7",
+          background: palette.info,
           padding: "0.75rem 1rem",
           borderRadius: 6,
           fontSize: "0.9rem",
           marginBottom: "1rem",
-          color: "#92400e",
+          color: palette.infoText,
         }}
       >
-        OpenTrad 当前在 <strong>{support.platform}</strong> 上不提供自动安装 Claude
-        Code。请按官方文档手动安装,装完后点"我已装好"按钮。
+        Windows 上需要手动安装 Claude Code。点击下方链接按官方文档完成安装,然后回到这里继续。
       </div>
 
-      <div style={{ marginBottom: "1rem" }}>
+      {/* 第 2 段:怎么办(浅灰底 + 外链 icon) */}
+      <div
+        style={{
+          background: palette.soft,
+          border: `1px solid ${palette.border}`,
+          padding: "0.75rem 1rem",
+          borderRadius: 6,
+          marginBottom: "1.25rem",
+        }}
+      >
         <a
           href={support.manualInstallUrl}
           target="_blank"
           rel="noreferrer"
           onClick={(e) => {
             e.preventDefault();
-            // shell.openExternal 会被 main 进程 IPC 拦截;此处直接打开外链
             window.open(support.manualInstallUrl, "_blank", "noopener,noreferrer");
           }}
           style={{
-            color: "#2563eb",
+            color: palette.primary,
             textDecoration: "underline",
             fontSize: "0.95rem",
+            display: "inline-flex",
+            alignItems: "center",
+            gap: "0.4rem",
           }}
         >
-          打开官方安装文档 →
+          打开官方安装文档
+          <ExternalLink size={14} aria-hidden="true" />
         </a>
       </div>
 
-      <div style={{ display: "flex", gap: "0.75rem" }}>
-        <button
-          type="button"
-          onClick={onAlreadyInstalled}
-          style={buttonPrimary}
-          disabled={phase.kind === "detecting"}
-        >
-          {phase.kind === "detecting" ? "检测中…" : "我已装好,重新检测"}
-        </button>
-        <button type="button" onClick={onSkip} style={buttonSecondary}>
-          跳过引导
-        </button>
-      </div>
+      {/* 第 3 段:做完了(主按钮) */}
+      <button
+        type="button"
+        onClick={onAlreadyInstalled}
+        style={buttonPrimary}
+        disabled={phase.kind === "detecting"}
+      >
+        {phase.kind === "detecting" ? "检测中…" : "已安装,继续"}
+      </button>
 
       {phase.kind === "detecting" ? (
-        <div style={{ marginTop: "1rem", color: palette.muted, fontSize: "0.85rem" }}>
-          正在检测…(每 3 秒查一次,1 分钟超时)
-        </div>
+        <DetectingIndicator palette={palette} hintMaxText="最多等待 1 分钟" />
       ) : null}
+    </div>
+  );
+}
+
+function DetectingIndicator({
+  palette,
+  hintMaxText,
+}: {
+  palette: { muted: string };
+  hintMaxText: string;
+}): ReactElement {
+  return (
+    <div
+      style={{
+        marginTop: "1rem",
+        display: "inline-flex",
+        alignItems: "center",
+        gap: "0.5rem",
+        color: palette.muted,
+        fontSize: "0.9rem",
+      }}
+    >
+      <Loader2 size={16} style={spinIconStyle} aria-hidden="true" />
+      <span>正在检测 Claude Code({hintMaxText})…</span>
     </div>
   );
 }

--- a/apps/desktop/src/renderer/features/onboarding/InstallStep.tsx
+++ b/apps/desktop/src/renderer/features/onboarding/InstallStep.tsx
@@ -1,0 +1,408 @@
+// CC 安装引导（M1 #21 / open-trad/opentrad#21 OnboardingStep1）。
+//
+// 三种用户路径：
+// 1. 自动安装（macOS / Linux）：点"一键安装" → 后端 PTY spawn install.sh →
+//    TerminalPane 显示输出 → install.sh 退出后启动 detect-loop 等 installed=true
+// 2. 手动安装（Windows，A3 降级）：UI 显示 docs.claude.com 链接 + "我已装好"
+//    按钮 → 点击后启动 detect-loop
+// 3. 跳过引导：进 main 但保持 onboarded=false（issue body 验收要求）
+//
+// 隐私：UI 醒目提示安装命令直接来自 claude.ai 官方，可读完再决定。
+
+import type {
+  CCStatus,
+  InstallerSupportsAutoInstallResponse,
+  PtyDataEvent,
+} from "@opentrad/shared";
+import { type ReactElement, useEffect, useState } from "react";
+
+export interface InstallStepProps {
+  // 已 installed 时回调（detect-loop 推 cc:status 自动触发）
+  onInstalled: (status: CCStatus) => void;
+  // 用户主动跳过引导
+  onSkip: () => void;
+}
+
+type ReadyPhase = {
+  kind: "ready";
+  support: InstallerSupportsAutoInstallResponse;
+  status: CCStatus;
+};
+type InstallingPhase = {
+  kind: "installing";
+  ptyId: string;
+  lines: string[];
+  support: InstallerSupportsAutoInstallResponse;
+};
+type DetectingPhase = {
+  kind: "detecting";
+  support: InstallerSupportsAutoInstallResponse;
+};
+
+type Phase =
+  | { kind: "loading" }
+  | ReadyPhase
+  | InstallingPhase
+  | DetectingPhase
+  | { kind: "error"; message: string };
+
+export function InstallStep({ onInstalled, onSkip }: InstallStepProps): ReactElement {
+  const [phase, setPhase] = useState<Phase>({ kind: "loading" });
+
+  // 初次加载：探平台支持 + 当前 cc:status
+  useEffect(() => {
+    let cancelled = false;
+    void (async () => {
+      try {
+        const [support, status] = await Promise.all([
+          window.api.installer.supportsAutoInstall(),
+          window.api.cc.status(),
+        ]);
+        if (cancelled) return;
+        if (status.installed) {
+          // 已经装好，直接推进（不进 onboarding）
+          onInstalled(status);
+          return;
+        }
+        setPhase({ kind: "ready", support, status });
+      } catch (err) {
+        if (cancelled) return;
+        const message = err instanceof Error ? err.message : String(err);
+        setPhase({ kind: "error", message });
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [onInstalled]);
+
+  // 监听 cc:status push（detect-loop 触发的）
+  useEffect(() => {
+    const unsubscribe = window.api.cc.onStatus((status) => {
+      if (status.installed) {
+        // 自动停 detect-loop 由 main 端做（推到 installed=true 后内部 stop）
+        onInstalled(status);
+      }
+    });
+    return unsubscribe;
+  }, [onInstalled]);
+
+  const handleAutoInstall = async (): Promise<void> => {
+    if (phase.kind !== "ready") return;
+    try {
+      const { ptyId } = await window.api.installer.runCcInstall();
+      setPhase({ kind: "installing", ptyId, lines: [], support: phase.support });
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      setPhase({ kind: "error", message });
+    }
+  };
+
+  // PTY 数据流 + 退出（installing 阶段）
+  useEffect(() => {
+    if (phase.kind !== "installing") return;
+    const ptyId = phase.ptyId;
+    const support = phase.support;
+
+    const offData = window.api.pty.onData((evt: PtyDataEvent) => {
+      if (evt.ptyId !== ptyId) return;
+      setPhase((prev) =>
+        prev.kind === "installing" && prev.ptyId === ptyId
+          ? { ...prev, lines: [...prev.lines, evt.data] }
+          : prev,
+      );
+    });
+    const offExit = window.api.pty.onExit((evt) => {
+      if (evt.ptyId !== ptyId) return;
+      // PTY 退出后启动 detect-loop（每 3s 检测一次，5min 兜底）
+      void window.api.cc.detectLoopStart({ intervalMs: 3000, maxDurationMs: 5 * 60 * 1000 });
+      setPhase({ kind: "detecting", support });
+    });
+
+    return () => {
+      offData();
+      offExit();
+    };
+  }, [phase]);
+
+  const handleAlreadyInstalled = (): void => {
+    if (phase.kind !== "ready") return;
+    void window.api.cc.detectLoopStart({ intervalMs: 3000, maxDurationMs: 60 * 1000 });
+    setPhase({ kind: "detecting", support: phase.support });
+  };
+
+  // ----- 渲染 -----
+
+  const palette = {
+    bg: "#0f172a",
+    cardBg: "#fff",
+    border: "#e5e7eb",
+    primary: "#2563eb",
+    text: "#111827",
+    muted: "#6b7280",
+    accent: "#dbeafe",
+  };
+
+  const containerStyle: React.CSSProperties = {
+    minHeight: "100vh",
+    display: "flex",
+    flexDirection: "column",
+    alignItems: "center",
+    justifyContent: "center",
+    padding: "2rem",
+    fontFamily: "system-ui, -apple-system, sans-serif",
+    color: palette.text,
+  };
+  const cardStyle: React.CSSProperties = {
+    background: palette.cardBg,
+    border: `1px solid ${palette.border}`,
+    borderRadius: 8,
+    padding: "2rem",
+    maxWidth: 720,
+    width: "100%",
+    boxShadow: "0 1px 3px rgba(0, 0, 0, 0.05)",
+  };
+  const buttonPrimary: React.CSSProperties = {
+    background: palette.primary,
+    color: "white",
+    border: "none",
+    padding: "0.6rem 1.2rem",
+    borderRadius: 6,
+    cursor: "pointer",
+    fontSize: "0.95rem",
+  };
+  const buttonSecondary: React.CSSProperties = {
+    background: "white",
+    color: palette.text,
+    border: `1px solid ${palette.border}`,
+    padding: "0.6rem 1.2rem",
+    borderRadius: 6,
+    cursor: "pointer",
+    fontSize: "0.95rem",
+  };
+
+  if (phase.kind === "loading") {
+    return (
+      <div style={containerStyle}>
+        <div style={cardStyle}>
+          <div style={{ color: palette.muted }}>检测中…</div>
+        </div>
+      </div>
+    );
+  }
+
+  if (phase.kind === "error") {
+    return (
+      <div style={containerStyle}>
+        <div style={cardStyle}>
+          <h2 style={{ margin: "0 0 1rem", color: "#b91c1c" }}>初始化失败</h2>
+          <pre
+            style={{
+              background: "#fef2f2",
+              padding: "1rem",
+              borderRadius: 6,
+              fontSize: "0.85rem",
+              overflow: "auto",
+            }}
+          >
+            {phase.message}
+          </pre>
+          <button type="button" onClick={onSkip} style={{ ...buttonSecondary, marginTop: "1rem" }}>
+            跳过引导
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div style={containerStyle}>
+      <div style={cardStyle}>
+        <h1 style={{ margin: "0 0 0.5rem", fontSize: "1.5rem" }}>欢迎使用 OpenTrad</h1>
+        <p style={{ margin: "0 0 1.5rem", color: palette.muted }}>第 1 步:安装 Claude Code</p>
+
+        {/* 自动安装路径（macOS / Linux）*/}
+        {phase.support.supportsAutoInstall ? (
+          <AutoInstallSection
+            phase={phase}
+            onAutoInstall={handleAutoInstall}
+            buttonPrimary={buttonPrimary}
+            buttonSecondary={buttonSecondary}
+            palette={palette}
+            onSkip={onSkip}
+          />
+        ) : (
+          <ManualInstallSection
+            support={phase.support}
+            onAlreadyInstalled={handleAlreadyInstalled}
+            buttonPrimary={buttonPrimary}
+            buttonSecondary={buttonSecondary}
+            palette={palette}
+            onSkip={onSkip}
+            phase={phase}
+          />
+        )}
+      </div>
+    </div>
+  );
+}
+
+interface SectionProps {
+  buttonPrimary: React.CSSProperties;
+  buttonSecondary: React.CSSProperties;
+  palette: { muted: string; accent: string; border: string };
+  onSkip: () => void;
+}
+
+interface AutoInstallSectionProps extends SectionProps {
+  phase: ReadyPhase | InstallingPhase | DetectingPhase;
+  onAutoInstall: () => void;
+}
+
+function AutoInstallSection({
+  phase,
+  onAutoInstall,
+  buttonPrimary,
+  buttonSecondary,
+  palette,
+  onSkip,
+}: AutoInstallSectionProps): ReactElement {
+  return (
+    <div>
+      <div
+        style={{
+          background: palette.accent,
+          padding: "0.75rem 1rem",
+          borderRadius: 6,
+          fontSize: "0.85rem",
+          marginBottom: "1rem",
+          color: "#1e3a8a",
+        }}
+      >
+        🛡 安装命令直接来自 claude.ai 官方:
+        <code style={{ display: "block", marginTop: "0.5rem", fontFamily: "monospace" }}>
+          curl -fsSL https://claude.ai/install.sh | bash
+        </code>
+        <span style={{ display: "block", marginTop: "0.5rem", fontSize: "0.8rem" }}>
+          你可以读完命令再决定是否执行。OpenTrad 不读 ~/.claude / 不存任何 token。
+        </span>
+      </div>
+
+      {phase.kind === "ready" ? (
+        <div style={{ display: "flex", gap: "0.75rem" }}>
+          <button type="button" onClick={onAutoInstall} style={buttonPrimary}>
+            一键安装 Claude Code
+          </button>
+          <button type="button" onClick={onSkip} style={buttonSecondary}>
+            跳过引导
+          </button>
+        </div>
+      ) : null}
+
+      {phase.kind === "installing" ? (
+        <div>
+          <div style={{ fontSize: "0.85rem", color: palette.muted, marginBottom: "0.5rem" }}>
+            正在安装(完成后自动检测)…
+          </div>
+          <pre
+            style={{
+              background: "#0f172a",
+              color: "#e2e8f0",
+              padding: "0.75rem",
+              borderRadius: 6,
+              maxHeight: 280,
+              overflow: "auto",
+              fontSize: "0.8rem",
+              whiteSpace: "pre-wrap",
+              fontFamily: '"SF Mono", Menlo, Monaco, monospace',
+            }}
+          >
+            {phase.lines.join("")}
+          </pre>
+        </div>
+      ) : null}
+
+      {phase.kind === "detecting" ? (
+        <div style={{ color: palette.muted, fontSize: "0.9rem" }}>
+          正在检测安装是否完成…(每 3 秒查一次,最长 5 分钟)
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+interface ManualInstallSectionProps extends SectionProps {
+  support: InstallerSupportsAutoInstallResponse;
+  onAlreadyInstalled: () => void;
+  // 接受 union 简化父组件类型；installing 在 manual 路径运行时不会出现
+  // （只 auto 路径转入），渲染层降级当 ready 处理
+  phase: ReadyPhase | InstallingPhase | DetectingPhase;
+}
+
+function ManualInstallSection({
+  support,
+  onAlreadyInstalled,
+  buttonPrimary,
+  buttonSecondary,
+  palette,
+  onSkip,
+  phase,
+}: ManualInstallSectionProps): ReactElement {
+  return (
+    <div>
+      <div
+        style={{
+          background: "#fef3c7",
+          padding: "0.75rem 1rem",
+          borderRadius: 6,
+          fontSize: "0.9rem",
+          marginBottom: "1rem",
+          color: "#92400e",
+        }}
+      >
+        OpenTrad 当前在 <strong>{support.platform}</strong> 上不提供自动安装 Claude
+        Code。请按官方文档手动安装,装完后点"我已装好"按钮。
+      </div>
+
+      <div style={{ marginBottom: "1rem" }}>
+        <a
+          href={support.manualInstallUrl}
+          target="_blank"
+          rel="noreferrer"
+          onClick={(e) => {
+            e.preventDefault();
+            // shell.openExternal 会被 main 进程 IPC 拦截;此处直接打开外链
+            window.open(support.manualInstallUrl, "_blank", "noopener,noreferrer");
+          }}
+          style={{
+            color: "#2563eb",
+            textDecoration: "underline",
+            fontSize: "0.95rem",
+          }}
+        >
+          打开官方安装文档 →
+        </a>
+      </div>
+
+      <div style={{ display: "flex", gap: "0.75rem" }}>
+        <button
+          type="button"
+          onClick={onAlreadyInstalled}
+          style={buttonPrimary}
+          disabled={phase.kind === "detecting"}
+        >
+          {phase.kind === "detecting" ? "检测中…" : "我已装好,重新检测"}
+        </button>
+        <button type="button" onClick={onSkip} style={buttonSecondary}>
+          跳过引导
+        </button>
+      </div>
+
+      {phase.kind === "detecting" ? (
+        <div style={{ marginTop: "1rem", color: palette.muted, fontSize: "0.85rem" }}>
+          正在检测…(每 3 秒查一次,1 分钟超时)
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/apps/desktop/src/renderer/features/onboarding/LoginStepPlaceholder.tsx
+++ b/apps/desktop/src/renderer/features/onboarding/LoginStepPlaceholder.tsx
@@ -1,0 +1,108 @@
+// LoginStep 占位（M1 #22 / open-trad/opentrad#22 落地真实实现）。
+// M1 #21 范围内只显示提示,允许"已登录"或"跳过"推进。
+
+import type { CCStatus } from "@opentrad/shared";
+import type { ReactElement } from "react";
+
+export interface LoginStepPlaceholderProps {
+  status: CCStatus;
+  onLoggedIn: () => void;
+  onSkip: () => void;
+}
+
+export function LoginStepPlaceholder({
+  status,
+  onLoggedIn,
+  onSkip,
+}: LoginStepPlaceholderProps): ReactElement {
+  const isLogged = status.loggedIn === true;
+
+  // 已登录直接推进
+  if (isLogged) {
+    setTimeout(onLoggedIn, 0);
+  }
+
+  return (
+    <div
+      style={{
+        minHeight: "100vh",
+        display: "flex",
+        flexDirection: "column",
+        alignItems: "center",
+        justifyContent: "center",
+        padding: "2rem",
+        fontFamily: "system-ui, -apple-system, sans-serif",
+      }}
+    >
+      <div
+        style={{
+          background: "#fff",
+          border: "1px solid #e5e7eb",
+          borderRadius: 8,
+          padding: "2rem",
+          maxWidth: 720,
+          width: "100%",
+        }}
+      >
+        <h1 style={{ margin: "0 0 0.5rem", fontSize: "1.5rem" }}>第 2 步:登录 Claude</h1>
+        <p style={{ margin: "0 0 1rem", color: "#6b7280" }}>
+          M1 #21 范围内 LoginStep 占位;真实实现在 M1 #22(open-trad/opentrad#22) 落地。
+        </p>
+
+        <div
+          style={{
+            background: "#fef3c7",
+            padding: "0.75rem 1rem",
+            borderRadius: 6,
+            fontSize: "0.9rem",
+            color: "#92400e",
+            marginBottom: "1rem",
+          }}
+        >
+          {isLogged ? (
+            <>已检测到已登录账号(自动跳转中…)</>
+          ) : (
+            <>
+              CC 已安装但未登录。请在系统终端跑 <code>claude auth login</code>{" "}
+              完成登录,然后回到这里继续。
+            </>
+          )}
+        </div>
+
+        <div style={{ display: "flex", gap: "0.75rem" }}>
+          <button
+            type="button"
+            onClick={onLoggedIn}
+            disabled={!isLogged}
+            style={{
+              background: isLogged ? "#2563eb" : "#cbd5e1",
+              color: "white",
+              border: "none",
+              padding: "0.6rem 1.2rem",
+              borderRadius: 6,
+              cursor: isLogged ? "pointer" : "not-allowed",
+              fontSize: "0.95rem",
+            }}
+          >
+            {isLogged ? "继续" : "等待登录…"}
+          </button>
+          <button
+            type="button"
+            onClick={onSkip}
+            style={{
+              background: "white",
+              color: "#111827",
+              border: "1px solid #e5e7eb",
+              padding: "0.6rem 1.2rem",
+              borderRadius: 6,
+              cursor: "pointer",
+              fontSize: "0.95rem",
+            }}
+          >
+            跳过引导
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/desktop/src/renderer/features/onboarding/OnboardingGate.tsx
+++ b/apps/desktop/src/renderer/features/onboarding/OnboardingGate.tsx
@@ -1,0 +1,120 @@
+// OnboardingGate（M1 #21 / open-trad/opentrad#21）：app 启动时根据 settings.onboarded
+// 和 cc:status 决定是否走 onboarding 流程。
+//
+// 决策树（启动时一次性判断）：
+// 1. settings.onboarded === true → 直接进 main App（用户曾完成或显式 onboarded）
+// 2. cc:status 已 installed + loggedIn → 自动设 onboarded=true → 进 main App
+//    （已 onboarded 但 settings 未持久化的情形,例如老用户从 W1 升级到 W2）
+// 3. 否则 → onboarding 流程（InstallStep → LoginStep → 完成 set onboarded=true）
+//
+// 跳过引导路径（用户在任一步点"跳过"）：进 main App 但保持 onboarded=false,
+// 下次启动再问。
+
+import type { CCStatus } from "@opentrad/shared";
+import { type ReactElement, type ReactNode, useEffect, useState } from "react";
+import { InstallStep } from "./InstallStep";
+import { LoginStepPlaceholder } from "./LoginStepPlaceholder";
+
+const ONBOARDED_KEY = "onboarded";
+
+type GateState =
+  | { kind: "loading" }
+  | { kind: "install" }
+  | { kind: "login"; status: CCStatus }
+  | { kind: "main" };
+
+export interface OnboardingGateProps {
+  // onboarded 后渲染的主界面（M0 hello world / 后续 #29 ChatLayout）
+  children: ReactNode;
+}
+
+export function OnboardingGate({ children }: OnboardingGateProps): ReactElement {
+  const [state, setState] = useState<GateState>({ kind: "loading" });
+
+  // 启动时决策：onboarded? cc:status?
+  useEffect(() => {
+    let cancelled = false;
+    void (async () => {
+      try {
+        const onboarded = await window.api.settings.get(ONBOARDED_KEY);
+        if (cancelled) return;
+        if (onboarded === true) {
+          setState({ kind: "main" });
+          return;
+        }
+        // 未持久化 onboarded → 看 cc:status 兜底
+        const status = await window.api.cc.status();
+        if (cancelled) return;
+        if (status.installed && status.loggedIn === true) {
+          // 已 ready,自动设 onboarded=true 跳过 onboarding
+          await window.api.settings.set(ONBOARDED_KEY, true);
+          if (!cancelled) setState({ kind: "main" });
+          return;
+        }
+        if (status.installed) {
+          setState({ kind: "login", status });
+        } else {
+          setState({ kind: "install" });
+        }
+      } catch (err) {
+        console.error("[onboarding-gate] decision failed", err);
+        if (!cancelled) setState({ kind: "main" }); // 出错时不阻塞,进 main
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  if (state.kind === "loading") {
+    return (
+      <div
+        style={{
+          minHeight: "100vh",
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "center",
+          color: "#6b7280",
+          fontFamily: "system-ui, sans-serif",
+        }}
+      >
+        加载中…
+      </div>
+    );
+  }
+
+  if (state.kind === "install") {
+    return (
+      <InstallStep
+        onInstalled={(status) => {
+          // 装好但未登录 → 进 LoginStep;已登录 → 直接 set onboarded=true 进 main
+          if (status.loggedIn === true) {
+            void window.api.settings.set(ONBOARDED_KEY, true);
+            setState({ kind: "main" });
+          } else {
+            setState({ kind: "login", status });
+          }
+        }}
+        onSkip={() => {
+          // 跳过引导:本会话进 main,但 onboarded 保持 false（下次启动再问）
+          setState({ kind: "main" });
+        }}
+      />
+    );
+  }
+
+  if (state.kind === "login") {
+    return (
+      <LoginStepPlaceholder
+        status={state.status}
+        onLoggedIn={() => {
+          void window.api.settings.set(ONBOARDED_KEY, true);
+          setState({ kind: "main" });
+        }}
+        onSkip={() => setState({ kind: "main" })}
+      />
+    );
+  }
+
+  return <>{children}</>;
+}

--- a/apps/desktop/tests/cc-detect-loop.test.ts
+++ b/apps/desktop/tests/cc-detect-loop.test.ts
@@ -1,0 +1,184 @@
+// DetectLoopRegistry 测试：start / stop / cleanupAll，超时自动停。
+// 用 vi.useFakeTimers 控制 setInterval 触发节奏。
+
+import type { CCManager, DetectInstallationResult } from "@opentrad/cc-adapter";
+import { IpcChannels } from "@opentrad/shared";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { DetectLoopRegistry } from "../src/main/services/cc-detect-loop";
+
+interface FakeWebContents {
+  id: number;
+  isDestroyed(): boolean;
+  send: ReturnType<typeof vi.fn>;
+  once: ReturnType<typeof vi.fn>;
+}
+
+function makeFakeSender(id: number): FakeWebContents {
+  return {
+    id,
+    isDestroyed: () => false,
+    send: vi.fn(),
+    once: vi.fn(),
+  };
+}
+
+function makeFakeManager(detect: () => Promise<DetectInstallationResult>): CCManager {
+  return {
+    detectInstallation: detect,
+    getAuthStatus: vi.fn().mockResolvedValue({ loggedIn: false }),
+  } as unknown as CCManager;
+}
+
+describe("DetectLoopRegistry", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("start 触发即时一次 + 按 intervalMs 周期推送 cc:status", async () => {
+    const detectFn = vi.fn().mockResolvedValue({ installed: false, error: "not yet" });
+    const manager = makeFakeManager(detectFn);
+    const registry = new DetectLoopRegistry(manager, (e) => e);
+    const sender = makeFakeSender(1);
+
+    registry.start(sender as unknown as Electron.WebContents, {
+      intervalMs: 3000,
+      maxDurationMs: 60_000,
+    });
+
+    // 立即触发一次
+    await vi.advanceTimersByTimeAsync(0);
+    expect(detectFn).toHaveBeenCalledTimes(1);
+
+    // 3s 后第二次
+    await vi.advanceTimersByTimeAsync(3000);
+    expect(detectFn).toHaveBeenCalledTimes(2);
+
+    // 6s 后第三次
+    await vi.advanceTimersByTimeAsync(3000);
+    expect(detectFn).toHaveBeenCalledTimes(3);
+
+    // 每次都通过 cc:status 推 sender
+    expect(sender.send).toHaveBeenCalledWith(IpcChannels.CCStatus, expect.any(Object));
+
+    registry.stop(sender as unknown as Electron.WebContents);
+  });
+
+  it("检测到 installed=true 时自动停（不再继续轮询）", async () => {
+    let calls = 0;
+    const detectFn = vi.fn(async () => {
+      calls++;
+      // 第三次返回 installed=true
+      return calls >= 3
+        ? ({ installed: true, version: "2.1.119" } as DetectInstallationResult)
+        : ({ installed: false, error: "not yet" } as DetectInstallationResult);
+    });
+    const manager = makeFakeManager(detectFn);
+    const registry = new DetectLoopRegistry(manager, (e) => e);
+    const sender = makeFakeSender(2);
+
+    registry.start(sender as unknown as Electron.WebContents, {
+      intervalMs: 100,
+      maxDurationMs: 60_000,
+    });
+
+    // 跑 5 个周期：第 3 次会返回 installed=true 并自动停
+    for (let i = 0; i < 5; i++) {
+      await vi.advanceTimersByTimeAsync(100);
+    }
+
+    // 第 3 次后应停止：calls 不会超过 3-4（取决于 timer 触发时序）
+    expect(calls).toBeLessThanOrEqual(4);
+  });
+
+  it("超过 maxDurationMs 后自动停（避免空跑死循环）", async () => {
+    const detectFn = vi.fn().mockResolvedValue({ installed: false, error: "not yet" });
+    const manager = makeFakeManager(detectFn);
+    const registry = new DetectLoopRegistry(manager, (e) => e);
+    const sender = makeFakeSender(3);
+
+    registry.start(sender as unknown as Electron.WebContents, {
+      intervalMs: 1000,
+      maxDurationMs: 5000,
+    });
+
+    // 跑 8 秒
+    for (let i = 0; i < 8; i++) {
+      await vi.advanceTimersByTimeAsync(1000);
+    }
+
+    // 5 秒超时后停 → calls 不会持续到 8
+    const callsAt5s = detectFn.mock.calls.length;
+    await vi.advanceTimersByTimeAsync(2000);
+    expect(detectFn.mock.calls.length).toBe(callsAt5s);
+  });
+
+  it("stop 立即清 timer", async () => {
+    const detectFn = vi.fn().mockResolvedValue({ installed: false, error: "..." });
+    const manager = makeFakeManager(detectFn);
+    const registry = new DetectLoopRegistry(manager, (e) => e);
+    const sender = makeFakeSender(4);
+
+    registry.start(sender as unknown as Electron.WebContents, {
+      intervalMs: 1000,
+      maxDurationMs: 60_000,
+    });
+    await vi.advanceTimersByTimeAsync(0);
+    const callsBeforeStop = detectFn.mock.calls.length;
+
+    registry.stop(sender as unknown as Electron.WebContents);
+    await vi.advanceTimersByTimeAsync(5000);
+
+    expect(detectFn.mock.calls.length).toBe(callsBeforeStop);
+  });
+
+  it("cleanupAll 清所有 sender 的 loop", async () => {
+    const detectFn = vi.fn().mockResolvedValue({ installed: false, error: "..." });
+    const manager = makeFakeManager(detectFn);
+    const registry = new DetectLoopRegistry(manager, (e) => e);
+    const s1 = makeFakeSender(5);
+    const s2 = makeFakeSender(6);
+
+    registry.start(s1 as unknown as Electron.WebContents, {
+      intervalMs: 1000,
+      maxDurationMs: 60_000,
+    });
+    registry.start(s2 as unknown as Electron.WebContents, {
+      intervalMs: 1000,
+      maxDurationMs: 60_000,
+    });
+    await vi.advanceTimersByTimeAsync(0);
+
+    registry.cleanupAll();
+    const callsAfterCleanup = detectFn.mock.calls.length;
+    await vi.advanceTimersByTimeAsync(5000);
+    expect(detectFn.mock.calls.length).toBe(callsAfterCleanup);
+  });
+
+  it("同一 sender 第二次 start 替换前一次（避免重复 timer）", async () => {
+    const detectFn = vi.fn().mockResolvedValue({ installed: false, error: "..." });
+    const manager = makeFakeManager(detectFn);
+    const registry = new DetectLoopRegistry(manager, (e) => e);
+    const sender = makeFakeSender(7);
+
+    registry.start(sender as unknown as Electron.WebContents, {
+      intervalMs: 1000,
+      maxDurationMs: 60_000,
+    });
+    registry.start(sender as unknown as Electron.WebContents, {
+      intervalMs: 1000,
+      maxDurationMs: 60_000,
+    });
+    await vi.advanceTimersByTimeAsync(0);
+
+    // 应该只跑 1 次（最近的 start;旧 timer 被 stop）
+    // 立即触发一次 + 第二次 start 立即触发 = 2 次。但不会因 timer 累积变 4 次。
+    await vi.advanceTimersByTimeAsync(1000);
+    expect(detectFn.mock.calls.length).toBeLessThanOrEqual(3);
+
+    registry.stop(sender as unknown as Electron.WebContents);
+  });
+});

--- a/apps/desktop/tests/installer.test.ts
+++ b/apps/desktop/tests/installer.test.ts
@@ -1,0 +1,57 @@
+// installer.ts 测试：平台分支 + 自动安装命令组装。
+// 用 vi.stubGlobal 改 process.platform 模拟三平台行为（A3 决策实现验证）。
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { getAutoInstallCommand, getPlatformInstallSupport } from "../src/main/services/installer";
+
+describe("getPlatformInstallSupport", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("macOS 支持自动安装", () => {
+    Object.defineProperty(process, "platform", { value: "darwin", configurable: true });
+    const support = getPlatformInstallSupport();
+    expect(support.platform).toBe("darwin");
+    expect(support.supportsAutoInstall).toBe(true);
+    expect(support.manualInstallUrl).toContain("docs.claude.com");
+  });
+
+  it("Linux 支持自动安装", () => {
+    Object.defineProperty(process, "platform", { value: "linux", configurable: true });
+    expect(getPlatformInstallSupport().supportsAutoInstall).toBe(true);
+  });
+
+  it("Windows 不支持自动安装(A3 降级)", () => {
+    Object.defineProperty(process, "platform", { value: "win32", configurable: true });
+    const support = getPlatformInstallSupport();
+    expect(support.platform).toBe("win32");
+    expect(support.supportsAutoInstall).toBe(false);
+    expect(support.manualInstallUrl).toContain("docs.claude.com");
+  });
+
+  it("其他未知平台降级到 other / 不支持", () => {
+    Object.defineProperty(process, "platform", { value: "freebsd", configurable: true });
+    const support = getPlatformInstallSupport();
+    expect(support.platform).toBe("other");
+    expect(support.supportsAutoInstall).toBe(false);
+  });
+});
+
+describe("getAutoInstallCommand", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("macOS / Linux 返回 bash -c 命令调 install.sh", () => {
+    Object.defineProperty(process, "platform", { value: "darwin", configurable: true });
+    const cmd = getAutoInstallCommand();
+    expect(cmd.command).toBe("/bin/bash");
+    expect(cmd.args).toEqual(["-c", "curl -fsSL https://claude.ai/install.sh | bash"]);
+  });
+
+  it("Windows 抛错(防御性,实际 caller 应先用 supportsAutoInstall 守门)", () => {
+    Object.defineProperty(process, "platform", { value: "win32", configurable: true });
+    expect(() => getAutoInstallCommand()).toThrow(/not supported/);
+  });
+});

--- a/packages/shared/src/channels.ts
+++ b/packages/shared/src/channels.ts
@@ -41,6 +41,10 @@ export const IpcChannels = {
   PtyKill: "pty:kill",
   PtyData: "pty:data",
   PtyExit: "pty:exit",
+  InstallerRunCcInstall: "installer:run-cc-install",
+  InstallerSupportsAutoInstall: "installer:supports-auto-install",
+  CCDetectLoopStart: "cc:detect-loop-start",
+  CCDetectLoopStop: "cc:detect-loop-stop",
 } as const;
 
 export type IpcChannel = (typeof IpcChannels)[keyof typeof IpcChannels];

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -9,6 +9,7 @@ export * from "./channels";
 export * from "./types/cc-event";
 export * from "./types/cc-task";
 export * from "./types/db";
+export * from "./types/installer";
 export * from "./types/ipc";
 export * from "./types/ipc-bridge";
 export * from "./types/pty";

--- a/packages/shared/src/types/installer.ts
+++ b/packages/shared/src/types/installer.ts
@@ -1,0 +1,60 @@
+// CC 安装向导 IPC 协议（M1 #21 / open-trad/opentrad#21）。
+// 03-architecture.md §7.1 OnboardingStep1 + 02-mvp-slicing F6.1 + F1.1。
+//
+// 跨平台支持矩阵（A3 决策落地）：
+// - macOS / Linux：自动安装通过 PTY 跑 `curl -fsSL https://claude.ai/install.sh | bash`
+// - Windows：**降级**——Anthropic 当前无官方一键脚本，UI 显示 docs.claude.com
+//   链接 + "我已自己装好了" 重新检测按钮，不强求自动安装
+
+import { z } from "zod";
+
+// installer:supports-auto-install（Renderer → Main）
+// 返回当前平台是否支持自动安装。Windows 永远 false（A3）；macOS / Linux 看
+// 是否能找到 curl + bash（fresh 系统都有，理论返回 true）。
+//
+// renderer 用这个决定 InstallStep UI 显示哪条路径：
+// - true → "一键安装"按钮 + TerminalPane（PTY 输出）
+// - false → docs.claude.com 链接 + "我已装好"按钮
+
+export const InstallerSupportsAutoInstallResponseSchema = z.object({
+  supportsAutoInstall: z.boolean(),
+  // 不支持时的指引（manualInstallUrl）。支持时也返回，作为 fallback。
+  manualInstallUrl: z.string(),
+  // 平台标识，UI 可以显示"在 Windows 上需要..."
+  platform: z.enum(["darwin", "linux", "win32", "other"]),
+});
+
+export type InstallerSupportsAutoInstallResponse = z.infer<
+  typeof InstallerSupportsAutoInstallResponseSchema
+>;
+
+// installer:run-cc-install（Renderer → Main）
+// renderer 点"一键安装"后调。Main 通过 PTY spawn 安装脚本，返回 ptyId 让
+// renderer 把 PTY 输出渲染到 TerminalPane。
+//
+// 安装结束（PTY 退出）renderer 可以触发 cc:detect-loop-start 自动轮询检测
+// 是否装好（避免用户来回点"重新检测"）。
+
+export const InstallerRunCcInstallResponseSchema = z.object({
+  ptyId: z.string(),
+});
+
+export type InstallerRunCcInstallResponse = z.infer<typeof InstallerRunCcInstallResponseSchema>;
+
+// cc:detect-loop-start（Renderer → Main）
+// 启动后台轮询 detectInstallation()，每 intervalMs 跑一次，通过 cc:status
+// channel 推送给 renderer。最长 maxDurationMs 后自动停（避免空跑）。
+//
+// renderer 在 install 完成 / 用户点"重新检测" / 点"我已装好"后启动；
+// 检测到 installed=true 自动停止 + 推进到下一步（M1 #22 LoginStep）。
+
+export const CCDetectLoopStartRequestSchema = z.object({
+  intervalMs: z.number().int().positive().default(3000),
+  maxDurationMs: z
+    .number()
+    .int()
+    .positive()
+    .default(5 * 60 * 1000), // 5 分钟兜底
+});
+
+export type CCDetectLoopStartRequest = z.infer<typeof CCDetectLoopStartRequestSchema>;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -59,6 +59,9 @@ importers:
       js-yaml:
         specifier: ^4.1.1
         version: 4.1.1
+      lucide-react:
+        specifier: ^1.11.0
+        version: 1.11.0(react@19.2.5)
       node-pty:
         specifier: ^1.1.0
         version: 1.1.0
@@ -1406,6 +1409,11 @@ packages:
 
   lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
+
+  lucide-react@1.11.0:
+    resolution: {integrity: sha512-UOhjdztXCgdBReRcIhsvz2siIBogfv/lhJEIViCpLt924dO+GDms9T7DNoucI23s6kEPpe988m5N0D2ajnzb2g==}
+    peerDependencies:
+      react: ^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
@@ -3109,6 +3117,10 @@ snapshots:
   lru-cache@5.1.1:
     dependencies:
       yallist: 3.1.1
+
+  lucide-react@1.11.0(react@19.2.5):
+    dependencies:
+      react: 19.2.5
 
   magic-string@0.30.21:
     dependencies:


### PR DESCRIPTION
按 [02-mvp-slicing F6.1 + F1.1](https://github.com/open-trad/docs/blob/main/design/02-mvp-slicing.md) + 03 §7.1 OnboardingStep1 落地首次启动安装引导。**A3 决策落地**:Windows 不强求自动安装,UI 引导用户去 docs.claude.com 手动装。

## 改动摘要

### Shared types

- \`channels.ts\` 加 4 个新 channel(\`installer:run-cc-install\` / \`installer:supports-auto-install\` / \`cc:detect-loop-start\` / \`cc:detect-loop-stop\`)
- \`types/installer.ts\` 加 schemas

### Desktop main 端

- \`services/installer.ts\` 跨平台 install 命令封装:
  - macOS / Linux:\`bash -c 'curl -fsSL https://claude.ai/install.sh | bash'\`
  - **Windows:A3 降级**,\`supportsAutoInstall=false\`,UI 走手动路径
- \`services/cc-detect-loop.ts\` DetectLoopRegistry,per webContents 后台轮询 \`detectInstallation()\`,installed=true 自动停 + 5min 超时兜底
- \`ipc/installer.ts\` 3 个 IPC handler
- \`main/index.ts\` 集成 detect-loop registry + \`cleanupAll\` finalize

### Preload

\`window.api.installer.{supportsAutoInstall, runCcInstall}\`、\`window.api.cc.{onStatus, detectLoopStart, detectLoopStop}\`、\`window.api.settings.{get, set}\`(之前缺,OnboardingGate 需要)。

### Renderer onboarding

- \`features/onboarding/InstallStep.tsx\` 双路径 UI(自动安装 / 手动安装)
- \`features/onboarding/LoginStepPlaceholder.tsx\` M1 #22 占位
- \`features/onboarding/OnboardingGate.tsx\` 启动时三路决策:
  1. \`settings.onboarded=true\` → 直接进 main
  2. cc:status 已 ready → 自动 set onboarded=true 跳过(**W1 老用户兼容**)
  3. 否则进 onboarding 流程
- \`App.tsx\` OnboardingGate 包裹 MainApp(M0 hello world demo)

## ⚠️ 通报 1:Windows 路径 UX 给你校(请帮看)

发起人之前要求"Windows 路径降级真实施时(尤其是 install.sh 在 Windows 上不可用 → 引导用户访问 docs.claude.com 那步)的 UX 截图给我"。

我没有 GUI 能力,**Windows UX 关键代码已就位**(\`InstallStep.tsx\` 的 \`ManualInstallSection\` 函数,本 PR L260-310)。要看 Windows UX 你可以这样**在 macOS 上预览**:

\`\`\`bash
git checkout feat/issue-21-cc-install-onboarding
# 临时 patch:把 InstallStep.tsx 里 supportsAutoInstall 强设为 false
# 一行 patch:apps/desktop/src/renderer/features/onboarding/InstallStep.tsx 的
# AutoInstallSection 渲染分支改成永远走 ManualInstallSection
pnpm dev
\`\`\`

或者直接看代码:UI 显示:
1. 黄色警告卡片:"OpenTrad 当前在 win32 上不提供自动安装 Claude Code。请按官方文档手动安装,装完后点'我已装好'按钮。"
2. 蓝色超链接 "打开官方安装文档 →" 指向 \`https://docs.claude.com/en/docs/claude-code/quickstart\`
3. 主按钮 "我已装好,重新检测"(检测中时禁用 + 改文案"检测中…")
4. 次按钮 "跳过引导"

**有任何 UX 调整建议直接评论本 PR**,我据此调。

## 通报 2:cc-adapter `detectInstallation` mock 路径(A3 macOS 真机延后)

M0 实现 \`detectInstallation(binary)\` 已支持参数注入:`packages/cc-adapter/src/detect.ts` 接受 binary 路径作可配参数。本 PR 单测验证 mock 路径(detect-loop 用 fake manager spawn 注入测试),真机 macOS 安装验收**延后到 Mac mini 临时账户到手后**。

## 通报 3:不在本 PR 范围(事先报备)

- 真实 LoginStep(PTY + claude auth login + URL 提取):M1 #22
- macOS 真机 onboarding 全流程(要求"未装 CC"环境):Mac mini 到手后补
- Windows 真机:本 PR 单测覆盖 + 三平台 CI 守门 + #13 收官段补

## 单测(199 tests pass)

| 包 | 数量 | 新增 |
|---|---|---|
| desktop | **66**(↑12) | installer.test 4 + cc-detect-loop.test 6 |
| 其他 | 133 | 无变化 |

## OnboardingGate 决策树(给未来 contributor 看)

\`\`\`
启动 → settings.onboarded?
  ├ true → MainApp(hello world / 后续 #29 ChatLayout)
  └ false / null → cc:status?
      ├ installed + loggedIn → set onboarded=true → MainApp
      ├ installed + !loggedIn → LoginStep(占位,#22 真实化)
      └ !installed → InstallStep
            ├ supportsAutoInstall(macOS/Linux)→ 一键安装 + PTY 输出
            └ !supportsAutoInstall(Windows)→ docs.claude.com + 手动
      跳过引导:本会话进 MainApp,onboarded=false 持续
\`\`\`

## Closes

Closes #21