### PR TITLE
feat(skill-runtime): SkillLoader + PromptComposer + 单测 (M1 #23)

### DIFF
--- a/packages/skill-runtime/package.json
+++ b/packages/skill-runtime/package.json
@@ -6,6 +6,14 @@
   "main": "./src/index.ts",
   "types": "./src/index.ts",
   "scripts": {
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run"
+  },
+  "dependencies": {
+    "@opentrad/shared": "workspace:*",
+    "js-yaml": "^4.1.0"
+  },
+  "devDependencies": {
+    "@types/js-yaml": "^4.0.9"
   }
 }

--- a/packages/skill-runtime/src/composer.ts
+++ b/packages/skill-runtime/src/composer.ts
@@ -1,0 +1,39 @@
+// PromptComposer:把 SkillManifest + 用户 inputs 拼成最终交给 CC 的 prompt。
+//
+// 03-architecture.md §4.3 PromptComposer。issue M1 #6 (#23) 决策点 D-M1-2:
+// - 不支持嵌套 mustache(M1 简化,M2 视需求加)
+// - 必填 input 缺失抛 ValidationError
+// - {{x}} 缺值时替换为空串(M1 简化;M2 视交互需要收紧为抛错或 UI 警告)
+
+import { ValidationError } from "./errors";
+import type { LoadedSkill } from "./loader";
+
+// 通用前缀:每个 skill 运行前都注入,提示 CC 在该 skill scope 内行动。
+// 03 §4.3:`You are operating within OpenTrad's <skillId> skill. <description>. Stay within scope.`
+function buildPrefix(skill: LoadedSkill): string {
+  const { manifest } = skill;
+  return `You are operating within OpenTrad's ${manifest.id} skill. ${manifest.description}. Stay within scope.\n\n`;
+}
+
+// 函数式主接口。stateless(M1 不需要可配置前缀;M2 用户自定义前缀时再升级到 instance class)。
+export function compose(skill: LoadedSkill, inputs: Record<string, unknown>): string {
+  const { manifest, promptTemplate } = skill;
+
+  // 必填字段校验
+  for (const input of manifest.inputs) {
+    if (input.required && !(input.name in inputs)) {
+      throw new ValidationError(`missing required input: ${input.name}`);
+    }
+  }
+
+  // mustache 替换 {{varName}}(无嵌套支持)
+  const filled = promptTemplate.replace(/\{\{(\w+)\}\}/g, (_, varName) => {
+    const v = inputs[varName];
+    return v === undefined || v === null ? "" : String(v);
+  });
+
+  return buildPrefix(skill) + filled;
+}
+
+// PromptComposer namespace(对齐 03 §4.3 命名)。biome 拒纯静态 class,用 const 对象等价。
+export const PromptComposer = { compose } as const;

--- a/packages/skill-runtime/src/errors.ts
+++ b/packages/skill-runtime/src/errors.ts
@@ -1,0 +1,24 @@
+// SkillLoader / PromptComposer 专用错误。
+//
+// **ValidationError**:PromptComposer 必填 input 缺失时抛(对齐 03 §4.3 + #23 决策点 D-M1-2)。
+// **SkillLoadError**:SkillLoader.loadFromDirectory 内部不抛(改为返回 LoadResult.error),
+//   但暴露此类供调用方在自己语境下抛/包裹。
+
+export class ValidationError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "ValidationError";
+  }
+}
+
+export class SkillLoadError extends Error {
+  // Error.cause 走 ES2022 标准(ErrorOptions),不重复声明实例字段,避免与基类 cause 冲突。
+  constructor(
+    message: string,
+    public readonly skillDir: string,
+    cause?: unknown,
+  ) {
+    super(message, cause !== undefined ? { cause } : undefined);
+    this.name = "SkillLoadError";
+  }
+}

--- a/packages/skill-runtime/src/index.ts
+++ b/packages/skill-runtime/src/index.ts
@@ -1,2 +1,15 @@
-// 占位，SkillLoader / PromptComposer 在 M1 里程碑填充
-export {};
+// @opentrad/skill-runtime 入口:loader / composer / errors。
+// SkillManifest / SkillInput 类型在 @opentrad/shared,本包不重复定义,
+// 但 re-export 方便业务包一行 import。
+
+export type { SkillInput, SkillManifest } from "@opentrad/shared";
+export { SkillInputSchema, SkillManifestSchema } from "@opentrad/shared";
+export { compose, PromptComposer } from "./composer";
+export { SkillLoadError, ValidationError } from "./errors";
+export {
+  type LoadedSkill,
+  type LoadResult,
+  loadBuiltinSkills,
+  loadFromDirectory,
+  loadUserSkills,
+} from "./loader";

--- a/packages/skill-runtime/src/loader.ts
+++ b/packages/skill-runtime/src/loader.ts
@@ -1,0 +1,105 @@
+// SkillLoader：扫描 skill 目录,读 skill.yml + prompt.md,zod 校验后返回 LoadedSkill。
+//
+// 03-architecture.md §4.3 SkillManifest + SkillLoader。issue M1 #6 (#23) 决策点 D-M1-2:
+// - 加载失败的 skill 不阻塞其他 skill(per-skill try/catch)
+// - skill manifest 的 version 字段 M1 仅校验存在,不做 semver 比对
+//
+// 三个加载入口:
+// - loadFromDirectory(dir):单 skill 加载,失败抛 SkillLoadError(精确诊断 + 给上层包装语境)
+// - loadBuiltinSkills(skillsDir):扫描内置 skill 目录,per-skill try/catch,返回 LoadResult[]
+// - loadUserSkills(userSkillsDir):同上,但 dir 不存在视为正常空数组(M1 友好,先建用户目录前不报错)
+
+import { existsSync, readdirSync, readFileSync, statSync } from "node:fs";
+import { join } from "node:path";
+import { type SkillManifest, SkillManifestSchema } from "@opentrad/shared";
+import * as yaml from "js-yaml";
+import { SkillLoadError } from "./errors";
+
+export interface LoadedSkill {
+  manifest: SkillManifest;
+  // promptTemplate 在 loader 阶段就读出来,避免 PromptComposer 反复 IO + 利于单测
+  promptTemplate: string;
+}
+
+// 单个 skill 加载结果。skillDir 永远存在(便于上层定位失败位置)。
+export type LoadResult =
+  | { ok: true; skillDir: string; skill: LoadedSkill }
+  | { ok: false; skillDir: string; error: SkillLoadError };
+
+// 单 skill 加载。失败抛 SkillLoadError,调用方用 loadBuiltinSkills 拿 LoadResult 不抛。
+export function loadFromDirectory(skillDir: string): LoadedSkill {
+  const yamlPath = join(skillDir, "skill.yml");
+  if (!existsSync(yamlPath)) {
+    throw new SkillLoadError(`skill.yml not found in ${skillDir}`, skillDir);
+  }
+
+  let raw: unknown;
+  try {
+    raw = yaml.load(readFileSync(yamlPath, "utf-8"));
+  } catch (err) {
+    throw new SkillLoadError(`yaml parse failed: ${yamlPath}`, skillDir, err);
+  }
+
+  let manifest: SkillManifest;
+  try {
+    manifest = SkillManifestSchema.parse(raw);
+  } catch (err) {
+    throw new SkillLoadError(`manifest schema validation failed: ${yamlPath}`, skillDir, err);
+  }
+
+  const promptPath = join(skillDir, manifest.promptTemplate);
+  if (!existsSync(promptPath)) {
+    throw new SkillLoadError(`prompt template not found: ${promptPath}`, skillDir);
+  }
+
+  let promptTemplate: string;
+  try {
+    promptTemplate = readFileSync(promptPath, "utf-8");
+  } catch (err) {
+    throw new SkillLoadError(`prompt template read failed: ${promptPath}`, skillDir, err);
+  }
+
+  return { manifest, promptTemplate };
+}
+
+// 扫描 skillsDir 下每个子目录,per-skill 加载;失败的 skill 标记 ok:false 不阻塞其他。
+export function loadBuiltinSkills(skillsDir: string): LoadResult[] {
+  if (!existsSync(skillsDir)) {
+    throw new SkillLoadError(`builtin skills directory not found: ${skillsDir}`, skillsDir);
+  }
+
+  const entries = readdirSync(skillsDir);
+  const results: LoadResult[] = [];
+
+  for (const entry of entries) {
+    const skillDir = join(skillsDir, entry);
+    // 跳过非目录(.DS_Store、单文件、symlink 等)
+    let isDir = false;
+    try {
+      isDir = statSync(skillDir).isDirectory();
+    } catch {
+      continue;
+    }
+    if (!isDir) continue;
+
+    try {
+      const skill = loadFromDirectory(skillDir);
+      results.push({ ok: true, skillDir, skill });
+    } catch (err) {
+      const error =
+        err instanceof SkillLoadError
+          ? err
+          : new SkillLoadError(`unexpected load error: ${entry}`, skillDir, err);
+      results.push({ ok: false, skillDir, error });
+    }
+  }
+
+  return results;
+}
+
+// 用户导入的 skill(M1 不暴露导入 UI,接口先就位)。
+// dir 不存在时返回 [](首次启动用户目录还没建,不算错)。
+export function loadUserSkills(userSkillsDir: string): LoadResult[] {
+  if (!existsSync(userSkillsDir)) return [];
+  return loadBuiltinSkills(userSkillsDir);
+}

--- a/packages/skill-runtime/tests/composer.test.ts
+++ b/packages/skill-runtime/tests/composer.test.ts
@@ -1,0 +1,78 @@
+// PromptComposer 测试:必填校验 + mustache 替换 + 通用前缀。
+
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import { compose, PromptComposer } from "../src/composer";
+import { ValidationError } from "../src/errors";
+import { type LoadedSkill, loadFromDirectory } from "../src/loader";
+
+const FIXTURE_SAMPLE_SKILL = join(__dirname, "..", "__fixtures__", "sample-skill");
+
+function loadSample(): LoadedSkill {
+  return loadFromDirectory(FIXTURE_SAMPLE_SKILL);
+}
+
+describe("PromptComposer.compose / compose", () => {
+  it("替换 {{varName}} 占位符 + 加通用前缀", () => {
+    const skill = loadSample();
+    const result = compose(skill, { topic: "测试主题" });
+    expect(result).toContain("OpenTrad's fixture-skill skill");
+    expect(result).toContain("Stay within scope");
+    expect(result).toContain("测试主题");
+    expect(result).not.toContain("{{topic}}");
+  });
+
+  it("通用前缀格式对齐 03 §4.3", () => {
+    const skill = loadSample();
+    const result = compose(skill, { topic: "x" });
+    // 前缀:`You are operating within OpenTrad's <id> skill. <description>. Stay within scope.\n\n`
+    expect(result.startsWith("You are operating within OpenTrad's fixture-skill skill.")).toBe(
+      true,
+    );
+    expect(result).toContain(skill.manifest.description);
+  });
+
+  it("必填 input 缺失抛 ValidationError", () => {
+    const skill = loadSample();
+    expect(() => compose(skill, {})).toThrow(ValidationError);
+  });
+
+  it("非必填字段缺失,{{x}} 替换为空串(M1 简化,#23 决策点 D-M1-2)", () => {
+    const baseSkill = loadSample();
+    const firstInput = baseSkill.manifest.inputs[0];
+    if (!firstInput) throw new Error("fixture should have at least one input");
+    const optionalSkill: LoadedSkill = {
+      ...baseSkill,
+      manifest: {
+        ...baseSkill.manifest,
+        inputs: [{ ...firstInput, required: false }],
+      },
+      promptTemplate: "Hello {{topic}}, age {{age}}.",
+    };
+    const result = compose(optionalSkill, { topic: "Alice" });
+    expect(result).toContain("Hello Alice, age .");
+  });
+
+  it("PromptComposer.compose 与 compose 函数等价", () => {
+    const skill = loadSample();
+    const a = compose(skill, { topic: "x" });
+    const b = PromptComposer.compose(skill, { topic: "x" });
+    expect(a).toBe(b);
+  });
+
+  it("null / undefined input 替换为空串(不抛)", () => {
+    const baseSkill = loadSample();
+    const firstInput = baseSkill.manifest.inputs[0];
+    if (!firstInput) throw new Error("fixture should have at least one input");
+    const skill: LoadedSkill = {
+      ...baseSkill,
+      manifest: {
+        ...baseSkill.manifest,
+        inputs: [{ ...firstInput, required: false }],
+      },
+      promptTemplate: "[{{topic}}]",
+    };
+    expect(compose(skill, { topic: undefined })).toContain("[]");
+    expect(compose(skill, { topic: null })).toContain("[]");
+  });
+});

--- a/packages/skill-runtime/tests/loader.test.ts
+++ b/packages/skill-runtime/tests/loader.test.ts
@@ -1,0 +1,179 @@
+// SkillLoader 测试:loadFromDirectory 主路径 + per-skill try/catch 不阻塞。
+// 5 个 manifest 中 1 个故意损坏的验收用 tmpdir 临时构造,test 内 cleanup。
+
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { SkillLoadError } from "../src/errors";
+import { loadBuiltinSkills, loadFromDirectory, loadUserSkills } from "../src/loader";
+
+const FIXTURE_SAMPLE_SKILL = join(__dirname, "..", "__fixtures__", "sample-skill");
+
+describe("loadFromDirectory", () => {
+  it("加载 sample-skill 返回完整 manifest + prompt", () => {
+    const loaded = loadFromDirectory(FIXTURE_SAMPLE_SKILL);
+    expect(loaded.manifest.id).toBe("fixture-skill");
+    expect(loaded.manifest.title).toBe("Fixture Test Skill");
+    expect(loaded.manifest.version).toBe("0.1.0");
+    expect(loaded.manifest.category).toBe("communication");
+    expect(loaded.manifest.riskLevel).toBe("draft_only");
+    expect(loaded.manifest.allowedTools).toEqual([
+      "mcp__opentrad__echo",
+      "mcp__opentrad__draft_save",
+    ]);
+    expect(loaded.manifest.disallowedTools).toEqual(["Bash(*)", "mcp__*__send*"]);
+    expect(loaded.manifest.inputs).toHaveLength(1);
+    expect(loaded.manifest.inputs[0]?.name).toBe("topic");
+    expect(loaded.manifest.outputs).toEqual(["draft"]);
+    expect(loaded.promptTemplate).toContain("{{topic}}");
+  });
+
+  it("dir 不存在抛 SkillLoadError", () => {
+    expect(() => loadFromDirectory("/nonexistent/path/to/skill")).toThrow(SkillLoadError);
+  });
+
+  it("skill.yml 缺必填字段时抛 SkillLoadError 包装 zod 错", () => {
+    const tmp = mkdtempSync(join(tmpdir(), "ot-skill-"));
+    try {
+      writeFileSync(
+        join(tmp, "skill.yml"),
+        "title: missing-id\nversion: 0.1.0\n", // 缺 id 等必填
+      );
+      expect(() => loadFromDirectory(tmp)).toThrow(SkillLoadError);
+    } finally {
+      rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  it("promptTemplate 文件不存在抛 SkillLoadError", () => {
+    const tmp = mkdtempSync(join(tmpdir(), "ot-skill-"));
+    try {
+      writeFileSync(
+        join(tmp, "skill.yml"),
+        `id: x
+title: Missing prompt
+version: 0.1.0
+description: test
+category: other
+riskLevel: read_only
+allowedTools: []
+inputs: []
+outputs: []
+promptTemplate: missing.md
+`,
+      );
+      expect(() => loadFromDirectory(tmp)).toThrow(/prompt template not found/);
+    } finally {
+      rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("loadBuiltinSkills", () => {
+  let tmp: string;
+
+  // 验收 4:5 个 skill 中 1 个故意损坏,只该 skill 标 ok:false,其他 4 个正常
+  beforeEach(() => {
+    tmp = mkdtempSync(join(tmpdir(), "ot-builtin-"));
+    for (let i = 1; i <= 4; i++) {
+      const dir = join(tmp, `valid-${i}`);
+      mkdirSync(dir);
+      writeFileSync(
+        join(dir, "skill.yml"),
+        `id: valid-${i}
+title: Valid ${i}
+version: 0.1.0
+description: valid skill ${i}
+category: other
+riskLevel: read_only
+allowedTools: []
+inputs: []
+outputs: []
+promptTemplate: prompt.md
+`,
+      );
+      writeFileSync(join(dir, "prompt.md"), `Hello from ${i}`);
+    }
+    // 第 5 个故意损坏(yaml 合法但 schema 拒)
+    const broken = join(tmp, "broken");
+    mkdirSync(broken);
+    writeFileSync(
+      join(broken, "skill.yml"),
+      "title: broken-no-id\nversion: 0.1.0\n", // 缺 id
+    );
+  });
+
+  afterEach(() => {
+    rmSync(tmp, { recursive: true, force: true });
+  });
+
+  it("5 个 manifest 中 4 个 ok + 1 个 broken,broken 不阻塞其他", () => {
+    const results = loadBuiltinSkills(tmp);
+    expect(results).toHaveLength(5);
+
+    const ok = results.filter((r) => r.ok);
+    const failed = results.filter((r) => !r.ok);
+    expect(ok).toHaveLength(4);
+    expect(failed).toHaveLength(1);
+
+    expect(failed[0]?.ok).toBe(false);
+    if (failed[0]?.ok === false) {
+      expect(failed[0].error).toBeInstanceOf(SkillLoadError);
+      expect(failed[0].skillDir).toContain("broken");
+    }
+
+    const ids = ok
+      .filter((r): r is Extract<typeof r, { ok: true }> => r.ok)
+      .map((r) => r.skill.manifest.id)
+      .sort();
+    expect(ids).toEqual(["valid-1", "valid-2", "valid-3", "valid-4"]);
+  });
+
+  it("跳过非目录 entry(.DS_Store / 单文件)", () => {
+    writeFileSync(join(tmp, ".DS_Store"), "");
+    writeFileSync(join(tmp, "stray.txt"), "");
+    const results = loadBuiltinSkills(tmp);
+    // 还是 5 个(4 valid + 1 broken),非目录被跳过
+    expect(results).toHaveLength(5);
+  });
+
+  it("dir 不存在抛 SkillLoadError", () => {
+    expect(() => loadBuiltinSkills("/nonexistent/skills/dir")).toThrow(SkillLoadError);
+  });
+});
+
+describe("loadUserSkills", () => {
+  it("dir 不存在返回空数组(不抛)", () => {
+    const results = loadUserSkills("/nonexistent/user/skills/dir");
+    expect(results).toEqual([]);
+  });
+
+  it("dir 存在时委托 loadBuiltinSkills", () => {
+    const tmp = mkdtempSync(join(tmpdir(), "ot-user-"));
+    try {
+      const dir = join(tmp, "my-skill");
+      mkdirSync(dir);
+      writeFileSync(
+        join(dir, "skill.yml"),
+        `id: my-skill
+title: My
+version: 0.1.0
+description: user
+category: other
+riskLevel: read_only
+allowedTools: []
+inputs: []
+outputs: []
+promptTemplate: prompt.md
+`,
+      );
+      writeFileSync(join(dir, "prompt.md"), "user content");
+      const results = loadUserSkills(tmp);
+      expect(results).toHaveLength(1);
+      expect(results[0]?.ok).toBe(true);
+    } finally {
+      rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+});

--- a/packages/skill-runtime/tsconfig.json
+++ b/packages/skill-runtime/tsconfig.json
@@ -1,9 +1,9 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "rootDir": "./src",
     "outDir": "./dist",
     "noEmit": true
   },
-  "include": ["src/**/*"]
+  "include": ["src/**/*", "tests/**/*", "vitest.config.ts"],
+  "exclude": ["node_modules", "dist"]
 }

--- a/packages/skill-runtime/vitest.config.ts
+++ b/packages/skill-runtime/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    include: ["tests/**/*.test.ts"],
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -132,7 +132,18 @@ importers:
         specifier: ^4.3.6
         version: 4.3.6
 
-  packages/skill-runtime: {}
+  packages/skill-runtime:
+    dependencies:
+      '@opentrad/shared':
+        specifier: workspace:*
+        version: link:../shared
+      js-yaml:
+        specifier: ^4.1.0
+        version: 4.1.1
+    devDependencies:
+      '@types/js-yaml':
+        specifier: ^4.0.9
+        version: 4.0.9
 
   packages/stream-parser:
     dependencies:


### PR DESCRIPTION
## Summary

按 03-architecture.md §4.3,packages/skill-runtime 落地三件套:**SkillLoader / PromptComposer / errors**。@opentrad/shared 既有 SkillManifest schema 通过 index.ts re-export,业务包一行 import。

- **SkillLoader** (loader.ts):loadFromDirectory(dir) 单加载 / loadBuiltinSkills(skillsDir) per-skill try/catch / loadUserSkills(userSkillsDir) dir 不存在视为 []
- **PromptComposer** (composer.ts):compose(skill, inputs) 函数式主接口 + PromptComposer namespace 对象 (biome 拒纯静态 class)
- **errors**:ValidationError(必填 input 缺失) + SkillLoadError(loader 失败包装原 cause)

## 验收对照(issue body 4 条)

- [x] **`pnpm --filter @opentrad/skill-runtime test` 全绿** — 2 test files / 15 cases
- [x] **单测覆盖 loader 加载 fixture skill / composer 替换+前缀 / zod 拒不合法 manifest / 5 manifest 中 1 broken 不阻塞** — 全部覆盖
- [x] **shared 类型可被其他包 import** — 验证:packages/skill-runtime/src/loader.ts L11 \`import { type SkillManifest, SkillManifestSchema } from \"@opentrad/shared\"\` 正常 typecheck
- [x] **loader 加载 5 manifest 中 1 故意损坏,只该 skill loadError,其他 4 个正常** — loader.test.ts L111 \`5 个 manifest 中 4 个 ok + 1 个 broken,broken 不阻塞其他\` 测试用 tmpdir 临时构造 5 dir 验证

## 决策点 D-M1-2(已落地)

- ✅ SkillLoader per-skill try/catch — loadBuiltinSkills 内 try/catch,单失败不抛
- ✅ PromptComposer 不嵌套 mustache — 简单 \`{{(\\\\w+)}}\` regex,无递归
- ✅ skill manifest version 字段仅校验存在,不做 semver — SkillManifestSchema 用 z.string()

## D9-1 自主决策(本 PR 范围)

**不在本 PR**:apps/desktop 切到 @opentrad/skill-runtime + 删除 services/skill-fixture-loader.ts。

**理由**:cc.ts 切换需要 fixture path 解析,与 PR #40 (bug A) 修法在同一处。两个 PR 同改一个文件路径解析会冲突。本 PR 严格按 issue body 验收范围(skill-runtime 包内),desktop 切换延后:
- 选项 A:#40 合后开独立小 PR(< 30 行,删 fixture loader + 改 cc.ts import + 移 path 解析到 cc.ts)
- 选项 B:#24 (SkillPicker UI) 实施时自然要重写 cc.ts 用 SkillRegistry 风格,届时一起切

请发起人在 #23 review 时定 A / B(默认 A,更小颗粒)。

## Test plan

- [x] \`pnpm --filter @opentrad/skill-runtime typecheck\` 0 错
- [x] \`pnpm --filter @opentrad/skill-runtime test\` 2 文件 / 15 测试全过
- [x] \`pnpm typecheck\` 全 workspace 0 错
- [x] \`pnpm test\` 全 workspace 全过 (ABI 切回 node,desktop 66/66 + cc-adapter 23/23 + skill-runtime 15/15 等)
- [x] \`pnpm lint\` biome 0 错
- [x] CI 三平台 + electron-abi-smoke 待跑

## 不在本 PR / 后续

- apps/desktop 切换(见上 D9-1 决策)
- 真实 trade-email-writer skill 加入 builtin(M1 #30)
- M2 用户自定义 universal prefix(PromptComposer 升级 instance class)

Closes #23

🤖 Generated with [Claude Code](https://claude.com/claude-code)