### PR TITLE
feat(browser-tools): Playwright 封装 + 3 个 review-level browser tools (M1 #27)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,11 @@ concurrency:
   group: ci-${{ github.ref }}
   cancel-in-progress: true
 
+# 全局 env：CI 不需要 Playwright Chromium binary(单测全 mock,e2e 留 dev),
+# 跳过 install 时 ~150MB 下载,节省 CI 时间 + 流量。打包真验证留 M1 #30。
+env:
+  PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: "1"
+
 jobs:
   check:
     name: check (${{ matrix.os }})

--- a/apps/mcp-server/package.json
+++ b/apps/mcp-server/package.json
@@ -14,6 +14,7 @@
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.29.0",
+    "@opentrad/browser-tools": "workspace:^",
     "zod": "^4.3.6"
   }
 }

--- a/apps/mcp-server/src/index.ts
+++ b/apps/mcp-server/src/index.ts
@@ -14,8 +14,10 @@
 import { Server } from "@modelcontextprotocol/sdk/server/index.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { CallToolRequestSchema, ListToolsRequestSchema } from "@modelcontextprotocol/sdk/types.js";
+import { BrowserService } from "@opentrad/browser-tools";
 import { z } from "zod";
 import { IpcBridgeClient } from "./ipc-bridge";
+import { MockRiskGate, type RiskGate } from "./risk-gate";
 import { getToolByName, tools } from "./tools";
 
 async function main(): Promise<void> {
@@ -39,6 +41,14 @@ async function main(): Promise<void> {
   });
   void bridge.connect();
 
+  // BrowserService(M1 #27):懒加载 Chromium,首次 browser_open 时才启。
+  // dev 模式 chromium binary 在 ~/Library/Caches/ms-playwright/(发起人首次跑 setup);
+  // packaged 模式 PLAYWRIGHT_BROWSERS_PATH env 由 desktop 主进程注入(M1 #30)。
+  const browserService = new BrowserService({ launchOptions: { headless: false } });
+
+  // RiskGate(M1 #27 用 MockRiskGate allow 所有,M1 #28 替换为 IpcRiskGate 走 bridge 弹窗)
+  const riskGate: RiskGate = new MockRiskGate();
+
   const server = new Server(
     { name: "opentrad", version: "0.0.0" },
     { capabilities: { tools: {} } },
@@ -60,10 +70,39 @@ async function main(): Promise<void> {
         content: [{ type: "text", text: `unknown tool: ${req.params.name}` }],
       };
     }
+
+    // RiskGate 拦截(M1 #27 落地点):review 走 RiskGate.requestApproval,blocked 直拒。
+    // safe 直接执行,与 #25 / #26 行为一致。
+    if (tool.riskLevel === "blocked") {
+      return {
+        isError: true,
+        content: [{ type: "text", text: `tool ${tool.name} is blocked by risk policy` }],
+      };
+    }
+    if (tool.riskLevel === "review") {
+      const decision = await riskGate.requestApproval({
+        sessionId,
+        toolName: tool.name,
+        params: req.params.arguments,
+      });
+      if (!decision.allowed) {
+        return {
+          isError: true,
+          content: [
+            {
+              type: "text",
+              text: `user denied ${tool.name}${decision.reason ? `: ${decision.reason}` : ""}`,
+            },
+          ],
+        };
+      }
+    }
+
     try {
       const content = await tool.execute(req.params.arguments ?? {}, {
         bridge,
         sessionId,
+        browserService,
       });
       return { content };
     } catch (err) {
@@ -77,6 +116,7 @@ async function main(): Promise<void> {
 
   // 退出清理：CC 关闭 stdio 时 SDK 会触发；这里再加一道 cleanup 保险
   const shutdown = (): void => {
+    void browserService.cleanup().catch(() => {});
     bridge.close();
     process.exit(0);
   };

--- a/apps/mcp-server/src/risk-gate.ts
+++ b/apps/mcp-server/src/risk-gate.ts
@@ -1,0 +1,44 @@
+// RiskGate interface + MockRiskGate(M1 #27 落地点)。
+//
+// 设计意图:tool execute 前根据 tool.riskLevel 决定:
+// - safe   → 直接执行
+// - review → 调 RiskGate.requestApproval,用户确认后才执行(真 RiskGate 弹窗在 M1 #28)
+// - blocked → 直接拒
+//
+// **本文件 M1 #27 提供 MockRiskGate(allow 所有)**。
+// **M1 #28 (#28) 落地真 RiskGate**:走 IPC bridge 调 desktop main 进程,弹窗等待用户决定。
+// 那时 RiskGate interface 不变,把 MockRiskGate 替换为 IpcRiskGate(走 bridge)即可。
+//
+// 不放 packages/shared:#28 时只需 mcp-server 端的具体 impl 替换,接口不必跨包共享。
+
+export interface ApprovalRequest {
+  sessionId: string;
+  toolName: string;
+  // tool 调用参数,用于在弹窗里给用户看(如 url、target email 等)
+  params: unknown;
+  // 业务级动作描述(M2 增强:skill 可声明 "我即将做 X");M1 此字段可为空
+  businessAction?: string;
+}
+
+export interface ApprovalResult {
+  allowed: boolean;
+  // 用户拒绝时的原因(可选,用于 audit log)
+  reason?: string;
+  // 用户是否选择"以后都允许该 skill 的此 tool"(M2 用,M1 mock 永远 false)
+  rememberDecision?: boolean;
+}
+
+export interface RiskGate {
+  requestApproval(req: ApprovalRequest): Promise<ApprovalResult>;
+}
+
+// M1 #27 mock:允许所有,记一行 stderr 方便诊断。
+// **不要在 M1 #28 之后还用本类**:真 RiskGate 落地后切到 IpcRiskGate。
+export class MockRiskGate implements RiskGate {
+  async requestApproval(req: ApprovalRequest): Promise<ApprovalResult> {
+    process.stderr.write(
+      `[opentrad-mcp] MockRiskGate auto-allow: tool=${req.toolName} session=${req.sessionId}\n`,
+    );
+    return { allowed: true };
+  }
+}

--- a/apps/mcp-server/src/tools/browser/open.ts
+++ b/apps/mcp-server/src/tools/browser/open.ts
@@ -1,0 +1,35 @@
+// browser_open(M1 #27):打开 URL,返回 pageId 供后续 browser_read / browser_screenshot 调。
+// riskLevel='review':真 RiskGate 弹窗在 M1 #28 替换 MockRiskGate;本 PR 用 MockRiskGate allow 所有。
+
+import { z } from "zod";
+import type { OpenTradTool } from "../index";
+
+const InputSchema = z.object({
+  url: z.string().url().describe("要打开的 URL,必须是有效 http(s) 地址"),
+});
+
+export const browserOpenTool: OpenTradTool = {
+  name: "browser_open",
+  description:
+    "Open a URL in the managed Chromium browser. Returns { pageId, title, url } for follow-up browser_read / browser_screenshot calls.",
+  inputSchema: InputSchema,
+  riskLevel: "review",
+  category: "browser",
+  async execute(rawInput, ctx) {
+    const input = InputSchema.parse(rawInput);
+    if (!ctx.browserService) {
+      throw new Error("browserService is not available in this context (mcp-server bug)");
+    }
+    const result = await ctx.browserService.newPage(input.url);
+    return [
+      {
+        type: "text",
+        text: JSON.stringify(
+          { pageId: result.pageId, title: result.title, url: result.url },
+          null,
+          2,
+        ),
+      },
+    ];
+  },
+};

--- a/apps/mcp-server/src/tools/browser/read.ts
+++ b/apps/mcp-server/src/tools/browser/read.ts
@@ -1,0 +1,27 @@
+// browser_read(M1 #27):读取 pageId 对应页面的简化 DOM snapshot。
+// 返回 ≤5KB 文本(extractDomSnapshot 算法 + snapshotToText 序列化),给 LLM 看而不是整页 HTML。
+// riskLevel='review':同 browser_open。
+
+import { z } from "zod";
+import type { OpenTradTool } from "../index";
+
+const InputSchema = z.object({
+  pageId: z.string().describe("由 browser_open 返回的 pageId"),
+});
+
+export const browserReadTool: OpenTradTool = {
+  name: "browser_read",
+  description:
+    "Read a simplified DOM snapshot (title / headings / visible text / first 50 links) of an opened page. Returns ≤5KB markdown-ish text suitable for LLM consumption.",
+  inputSchema: InputSchema,
+  riskLevel: "review",
+  category: "browser",
+  async execute(rawInput, ctx) {
+    const input = InputSchema.parse(rawInput);
+    if (!ctx.browserService) {
+      throw new Error("browserService is not available in this context (mcp-server bug)");
+    }
+    const { text } = await ctx.browserService.readPageText(input.pageId);
+    return [{ type: "text", text }];
+  },
+};

--- a/apps/mcp-server/src/tools/browser/screenshot.ts
+++ b/apps/mcp-server/src/tools/browser/screenshot.ts
@@ -1,0 +1,26 @@
+// browser_screenshot(M1 #27):返回 base64 PNG。viewport 锁 1280x720 避免巨大图。
+// riskLevel='review':同 browser_open / browser_read。
+
+import { z } from "zod";
+import type { OpenTradTool } from "../index";
+
+const InputSchema = z.object({
+  pageId: z.string().describe("由 browser_open 返回的 pageId"),
+});
+
+export const browserScreenshotTool: OpenTradTool = {
+  name: "browser_screenshot",
+  description:
+    "Capture a 1280x720 PNG screenshot of an opened page. Returns base64-encoded image content.",
+  inputSchema: InputSchema,
+  riskLevel: "review",
+  category: "browser",
+  async execute(rawInput, ctx) {
+    const input = InputSchema.parse(rawInput);
+    if (!ctx.browserService) {
+      throw new Error("browserService is not available in this context (mcp-server bug)");
+    }
+    const { pngBase64 } = await ctx.browserService.screenshot(input.pageId);
+    return [{ type: "image", data: pngBase64, mimeType: "image/png" }];
+  },
+};

--- a/apps/mcp-server/src/tools/index.ts
+++ b/apps/mcp-server/src/tools/index.ts
@@ -7,6 +7,7 @@
 //          走 IPC bridge）
 //   - #27：browser_open / browser_read / browser_screenshot（review-level）
 
+import type { BrowserService } from "@opentrad/browser-tools";
 import type { z } from "zod";
 import type { IpcBridgeClient } from "../ipc-bridge";
 
@@ -14,10 +15,15 @@ import type { IpcBridgeClient } from "../ipc-bridge";
 export interface ToolContext {
   bridge: IpcBridgeClient;
   sessionId: string;
+  // 可选:browser_* 工具需要;safe / draft 类工具忽略。
+  // mcp-server index.ts 启动时单例创建,所有 browser tool 共享。
+  browserService?: BrowserService;
 }
 
-// MCP 协议返回的 content。M1 只用 text；后续 M1 #27 browser_screenshot 加 image。
-export type ToolContent = { type: "text"; text: string };
+// MCP 协议返回的 content。M1 #27 起 browser_screenshot 加 image 类型(base64 PNG)。
+export type ToolContent =
+  | { type: "text"; text: string }
+  | { type: "image"; data: string; mimeType: string };
 
 export interface OpenTradTool {
   name: string;
@@ -30,6 +36,9 @@ export interface OpenTradTool {
 }
 
 // 工具集合：新增工具时 import + 加进数组。
+import { browserOpenTool } from "./browser/open";
+import { browserReadTool } from "./browser/read";
+import { browserScreenshotTool } from "./browser/screenshot";
 import { draftSaveTool } from "./draft-save";
 import { echoTool } from "./echo";
 import { hsCodeLookupTool } from "./hs-code-lookup";
@@ -40,6 +49,9 @@ export const tools: OpenTradTool[] = [
   draftSaveTool,
   hsCodeLookupTool,
   sessionGetMetadataTool,
+  browserOpenTool,
+  browserReadTool,
+  browserScreenshotTool,
 ];
 
 export function getToolByName(name: string): OpenTradTool | undefined {

--- a/apps/mcp-server/tests/browser-tools.test.ts
+++ b/apps/mcp-server/tests/browser-tools.test.ts
@@ -1,0 +1,90 @@
+// browser tools 测试(M1 #27):browser_open / browser_read / browser_screenshot 三 tool。
+// 用 mock BrowserService(不真启 Chromium),验证 ctx 注入 + 输入校验 + 返回内容形态。
+
+import type { BrowserService } from "@opentrad/browser-tools";
+import { describe, expect, it, vi } from "vitest";
+import type { ToolContext } from "../src/tools";
+import { browserOpenTool } from "../src/tools/browser/open";
+import { browserReadTool } from "../src/tools/browser/read";
+import { browserScreenshotTool } from "../src/tools/browser/screenshot";
+
+function makeCtxWithMockBrowser(impl: Partial<BrowserService>): ToolContext {
+  return {
+    bridge: {} as ToolContext["bridge"],
+    sessionId: "test-session",
+    browserService: impl as unknown as BrowserService,
+  };
+}
+
+describe("browser_open", () => {
+  it("调 newPage(url) 返回 pageId / title / url JSON 字符串", async () => {
+    const newPage = vi.fn().mockResolvedValue({
+      pageId: "pid-123",
+      title: "Example",
+      url: "https://example.com/",
+    });
+    const ctx = makeCtxWithMockBrowser({ newPage });
+
+    const result = await browserOpenTool.execute({ url: "https://example.com/" }, ctx);
+    expect(newPage).toHaveBeenCalledWith("https://example.com/");
+    expect(result[0]?.type).toBe("text");
+    if (result[0]?.type === "text") {
+      const parsed = JSON.parse(result[0].text);
+      expect(parsed).toEqual({
+        pageId: "pid-123",
+        title: "Example",
+        url: "https://example.com/",
+      });
+    }
+  });
+
+  it("zod 校验:非 URL 字符串抛错", async () => {
+    const ctx = makeCtxWithMockBrowser({ newPage: vi.fn() });
+    await expect(browserOpenTool.execute({ url: "not-a-url" }, ctx)).rejects.toThrow();
+  });
+
+  it("ctx.browserService 缺失抛 sentinel error", async () => {
+    const ctx: ToolContext = {
+      bridge: {} as ToolContext["bridge"],
+      sessionId: "s",
+    };
+    await expect(browserOpenTool.execute({ url: "https://example.com/" }, ctx)).rejects.toThrow(
+      /browserService is not available/,
+    );
+  });
+});
+
+describe("browser_read", () => {
+  it("调 readPageText(pageId) 返回 text content", async () => {
+    const readPageText = vi.fn().mockResolvedValue({
+      snapshot: {} as never,
+      text: "URL: https://x/\nTitle: X\n",
+    });
+    const ctx = makeCtxWithMockBrowser({ readPageText });
+
+    const result = await browserReadTool.execute({ pageId: "pid-1" }, ctx);
+    expect(readPageText).toHaveBeenCalledWith("pid-1");
+    expect(result).toEqual([{ type: "text", text: "URL: https://x/\nTitle: X\n" }]);
+  });
+
+  it("zod 校验:缺 pageId 抛错", async () => {
+    const ctx = makeCtxWithMockBrowser({ readPageText: vi.fn() });
+    await expect(browserReadTool.execute({}, ctx)).rejects.toThrow();
+  });
+});
+
+describe("browser_screenshot", () => {
+  it("调 screenshot(pageId) 返回 base64 PNG image content", async () => {
+    const screenshot = vi.fn().mockResolvedValue({ pngBase64: "UE5HZmFrZQ==" });
+    const ctx = makeCtxWithMockBrowser({ screenshot });
+
+    const result = await browserScreenshotTool.execute({ pageId: "pid-1" }, ctx);
+    expect(screenshot).toHaveBeenCalledWith("pid-1");
+    expect(result).toEqual([{ type: "image", data: "UE5HZmFrZQ==", mimeType: "image/png" }]);
+  });
+
+  it("zod 校验:缺 pageId 抛错", async () => {
+    const ctx = makeCtxWithMockBrowser({ screenshot: vi.fn() });
+    await expect(browserScreenshotTool.execute({}, ctx)).rejects.toThrow();
+  });
+});

--- a/apps/mcp-server/tests/risk-gate.test.ts
+++ b/apps/mcp-server/tests/risk-gate.test.ts
@@ -1,0 +1,36 @@
+// MockRiskGate 测试(M1 #27 占位实现)。
+// 真 RiskGate(走 IPC bridge 弹窗)在 M1 #28 落地,届时同 interface 替换。
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { MockRiskGate } from "../src/risk-gate";
+
+describe("MockRiskGate", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("requestApproval 永远 allow", async () => {
+    const gate = new MockRiskGate();
+    const result = await gate.requestApproval({
+      sessionId: "s1",
+      toolName: "browser_open",
+      params: { url: "https://example.com/" },
+    });
+    expect(result.allowed).toBe(true);
+  });
+
+  it("写一行 stderr 诊断(便于 dev 模式定位 mock 在生效)", async () => {
+    const writeSpy = vi.spyOn(process.stderr, "write").mockReturnValue(true);
+    const gate = new MockRiskGate();
+    await gate.requestApproval({
+      sessionId: "s2",
+      toolName: "browser_read",
+      params: { pageId: "p" },
+    });
+    expect(writeSpy).toHaveBeenCalled();
+    const calls = writeSpy.mock.calls.map((c) => String(c[0])).join("");
+    expect(calls).toContain("MockRiskGate auto-allow");
+    expect(calls).toContain("browser_read");
+    expect(calls).toContain("s2");
+  });
+});

--- a/apps/mcp-server/tests/tools.test.ts
+++ b/apps/mcp-server/tests/tools.test.ts
@@ -9,9 +9,12 @@ import { hsCodeLookupTool } from "../src/tools/hs-code-lookup";
 import { sessionGetMetadataTool } from "../src/tools/session-get-metadata";
 
 describe("tools registry", () => {
-  it("4 个工具都注册（echo + #26 三个 safe-only）", () => {
-    expect(tools).toHaveLength(4);
+  it("7 个工具都注册（#25 echo + #26 三个 safe-only + #27 三个 browser review）", () => {
+    expect(tools).toHaveLength(7);
     expect(tools.map((t) => t.name).sort()).toEqual([
+      "browser_open",
+      "browser_read",
+      "browser_screenshot",
       "draft_save",
       "echo",
       "hs_code_lookup",
@@ -27,9 +30,14 @@ describe("tools registry", () => {
     expect(getToolByName("nonexistent")).toBeUndefined();
   });
 
-  it("safe 类工具 riskLevel 全为 safe（M1 #26 范围）", () => {
+  it("riskLevel 分布:#25 / #26 全 safe,#27 browser_* 全 review", () => {
     for (const tool of tools) {
-      expect(tool.riskLevel).toBe("safe");
+      if (tool.name.startsWith("browser_")) {
+        expect(tool.riskLevel).toBe("review");
+        expect(tool.category).toBe("browser");
+      } else {
+        expect(tool.riskLevel).toBe("safe");
+      }
     }
   });
 });

--- a/packages/browser-tools/README.md
+++ b/packages/browser-tools/README.md
@@ -1,0 +1,37 @@
+# @opentrad/browser-tools
+
+Playwright 封装,给 mcp-server 的 browser tools(`browser_open` / `browser_read` / `browser_screenshot`)用。M1 #27 落地点。
+
+## Setup(dev 模式首次)
+
+CI 跳过 Chromium 下载(`PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1`),dev 模式发起人首次需手动安装 Chromium binary:
+
+```bash
+pnpm --filter @opentrad/browser-tools setup
+# 等价 npx playwright install chromium
+```
+
+约 150MB 下载,放在 `~/Library/Caches/ms-playwright/`(macOS)。
+
+M1 #30 真打包时 electron-builder `extraResources` 把 Chromium 内置到 `.app/.exe/.AppImage` Resources/playwright/,运行时 `PLAYWRIGHT_BROWSERS_PATH` env 指向 bundled 路径(不依赖用户 setup)。M1 #27 这步先 bundle 进 dev cache 即可。
+
+## API
+
+```ts
+import { BrowserService } from "@opentrad/browser-tools";
+
+const svc = new BrowserService();
+await svc.launch();
+const { pageId, title } = await svc.newPage("https://example.com");
+const text = await svc.readPageText(pageId);   // ≤5KB DOM snapshot
+const png = await svc.screenshot(pageId);       // base64 PNG
+await svc.cleanup();
+```
+
+## 测试策略
+
+单测注入 fake launcher(`BrowserLauncher` interface),不真启 Chromium。`extractDomSnapshot` 是 serializable 命名函数,运行在 page context 内,单测时 evaluate 由 fake page 直接 stub 返回值。dev 模式 e2e 验证 launch + 真实页面交互。
+
+## 退场计划
+
+无:本包是 M1 起的常驻 lib,后续 skill 增加更多 browser 操作时在此扩展。

--- a/packages/browser-tools/package.json
+++ b/packages/browser-tools/package.json
@@ -6,6 +6,11 @@
   "main": "./src/index.ts",
   "types": "./src/index.ts",
   "scripts": {
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run",
+    "setup": "playwright install chromium"
+  },
+  "dependencies": {
+    "playwright": "^1.59.1"
   }
 }

--- a/packages/browser-tools/src/browser-service.ts
+++ b/packages/browser-tools/src/browser-service.ts
@@ -1,0 +1,149 @@
+// BrowserService:Playwright Chromium 单例 + page lifecycle 管理。
+//
+// 03 ADR-007 + D-pre-1(bundle Chromium):dev 模式用 npm 默认 cache(发起人首次跑
+// `pnpm --filter @opentrad/browser-tools setup`),packaged 模式 PLAYWRIGHT_BROWSERS_PATH
+// env 由 desktop 主进程注入指向 .app/Resources/playwright/(M1 #30 落地)。
+//
+// 设计选择:
+// - 单例懒加载:首次调 launch / newPage 时才启 Chromium(避免 mcp-server 启动卡顿)
+// - launcher 注入(BrowserLauncher interface):单测 fake 不真启 Chromium,CI 不需 ~150MB binary
+// - cleanup:应用退出时调,关闭所有 page + browser(避免僵尸进程)
+
+import { randomUUID } from "node:crypto";
+import { type DomSnapshot, extractDomSnapshot, snapshotToText } from "./dom-snapshot";
+import type { BrowserHandle, BrowserLauncher, PageHandle } from "./types";
+
+export interface BrowserServiceOptions {
+  // 默认 dynamic import("playwright").chromium;单测注入 fake。
+  launcher?: BrowserLauncher;
+  // launch 时传给 playwright 的 options(headless 等)
+  launchOptions?: { headless?: boolean };
+}
+
+export interface NewPageResult {
+  pageId: string;
+  title: string;
+  url: string;
+}
+
+const SCREENSHOT_VIEWPORT = { width: 1280, height: 720 } as const;
+
+export class BrowserService {
+  private browser: BrowserHandle | undefined;
+  private readonly pages = new Map<string, PageHandle>();
+  private readonly launcher: BrowserLauncher | "lazy";
+  private readonly launchOptions: { headless?: boolean };
+  // 并发 launch 时的 in-flight promise,避免重复启动 Chromium
+  private launchPromise: Promise<BrowserHandle> | undefined;
+
+  constructor(opts: BrowserServiceOptions = {}) {
+    // "lazy" sentinel:真用时才 dynamic import playwright,避免单测时 transitive 加载 playwright
+    this.launcher = opts.launcher ?? "lazy";
+    this.launchOptions = opts.launchOptions ?? { headless: false };
+  }
+
+  // 显式启动(可选,首次 newPage 也会自动启)
+  async launch(): Promise<void> {
+    await this.ensureBrowser();
+  }
+
+  async newPage(url?: string): Promise<NewPageResult> {
+    const browser = await this.ensureBrowser();
+    const page = await browser.newPage();
+    if (url) {
+      await page.goto(url, { timeout: 30_000 });
+    }
+    const pageId = randomUUID();
+    this.pages.set(pageId, page);
+    return {
+      pageId,
+      title: await page.title(),
+      url: url ?? "",
+    };
+  }
+
+  // 内部使用;tools 通过 readPageText / screenshot 调
+  getPage(pageId: string): PageHandle | undefined {
+    return this.pages.get(pageId);
+  }
+
+  async readPageText(pageId: string): Promise<{ snapshot: DomSnapshot; text: string }> {
+    const page = this.requirePage(pageId);
+    const snapshot = await page.evaluate<DomSnapshot>(extractDomSnapshot);
+    const text = snapshotToText(snapshot);
+    return { snapshot, text };
+  }
+
+  async screenshot(pageId: string): Promise<{ pngBase64: string }> {
+    const page = this.requirePage(pageId);
+    await page.setViewportSize(SCREENSHOT_VIEWPORT);
+    const buffer = await page.screenshot({ type: "png" });
+    return { pngBase64: buffer.toString("base64") };
+  }
+
+  async closePage(pageId: string): Promise<void> {
+    const page = this.pages.get(pageId);
+    if (!page) return;
+    this.pages.delete(pageId);
+    try {
+      await page.close();
+    } catch {
+      // 已关闭 / 进程退出等忽略
+    }
+  }
+
+  // 应用退出时调:关闭所有 page + browser。
+  // 错误吞掉:cleanup 路径上 throw 会阻塞 app.before-quit。
+  async cleanup(): Promise<void> {
+    const pageIds = Array.from(this.pages.keys());
+    for (const id of pageIds) {
+      try {
+        await this.closePage(id);
+      } catch {}
+    }
+    if (this.browser) {
+      try {
+        await this.browser.close();
+      } catch {}
+      this.browser = undefined;
+    }
+    this.launchPromise = undefined;
+  }
+
+  private requirePage(pageId: string): PageHandle {
+    const page = this.pages.get(pageId);
+    if (!page) {
+      throw new Error(`page not found: ${pageId}`);
+    }
+    return page;
+  }
+
+  private async ensureBrowser(): Promise<BrowserHandle> {
+    if (this.browser) return this.browser;
+    if (this.launchPromise) return this.launchPromise;
+    this.launchPromise = this.doLaunch();
+    try {
+      this.browser = await this.launchPromise;
+      return this.browser;
+    } finally {
+      this.launchPromise = undefined;
+    }
+  }
+
+  private async doLaunch(): Promise<BrowserHandle> {
+    const launcher = await this.resolveLauncher();
+    return launcher.launch(this.launchOptions);
+  }
+
+  private async resolveLauncher(): Promise<BrowserLauncher> {
+    if (this.launcher !== "lazy") return this.launcher;
+    // dynamic import 避免单测顶层加载 playwright;CI PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1
+    // 下 playwright npm 包仍可 import(只是没下 chromium binary,launch 真跑会抛)。
+    const { chromium } = await import("playwright");
+    return {
+      async launch(opts) {
+        return chromium.launch(opts) as unknown as BrowserHandle;
+      },
+    };
+  }
+}

--- a/packages/browser-tools/src/dom-snapshot.ts
+++ b/packages/browser-tools/src/dom-snapshot.ts
@@ -1,0 +1,93 @@
+// DOM snapshot 提取算法(M1 #27 issue body §架构决策):
+// - <title>
+// - <h1>-<h3>
+// - 可见 text(innerText 限定根元素深度 5)
+// - <a> 链接(限 50 个)
+//
+// 这个函数会被 playwright `page.evaluate` 序列化到 browser context 执行,
+// **不能引用模块作用域内的任何东西**(闭包变量、import 等都不可用),
+// 必须 self-contained。返回值经 JSON 序列化回 Node 进程。
+//
+// M2 视 skill 需求增强(读结构化表格 / 表单字段 / 价格抽取等)。
+
+export interface DomSnapshot {
+  title: string;
+  url: string;
+  headings: { level: 1 | 2 | 3; text: string }[];
+  visibleText: string; // 已截断到 ~3.5KB 留 buffer
+  links: { href: string; text: string }[]; // 限 50 个
+}
+
+// 在 page context 内运行的纯函数(self-contained,不依赖外部 import)。
+// 单测时 fake page.evaluate 不会真跑这个 fn,只 stub 返回值;
+// 真 e2e 时(发起人 dev 校验)playwright 把它序列化进 chromium。
+export function extractDomSnapshot(): DomSnapshot {
+  // 在 browser context 内 document 可用
+  const doc = document;
+  const win = window;
+
+  const headings: { level: 1 | 2 | 3; text: string }[] = [];
+  for (const tag of ["h1", "h2", "h3"] as const) {
+    const elems = doc.querySelectorAll(tag);
+    for (const el of Array.from(elems)) {
+      const t = (el.textContent ?? "").trim();
+      if (t) {
+        headings.push({
+          level: Number.parseInt(tag[1] ?? "0", 10) as 1 | 2 | 3,
+          text: t.slice(0, 200),
+        });
+      }
+    }
+  }
+
+  // 可见 text:body.innerText(浏览器自带可见性过滤),截断到 ~3.5KB
+  const rawText = doc.body?.innerText ?? "";
+  const visibleText = rawText.length > 3500 ? `${rawText.slice(0, 3500)}…[truncated]` : rawText;
+
+  // <a> 链接,限 50 个,跳空 href
+  const linkElems = Array.from(doc.querySelectorAll("a")).slice(0, 200);
+  const links: { href: string; text: string }[] = [];
+  for (const a of linkElems) {
+    const href = (a as HTMLAnchorElement).href;
+    if (!href || href.startsWith("javascript:")) continue;
+    const text = (a.textContent ?? "").trim().slice(0, 100);
+    links.push({ href, text });
+    if (links.length >= 50) break;
+  }
+
+  return {
+    title: doc.title,
+    url: win.location.href,
+    headings,
+    visibleText,
+    links,
+  };
+}
+
+// 把 DomSnapshot 序列化成给 LLM 看的 plaintext 摘要(目标 ≤5KB)。
+// LLM 友好格式:Markdown-ish 但不严格 markdown(避免 CC 把它当成 markdown 渲染)。
+export function snapshotToText(snap: DomSnapshot): string {
+  const lines: string[] = [];
+  lines.push(`URL: ${snap.url}`);
+  lines.push(`Title: ${snap.title}`);
+  if (snap.headings.length > 0) {
+    lines.push("");
+    lines.push("Headings:");
+    for (const h of snap.headings.slice(0, 30)) {
+      lines.push(`  ${"#".repeat(h.level)} ${h.text}`);
+    }
+  }
+  if (snap.visibleText) {
+    lines.push("");
+    lines.push("Visible text:");
+    lines.push(snap.visibleText);
+  }
+  if (snap.links.length > 0) {
+    lines.push("");
+    lines.push(`Links (${snap.links.length}):`);
+    for (const l of snap.links) {
+      lines.push(`  - [${l.text || "(no text)"}] ${l.href}`);
+    }
+  }
+  return lines.join("\n");
+}

--- a/packages/browser-tools/src/index.ts
+++ b/packages/browser-tools/src/index.ts
@@ -1,2 +1,16 @@
-// 占位，Playwright 浏览器工具封装在 M2 里程碑填充
-export {};
+// @opentrad/browser-tools 入口(M1 #27)。
+// BrowserService(单例 + page lifecycle)+ DomSnapshot 类型/抽取算法。
+
+export {
+  BrowserService,
+  type BrowserServiceOptions,
+  type NewPageResult,
+} from "./browser-service";
+export { type DomSnapshot, extractDomSnapshot, snapshotToText } from "./dom-snapshot";
+export type {
+  BrowserHandle,
+  BrowserLauncher,
+  LaunchOptions,
+  PageHandle,
+  ScreenshotOptions,
+} from "./types";

--- a/packages/browser-tools/src/types.ts
+++ b/packages/browser-tools/src/types.ts
@@ -1,0 +1,38 @@
+// BrowserLauncher / BrowserHandle / PageHandle:Playwright 接口的 minimal 子集。
+//
+// 单测注入 fake 实现避免真启 Chromium(CI 不下载 binary)。生产用 playwright 的
+// chromium 实例,运行时鸭子类型兼容(playwright Browser/Page 实际方法集合是这些 minimal
+// 接口的超集)。
+//
+// 这里不依赖 playwright 类型 import,避免 CI 在 PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1
+// 下可能出现的 transitive 类型问题。
+
+export interface LaunchOptions {
+  headless?: boolean;
+  // 后续按需扩展:slowMo / args / executablePath / timeout
+}
+
+export interface BrowserLauncher {
+  launch(opts?: LaunchOptions): Promise<BrowserHandle>;
+}
+
+export interface BrowserHandle {
+  newPage(): Promise<PageHandle>;
+  close(): Promise<void>;
+}
+
+export interface PageHandle {
+  goto(url: string, opts?: { timeout?: number }): Promise<unknown>;
+  title(): Promise<string>;
+  // evaluate fn 序列化到 browser context 跑;arg 是可选传参。
+  // 单测时 fake page 直接 stub 返回值,fn 不会真跑,document 在测试不存在 OK。
+  evaluate<R>(fn: (...args: unknown[]) => R | Promise<R>, arg?: unknown): Promise<R>;
+  screenshot(opts?: ScreenshotOptions): Promise<Buffer>;
+  setViewportSize(size: { width: number; height: number }): Promise<unknown>;
+  close(): Promise<void>;
+}
+
+export interface ScreenshotOptions {
+  type?: "png" | "jpeg";
+  fullPage?: boolean;
+}

--- a/packages/browser-tools/tests/browser-service.test.ts
+++ b/packages/browser-tools/tests/browser-service.test.ts
@@ -1,0 +1,191 @@
+// BrowserService 测试:用 fake launcher / browser / page,不真启 Chromium。
+// 单测覆盖 lifecycle (launch / newPage / close / cleanup) + readPageText + screenshot
+// + 错误路径(pageId not found)+ 并发 launch 不重复启动。
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { BrowserService } from "../src/browser-service";
+import type { DomSnapshot } from "../src/dom-snapshot";
+import type { BrowserHandle, BrowserLauncher, PageHandle } from "../src/types";
+
+interface FakePage extends PageHandle {
+  closed: boolean;
+}
+
+function makeFakePage(opts?: {
+  title?: string;
+  snapshot?: DomSnapshot;
+  screenshotBuffer?: Buffer;
+}): FakePage {
+  const snapshot: DomSnapshot = opts?.snapshot ?? {
+    title: "Mock Title",
+    url: "https://mock.example/",
+    headings: [{ level: 1, text: "Hello" }],
+    visibleText: "Mock body text",
+    links: [{ href: "https://mock.example/a", text: "A" }],
+  };
+  const screenshotBuffer = opts?.screenshotBuffer ?? Buffer.from("PNGFAKE");
+  const page: FakePage = {
+    closed: false,
+    goto: vi.fn().mockResolvedValue(undefined),
+    title: vi.fn().mockResolvedValue(opts?.title ?? snapshot.title),
+    evaluate: vi.fn().mockResolvedValue(snapshot) as PageHandle["evaluate"],
+    screenshot: vi.fn().mockResolvedValue(screenshotBuffer),
+    setViewportSize: vi.fn().mockResolvedValue(undefined),
+    close: vi.fn().mockImplementation(async () => {
+      page.closed = true;
+    }),
+  };
+  return page;
+}
+
+interface FakeBrowser extends BrowserHandle {
+  closed: boolean;
+  pages: FakePage[];
+}
+
+function makeFakeBrowser(): FakeBrowser {
+  const browser: FakeBrowser = {
+    closed: false,
+    pages: [],
+    newPage: vi.fn().mockImplementation(async () => {
+      const p = makeFakePage();
+      browser.pages.push(p);
+      return p;
+    }),
+    close: vi.fn().mockImplementation(async () => {
+      browser.closed = true;
+    }),
+  };
+  return browser;
+}
+
+function makeFakeLauncher(browser: FakeBrowser): BrowserLauncher & { launchCount: number } {
+  let count = 0;
+  return {
+    get launchCount() {
+      return count;
+    },
+    async launch() {
+      count++;
+      return browser;
+    },
+  };
+}
+
+describe("BrowserService", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("launch 启动 browser(单例,二次调用不重复 launch)", async () => {
+    const browser = makeFakeBrowser();
+    const launcher = makeFakeLauncher(browser);
+    const svc = new BrowserService({ launcher });
+
+    await svc.launch();
+    await svc.launch();
+
+    expect(launcher.launchCount).toBe(1);
+  });
+
+  it("newPage 自动 launch + 返回 pageId / title / url", async () => {
+    const browser = makeFakeBrowser();
+    const launcher = makeFakeLauncher(browser);
+    const svc = new BrowserService({ launcher });
+
+    const result = await svc.newPage("https://example.com/");
+
+    expect(result.pageId).toMatch(/^[0-9a-f-]{36}$/i);
+    expect(result.title).toBe("Mock Title");
+    expect(result.url).toBe("https://example.com/");
+    expect(browser.pages).toHaveLength(1);
+    expect(browser.pages[0]?.goto).toHaveBeenCalledWith("https://example.com/", {
+      timeout: 30_000,
+    });
+  });
+
+  it("readPageText 返回 snapshot + 序列化文本", async () => {
+    const browser = makeFakeBrowser();
+    const launcher = makeFakeLauncher(browser);
+    const svc = new BrowserService({ launcher });
+
+    const { pageId } = await svc.newPage("https://example.com/");
+    const { snapshot, text } = await svc.readPageText(pageId);
+
+    expect(snapshot.title).toBe("Mock Title");
+    expect(text).toContain("URL: https://mock.example/");
+    expect(text).toContain("Title: Mock Title");
+    expect(text).toContain("# Hello");
+    expect(text).toContain("Mock body text");
+    expect(text).toContain("https://mock.example/a");
+  });
+
+  it("screenshot 锁定 viewport 1280x720 + 返回 base64 PNG", async () => {
+    const browser = makeFakeBrowser();
+    const launcher = makeFakeLauncher(browser);
+    const svc = new BrowserService({ launcher });
+
+    const { pageId } = await svc.newPage("https://example.com/");
+    const { pngBase64 } = await svc.screenshot(pageId);
+
+    const page = browser.pages[0];
+    expect(page?.setViewportSize).toHaveBeenCalledWith({ width: 1280, height: 720 });
+    expect(page?.screenshot).toHaveBeenCalledWith({ type: "png" });
+    expect(pngBase64).toBe(Buffer.from("PNGFAKE").toString("base64"));
+  });
+
+  it("readPageText / screenshot 找不到 pageId 抛错", async () => {
+    const browser = makeFakeBrowser();
+    const launcher = makeFakeLauncher(browser);
+    const svc = new BrowserService({ launcher });
+    await svc.launch();
+
+    await expect(svc.readPageText("nonexistent")).rejects.toThrow(/page not found/);
+    await expect(svc.screenshot("nonexistent")).rejects.toThrow(/page not found/);
+  });
+
+  it("closePage 移除 page 并调 page.close", async () => {
+    const browser = makeFakeBrowser();
+    const launcher = makeFakeLauncher(browser);
+    const svc = new BrowserService({ launcher });
+
+    const { pageId } = await svc.newPage("https://example.com/");
+    await svc.closePage(pageId);
+
+    const page = browser.pages[0] as FakePage;
+    expect(page.closed).toBe(true);
+    // 二次 close 不抛(已不在 map)
+    await expect(svc.closePage(pageId)).resolves.toBeUndefined();
+  });
+
+  it("cleanup 关闭所有 page + browser", async () => {
+    const browser = makeFakeBrowser();
+    const launcher = makeFakeLauncher(browser);
+    const svc = new BrowserService({ launcher });
+
+    await svc.newPage("https://a.example/");
+    await svc.newPage("https://b.example/");
+    await svc.cleanup();
+
+    expect(browser.closed).toBe(true);
+    for (const p of browser.pages) {
+      expect((p as FakePage).closed).toBe(true);
+    }
+  });
+
+  it("并发 launch 共享 in-flight promise(不重复启动 Chromium)", async () => {
+    const browser = makeFakeBrowser();
+    const launcher = makeFakeLauncher(browser);
+    const svc = new BrowserService({ launcher });
+
+    // 三个并发 newPage,实际 launch 应只触发 1 次
+    await Promise.all([
+      svc.newPage("https://a.example/"),
+      svc.newPage("https://b.example/"),
+      svc.newPage("https://c.example/"),
+    ]);
+
+    expect(launcher.launchCount).toBe(1);
+    expect(browser.pages).toHaveLength(3);
+  });
+});

--- a/packages/browser-tools/tests/dom-snapshot.test.ts
+++ b/packages/browser-tools/tests/dom-snapshot.test.ts
@@ -1,0 +1,70 @@
+// snapshotToText 测试:验证 LLM 友好 plaintext 序列化格式。
+// extractDomSnapshot 本身需要 browser context (document/window),
+// 单测不跑该函数(覆盖在 BrowserService.readPageText 集成测里 mock 它的返回值)。
+
+import { describe, expect, it } from "vitest";
+import { type DomSnapshot, snapshotToText } from "../src/dom-snapshot";
+
+const SAMPLE: DomSnapshot = {
+  title: "Test Page",
+  url: "https://test.example/path?q=1",
+  headings: [
+    { level: 1, text: "Welcome" },
+    { level: 2, text: "Section A" },
+    { level: 3, text: "Sub A.1" },
+  ],
+  visibleText: "Body content here.",
+  links: [
+    { href: "https://test.example/about", text: "About" },
+    { href: "https://test.example/docs", text: "Docs" },
+  ],
+};
+
+describe("snapshotToText", () => {
+  it("包含 URL / Title / Headings / Visible text / Links", () => {
+    const text = snapshotToText(SAMPLE);
+    expect(text).toContain("URL: https://test.example/path?q=1");
+    expect(text).toContain("Title: Test Page");
+    expect(text).toContain("# Welcome");
+    expect(text).toContain("## Section A");
+    expect(text).toContain("### Sub A.1");
+    expect(text).toContain("Body content here.");
+    expect(text).toContain("https://test.example/about");
+    expect(text).toContain("https://test.example/docs");
+  });
+
+  it("空 headings / 空 links 不输出对应段落", () => {
+    const text = snapshotToText({
+      ...SAMPLE,
+      headings: [],
+      links: [],
+      visibleText: "only body",
+    });
+    expect(text).not.toContain("Headings:");
+    expect(text).not.toContain("Links (");
+    expect(text).toContain("only body");
+  });
+
+  it("无文本 link 显示 (no text)", () => {
+    const text = snapshotToText({
+      ...SAMPLE,
+      links: [{ href: "https://x.example/", text: "" }],
+    });
+    expect(text).toContain("[(no text)] https://x.example/");
+  });
+
+  it("headings 截到 30 个", () => {
+    const many: DomSnapshot["headings"] = Array.from({ length: 50 }, (_, i) => ({
+      level: 1,
+      text: `H${i}`,
+    }));
+    const text = snapshotToText({ ...SAMPLE, headings: many });
+    expect(text).toContain("# H29");
+    expect(text).not.toContain("# H30");
+  });
+
+  it("输出大小约束:典型 case ≤5KB", () => {
+    const text = snapshotToText(SAMPLE);
+    expect(Buffer.byteLength(text, "utf-8")).toBeLessThan(5 * 1024);
+  });
+});

--- a/packages/browser-tools/tsconfig.json
+++ b/packages/browser-tools/tsconfig.json
@@ -1,9 +1,9 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "rootDir": "./src",
     "outDir": "./dist",
     "noEmit": true
   },
-  "include": ["src/**/*"]
+  "include": ["src/**/*", "tests/**/*", "vitest.config.ts"],
+  "exclude": ["node_modules", "dist"]
 }

--- a/packages/browser-tools/vitest.config.ts
+++ b/packages/browser-tools/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    include: ["tests/**/*.test.ts"],
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -105,6 +105,9 @@ importers:
       '@modelcontextprotocol/sdk':
         specifier: ^1.29.0
         version: 1.29.0(zod@4.3.6)
+      '@opentrad/browser-tools':
+        specifier: workspace:^
+        version: link:../../packages/browser-tools
       zod:
         specifier: ^4.3.6
         version: 4.3.6
@@ -113,7 +116,11 @@ importers:
         specifier: workspace:^
         version: link:../../packages/shared
 
-  packages/browser-tools: {}
+  packages/browser-tools:
+    dependencies:
+      playwright:
+        specifier: ^1.59.1
+        version: 1.59.1
 
   packages/cc-adapter:
     dependencies:
@@ -1189,6 +1196,11 @@ packages:
     resolution: {integrity: sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==}
     engines: {node: '>=6 <7 || >=8'}
 
+  fsevents@2.3.2:
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -1566,6 +1578,16 @@ packages:
   pkce-challenge@5.0.1:
     resolution: {integrity: sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==}
     engines: {node: '>=16.20.0'}
+
+  playwright-core@1.59.1:
+    resolution: {integrity: sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  playwright@1.59.1:
+    resolution: {integrity: sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   postcss@8.5.10:
     resolution: {integrity: sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==}
@@ -2917,6 +2939,9 @@ snapshots:
       jsonfile: 4.0.0
       universalify: 0.1.2
 
+  fsevents@2.3.2:
+    optional: true
+
   fsevents@2.3.3:
     optional: true
 
@@ -3238,6 +3263,14 @@ snapshots:
   picomatch@4.0.4: {}
 
   pkce-challenge@5.0.1: {}
+
+  playwright-core@1.59.1: {}
+
+  playwright@1.59.1:
+    dependencies:
+      playwright-core: 1.59.1
+    optionalDependencies:
+      fsevents: 2.3.2
 
   postcss@8.5.10:
     dependencies:


### PR DESCRIPTION
## Summary

按 03 ADR-007 + D-pre-1(bundle Chromium),创建 `packages/browser-tools` 包,落地:
- **BrowserService**:Chromium 单例 + page lifecycle 管理
- **3 个 review-level tools**(`browser_open` / `browser_read` / `browser_screenshot`)接入 mcp-server
- **MockRiskGate**:M1 #27 占位(allow 所有),M1 #28 替换为 IpcRiskGate 走 bridge 弹窗

**范围按发起人指示缩小**:
- 不做 electron-builder.yml extraResources(留 M1 #13 / #30 真打包)
- CI 不下载 Chromium binary(\`PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1\`,单测全 mock,e2e 留 dev 接管)
- 不做断网验证 / 三平台体积验证(留 #30)

## 验收对照(issue body)

- [x] **packages/browser-tools 包封装 Playwright 1.50+** — playwright@1.59.1
- [x] **BrowserService(launch / newPage / readPageText / screenshot / closePage / cleanup)** — src/browser-service.ts
- [x] **三个 tool 接口** — browser/{open,read,screenshot}.ts,riskLevel='review'
- [x] **mock RiskGate 拦截 review 都直接 allow** — apps/mcp-server/src/risk-gate.ts MockRiskGate
- [ ] **electron-builder extraResources** — **延后到 #30**(本 PR scope 缩小,见上)
- [ ] **三平台 e2e 验证** — **dev 模式 macOS 留发起人接管;Windows/Linux 留 #30**

## DOM snapshot 算法(03 §"架构决策"对齐)

\`extractDomSnapshot\` 在 page context 内运行,self-contained 不依赖闭包:
- \`<title>\`(document.title)
- \`<h1>-<h3>\`(每条截 200 char)
- visible text(\`document.body.innerText\` 截到 3.5KB,留 buffer)
- \`<a>\` 链接(限 50 个,跳过空 / javascript: href)

\`snapshotToText\` 序列化为 markdown-ish plaintext:
\`\`\`
URL: ...
Title: ...

Headings:
  # H1
  ## H2

Visible text:
...

Links (N):
  - [text] href
\`\`\`

实测典型 case ≤5KB(单测断言)。

## 测试策略

CI 不下载 Chromium,单测全 mock:
- **BrowserService**:fake \`BrowserLauncher\` 注入,验证 lifecycle / readPageText / screenshot / closePage / cleanup / 并发 launch 不重复(7 cases)
- **DomSnapshot**:\`snapshotToText\` 直接传 fixture DomSnapshot 验证序列化(6 cases)
- **browser tools**:fake BrowserService 注入 ctx,验证 zod 校验 + 调用转发 + 缺失 sentinel error(7 cases)
- **MockRiskGate**:allow 行为 + stderr 诊断输出(2 cases)

dev e2e 留发起人接管(\`pnpm --filter @opentrad/browser-tools setup\` 装 chromium → \`pnpm dev\` → trade-email-writer skill 触发 browser_open)。

## 体积影响

- npm playwright 包(JS):**+10MB**
- Chromium binary:**0**(本 PR 不下载,#30 才进打包流水线)
- mcp-server bundle:不变(playwright lazy import,运行时才加载)

## Test plan

- [x] \`pnpm --filter @opentrad/browser-tools typecheck\` 0 错
- [x] \`pnpm --filter @opentrad/browser-tools test\` 13 cases 全过
- [x] \`pnpm --filter @opentrad/mcp-server typecheck\` 0 错
- [x] \`pnpm --filter @opentrad/mcp-server test\` 28 cases 全过(原 19 + 新增 9)
- [x] \`pnpm typecheck\` 全 workspace 0 错
- [x] \`pnpm test\` 全 workspace 全过(221 cases total)
- [x] \`pnpm lint\` biome 0 错
- [x] CI 三平台 + electron-abi-smoke 待跑(PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD 全局 env 已加)

## 不在本 PR / 后续

- **electron-builder extraResources** Chromium 内置 — M1 #30
- **PLAYWRIGHT_BROWSERS_PATH** env 注入(desktop 主进程 spawn mcp-server 时)— M1 #30
- **断网验证 + 三平台体积验证** — M1 #30
- **真 RiskGate**(走 IPC bridge 弹窗)— M1 #28
- **Windows 真机 e2e** — M1 #30 收官段

## D9-1 决策

发起人原话"riskLevel='review',此 PR 用 mock RiskGate(allow 所有),真 RiskGate 在 #28 替换"已落地。Mock 实现写一行 stderr 诊断便于 dev 模式定位是否生效。

Closes #27

🤖 Generated with [Claude Code](https://claude.com/claude-code)