### PR TITLE
fix(desktop): skill-fixture-loader 路径在 electron bundle 下解析失效 (bug A)

### DIFF
--- a/apps/desktop/src/main/services/skill-fixture-loader.ts
+++ b/apps/desktop/src/main/services/skill-fixture-loader.ts
@@ -12,13 +12,42 @@
 // 这里坚持 stub != mock，full-fidelity fixture。
 
 import { existsSync, readFileSync } from "node:fs";
+import { createRequire } from "node:module";
 import { join } from "node:path";
 import { type SkillManifest, SkillManifestSchema } from "@opentrad/shared";
 import * as yaml from "js-yaml";
 
-// fixture 仓库内绝对路径。从 desktop 的 dist 跑时通过相对 monorepo 解析。
-const REPO_ROOT = join(__dirname, "..", "..", "..", "..", "..");
-const FIXTURE_DIR = join(REPO_ROOT, "packages", "skill-runtime", "__fixtures__");
+// fixture 路径解析:dev / packaged / vitest 三种环境路径深度不同。
+//
+// - vitest:跑 src/main/services/skill-fixture-loader.ts,__dirname 是源码目录,
+//   5 层 ".." 上溯到 monorepo root。
+// - electron(dev / packaged):main bundle 到 apps/desktop/out/main/index.js,
+//   __dirname 路径深度变化,5 层 ".." 会跑到错误目录(M1 #21 dev 验证 bug A)。
+//   改用 electron app.getAppPath()(返回 apps/desktop),上 2 层到 monorepo root。
+//
+// 探测靠 process.versions.electron(electron 进程独有);vitest 走 fallback。
+// createRequire 同步加载 electron(模块顶层用 dynamic import 不行,本函数同步)。
+//
+// **#23 (M1 #6) SkillLoader 落地后本文件删除**,届时 packaged 走 ~/.opentrad/skills/,
+// 此 path 解析也随之退场。
+function resolveFixtureDir(): string {
+  if (process.versions?.electron) {
+    const requireFromHere = createRequire(import.meta.url);
+    const electron = requireFromHere("electron") as { app: { getAppPath: () => string } };
+    // app.getAppPath() = apps/desktop;monorepo root 是上 2 层
+    return join(electron.app.getAppPath(), "..", "..", "packages", "skill-runtime", "__fixtures__");
+  }
+  // vitest fallback:src/main/services → 5 ".." → monorepo root
+  return join(__dirname, "..", "..", "..", "..", "..", "packages", "skill-runtime", "__fixtures__");
+}
+
+// 模块加载时不解析(electron require 在 vitest import 时不应触发);
+// loadFixtureSkill 调用时再解析,带 cache 避免每次 require。
+let cachedFixtureDir: string | undefined;
+function getFixtureDir(): string {
+  if (!cachedFixtureDir) cachedFixtureDir = resolveFixtureDir();
+  return cachedFixtureDir;
+}
 
 export interface LoadedSkill {
   manifest: SkillManifest;
@@ -26,7 +55,7 @@ export interface LoadedSkill {
 }
 
 export function loadFixtureSkill(skillId: string): LoadedSkill {
-  const skillDir = join(FIXTURE_DIR, skillId);
+  const skillDir = join(getFixtureDir(), skillId);
   const yamlPath = join(skillDir, "skill.yml");
   if (!existsSync(yamlPath)) {
     throw new Error(`fixture skill not found: ${skillId} (looked at ${yamlPath})`);


### PR DESCRIPTION
## Summary

- **bug A**(#21 PR #39 dev 校验时发起人发现):dev 模式点 "Say Hi in Chinese" 报 "fixture skill not found"。
- **根因**:`skill-fixture-loader.ts:20` 用 `join(__dirname, ".." × 5)` 按源码路径 `apps/desktop/src/main/services` 算深度。electron-vite bundle 后 main 入 `apps/desktop/out/main/index.js`,`__dirname` 路径深度变化,5 层 \"..\" 跑到 monorepo 父目录的父。vitest 跑源码 .ts 时深度仍对,所以单测一直绿,bug 藏到 dev 真机才暴露。
- **影响范围**:#21 / #22 / #24 / #30 dev 调试期间 Hello World 链路。M0 hello demo 在 #26 升级到 fixture-skill 后也受影响。
- **修法**:`process.versions.electron` 探测分支 — electron 走 `app.getAppPath()` 上 2 层到 monorepo root;vitest fallback 原 5 层 ".." 不变。`createRequire(import.meta.url)` 同步加载 electron(模块顶层 dynamic import 不行,本函数同步签名);首次调用 cache 避免重复 require。
- **退场计划**:M1 #23 SkillLoader 落地后本文件删除,此 path 解析随之退场,只保 dev 期间 1-2 个 issue 的 lifespan。

## Test plan

- [x] `pnpm --filter @opentrad/desktop typecheck` 0 错
- [x] `pnpm --filter @opentrad/desktop test --run` 13 文件 / 66 测试全过(skill-fixture-loader.test.ts 走 vitest fallback 路径,验证不回归)
- [x] `pnpm --filter @opentrad/desktop build` electron-vite 三段(main/preload/renderer)全过
- [x] `pnpm lint` biome 0 错
- [x] CI 三平台 + electron-abi-smoke 待跑
- [ ] **dev 真机 e2e 留发起人**:`pnpm --filter @opentrad/desktop dev` 启动后点 \"Say Hi in Chinese\",应看到 system/init → assistant_text \"好的。\" → \"✓ 任务完成\",而不是 \"fixture skill not found\"

## Known limitation

我无 GUI 交互能力,无法在 mac 完成 dev e2e 自查。CI 可验证 typecheck / lint / unit test / build,但无法跑 electron 实例验证 `app.getAppPath()` 真实返回值 + fixture 文件存在。

留给发起人的验证步骤:
\`\`\`bash
sqlite3 ~/.opentrad/opentrad.db \"DELETE FROM settings WHERE key='onboarded';\"  # 如已 onboarded
pnpm --filter @opentrad/desktop dev
# 跳过引导 → MainApp → Say Hi in Chinese → 看是否 \"fixture skill not found\"
\`\`\`

## 不在本 PR 内

- packaged 模式 fixture 路径(electron-builder 不打包 packages/skill-runtime/__fixtures__)— 是 expected,packaged 走 ~/.opentrad/skills/(M1 #23 + M1 #30 范畴)
- 类似 path-resolution bug 在其他 main 模块的盘点(本次只修触发的一处)

Refs #21

🤖 Generated with [Claude Code](https://claude.com/claude-code)