### PR TITLE
feat(desktop): Markdown chat UI + 历史回放 + 三栏可拖拽 + Settings 多 tab (M1 #29)

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -30,6 +30,10 @@
     "node-pty": "^1.1.0",
     "react": "^19.2.5",
     "react-dom": "^19.2.5",
+    "react-markdown": "^10.1.0",
+    "react-resizable-panels": "^4.10.0",
+    "react-syntax-highlighter": "^16.1.1",
+    "remark-gfm": "^4.0.1",
     "zod": "^4.3.6",
     "zustand": "^5.0.12"
   },
@@ -39,6 +43,7 @@
     "@types/js-yaml": "^4.0.9",
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",
+    "@types/react-syntax-highlighter": "^15.5.13",
     "@vitejs/plugin-react": "^6.0.1",
     "electron-vite": "^5.0.0",
     "vite": "^8.0.10"

--- a/apps/desktop/src/main/ipc/session.ts
+++ b/apps/desktop/src/main/ipc/session.ts
@@ -7,6 +7,7 @@
 // session:resume 在 M1 #29 / #12 落地（D-M1-7：M1 只查看 events 回放，不重启 CC 子进程）。
 
 import {
+  type CCEvent,
   IpcChannels,
   type SessionDeleteRequest,
   SessionDeleteRequestSchema,
@@ -15,6 +16,9 @@ import {
   type SessionListRequest,
   SessionListRequestSchema,
   type SessionMeta,
+  type SessionResumeRequest,
+  SessionResumeRequestSchema,
+  type SessionResumeResponse,
   type SessionRow,
 } from "@opentrad/shared";
 import { ipcMain } from "electron";
@@ -35,9 +39,32 @@ export function registerSessionHandlers(db: DbServices): void {
   );
 
   ipcMain.handle(IpcChannels.SessionDelete, async (_event, raw: unknown): Promise<void> => {
-    const req: SessionDeleteRequest = SessionDeleteRequestSchema.parse(raw);
-    db.sessions.delete(req.sessionId);
+    db.sessions.delete((SessionDeleteRequestSchema.parse(raw) as SessionDeleteRequest).sessionId);
   });
+
+  // M1 #29 D-M1-7:历史回放,返回 session meta + events 完整数组(payload 已 normalize 后 CCEvent)。
+  // 不重启 CC 子进程,renderer 端只渲染 read-only。
+  ipcMain.handle(
+    IpcChannels.SessionResume,
+    async (_event, raw: unknown): Promise<SessionResumeResponse | null> => {
+      const req: SessionResumeRequest = SessionResumeRequestSchema.parse(raw);
+      const session = db.sessions.get(req.sessionId);
+      if (!session) return null;
+      const eventRows = db.events.readBySession(req.sessionId);
+      // payload 是 string(JSON),parse 还原为 CCEvent。失败的 row 跳过(M1 友好,
+      // M2 视情况显式标"残缺事件")。
+      const events: CCEvent[] = [];
+      for (const row of eventRows) {
+        try {
+          const parsed = JSON.parse(row.payload as string) as CCEvent;
+          events.push(parsed);
+        } catch (err) {
+          console.warn(`[session:resume] skip malformed event row id=${row.seq}`, err);
+        }
+      }
+      return { session: toMeta(session), events };
+    },
+  );
 }
 
 function toMeta(row: SessionRow): SessionMeta {

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -36,6 +36,10 @@ import type {
   RiskGateResponsePayload,
   RiskRuleRow,
   RiskRulesDeleteRequest,
+  SessionListRequest,
+  SessionMeta,
+  SessionResumeRequest,
+  SessionResumeResponse,
   ShellOpenExternalRequest,
   SkillManifest,
 } from "@opentrad/shared";
@@ -133,6 +137,14 @@ const api = {
   skill: {
     list(): Promise<SkillManifest[]> {
       return ipcRenderer.invoke(IpcChannels.SkillList);
+    },
+  },
+  session: {
+    list(req: SessionListRequest = { limit: 50, offset: 0 }): Promise<SessionMeta[]> {
+      return ipcRenderer.invoke(IpcChannels.SessionList, req);
+    },
+    resume(req: SessionResumeRequest): Promise<SessionResumeResponse | null> {
+      return ipcRenderer.invoke(IpcChannels.SessionResume, req);
     },
   },
   riskGate: {

--- a/apps/desktop/src/renderer/App.tsx
+++ b/apps/desktop/src/renderer/App.tsx
@@ -10,12 +10,11 @@
 import type { CCStatus } from "@opentrad/shared";
 import { Settings } from "lucide-react";
 import { type ReactElement, useEffect, useState } from "react";
-import { SkillPicker } from "./components/layout/SkillPicker";
 import { TerminalPane } from "./components/ui/TerminalPane";
+import { MainLayout } from "./features/layout/MainLayout";
 import { OnboardingGate } from "./features/onboarding/OnboardingGate";
 import { RiskGateOverlay } from "./features/risk-gate/RiskGateOverlay";
 import { SettingsRiskOverlay } from "./features/settings/SettingsRiskOverlay";
-import { SkillWorkArea } from "./features/skills/SkillWorkArea";
 
 type CcStatusState =
   | { kind: "loading" }
@@ -72,8 +71,7 @@ function MainApp(): ReactElement {
     >
       <Header ccStatus={ccStatus} onOpenSettings={() => setSettingsOpen(true)} />
       <div style={{ display: "flex", flex: 1, overflow: "hidden" }}>
-        <SkillPicker />
-        <SkillWorkArea />
+        <MainLayout />
       </div>
       <PtyDrawer open={ptyOpen} onToggle={() => setPtyOpen((v) => !v)} />
       <SettingsRiskOverlay open={settingsOpen} onClose={() => setSettingsOpen(false)} />

--- a/apps/desktop/src/renderer/App.tsx
+++ b/apps/desktop/src/renderer/App.tsx
@@ -14,7 +14,7 @@ import { TerminalPane } from "./components/ui/TerminalPane";
 import { MainLayout } from "./features/layout/MainLayout";
 import { OnboardingGate } from "./features/onboarding/OnboardingGate";
 import { RiskGateOverlay } from "./features/risk-gate/RiskGateOverlay";
-import { SettingsRiskOverlay } from "./features/settings/SettingsRiskOverlay";
+import { SettingsOverlay } from "./features/settings/SettingsOverlay";
 
 type CcStatusState =
   | { kind: "loading" }
@@ -74,7 +74,7 @@ function MainApp(): ReactElement {
         <MainLayout />
       </div>
       <PtyDrawer open={ptyOpen} onToggle={() => setPtyOpen((v) => !v)} />
-      <SettingsRiskOverlay open={settingsOpen} onClose={() => setSettingsOpen(false)} />
+      <SettingsOverlay open={settingsOpen} onClose={() => setSettingsOpen(false)} />
     </div>
   );
 }

--- a/apps/desktop/src/renderer/components/chat/MessageBubble.tsx
+++ b/apps/desktop/src/renderer/components/chat/MessageBubble.tsx
@@ -1,0 +1,236 @@
+// MessageBubble(M1 #29 12a):assistant_text / assistant_thinking 渲染。
+//
+// react-markdown + remark-gfm 支持:
+// - 代码块(语法高亮 + 复制按钮)
+// - markdown 表格(remark-gfm 自动 → HTML <table>)
+// - 链接、列表、标题、引用、粗体斜体、删除线等标准 GFM
+//
+// thinking 默认折叠(<details>),text 默认展开。
+
+import { Check, Copy } from "lucide-react";
+import { type ReactElement, useState } from "react";
+import ReactMarkdown from "react-markdown";
+import { Prism as SyntaxHighlighter } from "react-syntax-highlighter";
+import { atomDark } from "react-syntax-highlighter/dist/esm/styles/prism";
+import remarkGfm from "remark-gfm";
+
+export interface MessageBubbleProps {
+  kind: "text" | "thinking";
+  content: string;
+}
+
+export function MessageBubble({ kind, content }: MessageBubbleProps): ReactElement {
+  if (kind === "thinking") {
+    return (
+      <details style={thinkingStyle}>
+        <summary style={thinkingSummaryStyle}>思考过程</summary>
+        <div style={{ marginTop: "0.5rem" }}>
+          <Markdown content={content} />
+        </div>
+      </details>
+    );
+  }
+  return (
+    <div style={textStyle}>
+      <Markdown content={content} />
+    </div>
+  );
+}
+
+// markdown 渲染共用组件
+function Markdown({ content }: { content: string }): ReactElement {
+  return (
+    <div style={markdownStyle}>
+      <ReactMarkdown
+        remarkPlugins={[remarkGfm]}
+        components={{
+          code: ({ className, children }) => {
+            const match = /language-(\w+)/.exec(className ?? "");
+            const text = String(children ?? "").replace(/\n$/, "");
+            // inline code(无 language- className 且单行)
+            if (!match || !text.includes("\n")) {
+              return <code style={inlineCodeStyle}>{children}</code>;
+            }
+            return <CodeBlock language={match[1] ?? "text"} code={text} />;
+          },
+          // 表格 wrap 横向滚动 + 浅边框
+          table: ({ children }) => (
+            <div style={tableWrapperStyle}>
+              <table style={tableStyle}>{children}</table>
+            </div>
+          ),
+          th: ({ children }) => <th style={thStyle}>{children}</th>,
+          td: ({ children }) => <td style={tdStyle}>{children}</td>,
+          a: ({ href, children }) => (
+            <a
+              href={href}
+              target="_blank"
+              rel="noreferrer"
+              onClick={(e) => {
+                e.preventDefault();
+                if (href) {
+                  void window.api.shell
+                    .openExternal({ url: href })
+                    .catch((err) => console.error("[md] openExternal failed", err));
+                }
+              }}
+              style={linkStyle}
+            >
+              {children}
+            </a>
+          ),
+        }}
+      >
+        {content}
+      </ReactMarkdown>
+    </div>
+  );
+}
+
+function CodeBlock({ language, code }: { language: string; code: string }): ReactElement {
+  const [copied, setCopied] = useState(false);
+
+  const handleCopy = async (): Promise<void> => {
+    try {
+      await navigator.clipboard.writeText(code);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 1500);
+    } catch (err) {
+      console.error("[code-block] copy failed", err);
+    }
+  };
+
+  return (
+    <div style={codeBlockWrapperStyle}>
+      <header style={codeBlockHeaderStyle}>
+        <span style={{ fontSize: "0.75rem", color: "#94a3b8" }}>{language}</span>
+        <button
+          type="button"
+          onClick={() => void handleCopy()}
+          style={copyBtnStyle}
+          aria-label="复制"
+          title="复制"
+        >
+          {copied ? <Check size={12} /> : <Copy size={12} />}
+          <span style={{ marginLeft: "0.25rem" }}>{copied ? "已复制" : "复制"}</span>
+        </button>
+      </header>
+      <SyntaxHighlighter
+        language={language}
+        style={atomDark}
+        customStyle={{
+          margin: 0,
+          padding: "0.75rem",
+          fontSize: "0.8rem",
+          borderRadius: 0,
+          borderBottomLeftRadius: 6,
+          borderBottomRightRadius: 6,
+        }}
+      >
+        {code}
+      </SyntaxHighlighter>
+    </div>
+  );
+}
+
+// ----- styles -----
+
+const textStyle: React.CSSProperties = {
+  background: "#dbeafe",
+  color: "#1e3a8a",
+  border: "1px solid #93c5fd",
+  borderRadius: 8,
+  padding: "0.7rem 0.95rem",
+  fontSize: "0.9rem",
+};
+
+const thinkingStyle: React.CSSProperties = {
+  background: "#f3f4f6",
+  border: "1px solid #e5e7eb",
+  borderRadius: 8,
+  padding: "0.6rem 0.85rem",
+  fontSize: "0.85rem",
+  color: "#475569",
+};
+
+const thinkingSummaryStyle: React.CSSProperties = {
+  cursor: "pointer",
+  fontSize: "0.8rem",
+  color: "#6b7280",
+};
+
+const markdownStyle: React.CSSProperties = {
+  // markdown 元素全局微调:p / h / ul / ol margin 收紧
+  lineHeight: 1.5,
+};
+
+const inlineCodeStyle: React.CSSProperties = {
+  background: "rgba(15, 23, 42, 0.08)",
+  padding: "0.1rem 0.3rem",
+  borderRadius: 3,
+  fontFamily: '"SF Mono", Menlo, Monaco, monospace',
+  fontSize: "0.85em",
+};
+
+const codeBlockWrapperStyle: React.CSSProperties = {
+  margin: "0.5rem 0",
+  borderRadius: 6,
+  overflow: "hidden",
+  background: "#0f172a",
+};
+
+const codeBlockHeaderStyle: React.CSSProperties = {
+  display: "flex",
+  justifyContent: "space-between",
+  alignItems: "center",
+  padding: "0.35rem 0.6rem",
+  background: "#1e293b",
+  borderBottom: "1px solid #334155",
+};
+
+const copyBtnStyle: React.CSSProperties = {
+  display: "inline-flex",
+  alignItems: "center",
+  background: "transparent",
+  color: "#cbd5e1",
+  border: "1px solid #334155",
+  padding: "0.2rem 0.5rem",
+  borderRadius: 4,
+  cursor: "pointer",
+  fontSize: "0.7rem",
+  fontFamily: "inherit",
+};
+
+const tableWrapperStyle: React.CSSProperties = {
+  overflow: "auto",
+  marginTop: "0.5rem",
+  marginBottom: "0.5rem",
+  border: "1px solid #e2e8f0",
+  borderRadius: 6,
+};
+
+const tableStyle: React.CSSProperties = {
+  borderCollapse: "collapse",
+  width: "100%",
+  fontSize: "0.85rem",
+};
+
+const thStyle: React.CSSProperties = {
+  background: "#f8fafc",
+  borderBottom: "1px solid #e2e8f0",
+  padding: "0.4rem 0.6rem",
+  textAlign: "left",
+  fontWeight: 600,
+  color: "#374151",
+};
+
+const tdStyle: React.CSSProperties = {
+  borderBottom: "1px solid #f1f5f9",
+  padding: "0.4rem 0.6rem",
+  color: "#1f2937",
+};
+
+const linkStyle: React.CSSProperties = {
+  color: "#2563eb",
+  textDecoration: "underline",
+};

--- a/apps/desktop/src/renderer/components/chat/ToolCallCard.tsx
+++ b/apps/desktop/src/renderer/components/chat/ToolCallCard.tsx
@@ -1,0 +1,98 @@
+// ToolCallCard(M1 #29 12a):assistant_tool_use 事件渲染。
+// 参数 JSON 默认折叠,点击展开;紫色主题(对应 M0 简版)。
+
+import { ChevronDown, ChevronRight, Wrench } from "lucide-react";
+import { type ReactElement, useState } from "react";
+
+export interface ToolCallCardProps {
+  toolName: string;
+  toolUseId: string;
+  input: unknown;
+}
+
+export function ToolCallCard({ toolName, toolUseId, input }: ToolCallCardProps): ReactElement {
+  const [expanded, setExpanded] = useState(false);
+
+  let inputJson = "";
+  try {
+    inputJson = JSON.stringify(input, null, 2);
+  } catch {
+    inputJson = "(无法序列化)";
+  }
+
+  return (
+    <div style={cardStyle}>
+      <header style={headerStyle}>
+        <Wrench size={14} aria-hidden="true" />
+        <code style={codeStyle}>{toolName}</code>
+        <span style={idHintStyle}>{toolUseId.slice(0, 8)}…</span>
+        <button
+          type="button"
+          onClick={() => setExpanded((v) => !v)}
+          style={toggleBtnStyle}
+          aria-label={expanded ? "折叠参数" : "展开参数"}
+        >
+          {expanded ? <ChevronDown size={14} /> : <ChevronRight size={14} />}
+          <span style={{ marginLeft: "0.2rem" }}>{expanded ? "折叠" : "参数"}</span>
+        </button>
+      </header>
+      {expanded ? <pre style={paramsPreStyle}>{inputJson}</pre> : null}
+    </div>
+  );
+}
+
+const cardStyle: React.CSSProperties = {
+  background: "#faf5ff",
+  border: "1px solid #d8b4fe",
+  borderRadius: 8,
+  padding: "0.5rem 0.75rem",
+  fontSize: "0.85rem",
+  color: "#581c87",
+};
+
+const headerStyle: React.CSSProperties = {
+  display: "flex",
+  alignItems: "center",
+  gap: "0.4rem",
+};
+
+const codeStyle: React.CSSProperties = {
+  fontFamily: '"SF Mono", Menlo, Monaco, monospace',
+  fontSize: "0.8rem",
+  background: "#ede9fe",
+  padding: "0.1rem 0.4rem",
+  borderRadius: 3,
+};
+
+const idHintStyle: React.CSSProperties = {
+  fontSize: "0.7rem",
+  color: "#a78bfa",
+  fontFamily: '"SF Mono", Menlo, Monaco, monospace',
+  marginLeft: "auto",
+};
+
+const toggleBtnStyle: React.CSSProperties = {
+  display: "inline-flex",
+  alignItems: "center",
+  background: "transparent",
+  color: "#7c3aed",
+  border: "none",
+  padding: "0.1rem 0.3rem",
+  cursor: "pointer",
+  fontSize: "0.75rem",
+  fontFamily: "inherit",
+};
+
+const paramsPreStyle: React.CSSProperties = {
+  background: "#1e1b4b",
+  color: "#e0e7ff",
+  padding: "0.6rem",
+  borderRadius: 4,
+  marginTop: "0.5rem",
+  fontFamily: '"SF Mono", Menlo, Monaco, monospace',
+  fontSize: "0.75rem",
+  whiteSpace: "pre-wrap",
+  wordBreak: "break-all",
+  maxHeight: 240,
+  overflow: "auto",
+};

--- a/apps/desktop/src/renderer/components/chat/ToolResultCard.tsx
+++ b/apps/desktop/src/renderer/components/chat/ToolResultCard.tsx
@@ -1,0 +1,123 @@
+// ToolResultCard(M1 #29 12a):tool_result 事件渲染。
+// 长文本默认折叠到前 200 字符,点"展开"看全;isError 红色主题。
+
+import { ChevronDown, ChevronRight } from "lucide-react";
+import { type ReactElement, useState } from "react";
+
+export interface ToolResultCardProps {
+  toolUseId: string;
+  // payload 字段名沿 cc-event schema(M0 D6 normalize 后);content 是 array<{type, text}> 或 string
+  content: unknown;
+  isError?: boolean;
+}
+
+const PREVIEW_LENGTH = 200;
+
+export function ToolResultCard({ toolUseId, content, isError }: ToolResultCardProps): ReactElement {
+  const [expanded, setExpanded] = useState(false);
+
+  const text = stringifyContent(content);
+  const isLong = text.length > PREVIEW_LENGTH;
+  const preview = isLong ? `${text.slice(0, PREVIEW_LENGTH)}…` : text;
+
+  return (
+    <div style={cardStyle(isError)}>
+      <header style={headerStyle}>
+        <span style={labelStyle(isError)}>{isError ? "✕ tool error" : "✓ tool result"}</span>
+        <span style={idHintStyle}>{toolUseId.slice(0, 8)}…</span>
+        {isLong ? (
+          <button
+            type="button"
+            onClick={() => setExpanded((v) => !v)}
+            style={toggleBtnStyle(isError)}
+            aria-label={expanded ? "折叠" : "展开"}
+          >
+            {expanded ? <ChevronDown size={14} /> : <ChevronRight size={14} />}
+            <span style={{ marginLeft: "0.2rem" }}>{expanded ? "折叠" : "展开"}</span>
+          </button>
+        ) : null}
+      </header>
+      <pre style={contentPreStyle}>{expanded || !isLong ? text : preview}</pre>
+    </div>
+  );
+}
+
+function stringifyContent(content: unknown): string {
+  if (typeof content === "string") return content;
+  if (Array.isArray(content)) {
+    return content
+      .map((item) => {
+        if (typeof item === "string") return item;
+        if (item && typeof item === "object") {
+          const obj = item as { type?: string; text?: string };
+          if (obj.type === "text" && typeof obj.text === "string") return obj.text;
+          return JSON.stringify(item);
+        }
+        return String(item);
+      })
+      .join("\n");
+  }
+  if (content && typeof content === "object") {
+    try {
+      return JSON.stringify(content, null, 2);
+    } catch {
+      return "(无法序列化)";
+    }
+  }
+  return String(content);
+}
+
+const cardStyle = (isError?: boolean): React.CSSProperties => ({
+  background: isError ? "#fef2f2" : "#faf5ff",
+  border: `1px solid ${isError ? "#fecaca" : "#d8b4fe"}`,
+  borderRadius: 8,
+  padding: "0.5rem 0.75rem",
+  fontSize: "0.85rem",
+  color: isError ? "#7f1d1d" : "#581c87",
+});
+
+const headerStyle: React.CSSProperties = {
+  display: "flex",
+  alignItems: "center",
+  gap: "0.5rem",
+};
+
+const labelStyle = (isError?: boolean): React.CSSProperties => ({
+  fontWeight: 500,
+  color: isError ? "#dc2626" : "#7c3aed",
+  fontSize: "0.8rem",
+});
+
+const idHintStyle: React.CSSProperties = {
+  fontSize: "0.7rem",
+  color: "#a78bfa",
+  fontFamily: '"SF Mono", Menlo, Monaco, monospace',
+  marginLeft: "auto",
+};
+
+const toggleBtnStyle = (isError?: boolean): React.CSSProperties => ({
+  display: "inline-flex",
+  alignItems: "center",
+  background: "transparent",
+  color: isError ? "#dc2626" : "#7c3aed",
+  border: "none",
+  padding: "0.1rem 0.3rem",
+  cursor: "pointer",
+  fontSize: "0.75rem",
+  fontFamily: "inherit",
+});
+
+const contentPreStyle: React.CSSProperties = {
+  background: "#fafafa",
+  border: "1px solid #f3f4f6",
+  padding: "0.5rem",
+  borderRadius: 4,
+  marginTop: "0.4rem",
+  fontFamily: '"SF Mono", Menlo, Monaco, monospace',
+  fontSize: "0.75rem",
+  whiteSpace: "pre-wrap",
+  wordBreak: "break-word",
+  maxHeight: 320,
+  overflow: "auto",
+  color: "#1f2937",
+};

--- a/apps/desktop/src/renderer/components/layout/HistoryList.tsx
+++ b/apps/desktop/src/renderer/components/layout/HistoryList.tsx
@@ -1,0 +1,164 @@
+// HistoryList(M1 #29 12b):左栏会话历史。
+//
+// 数据:IPC session:list(50/页;M1 不分页,M2 加滚动加载)。
+// 点击 → useSkillStore.resumeSession(id) → SkillWorkArea 进 replay phase。
+// 当前 replaySessionId 高亮。
+//
+// 相对时间(刚刚 / 5 分钟前 / 2 小时前 / 3 天前 / YYYY-MM-DD)。
+
+import type { SessionMeta } from "@opentrad/shared";
+import { History } from "lucide-react";
+import { type ReactElement, useCallback, useEffect, useState } from "react";
+import { useSkillStore } from "../../stores/skill";
+
+export function HistoryList(): ReactElement {
+  const replaySessionId = useSkillStore((s) => s.replaySessionId);
+  const resumeSession = useSkillStore((s) => s.resumeSession);
+  const [sessions, setSessions] = useState<SessionMeta[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const reload = useCallback(async (): Promise<void> => {
+    setLoading(true);
+    setError(null);
+    try {
+      const list = await window.api.session.list({ limit: 50, offset: 0 });
+      setSessions(list);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void reload();
+  }, [reload]);
+
+  // 当 replaySessionId 切换(用户回放完毕回到 chat / 选其他 skill 清空时),
+  // 列表数据本身不变,但 replay session 可能是新建的;每次清空时 reload 一次
+  // (debounce 不重要,只在 user-actor 行为后)
+  useEffect(() => {
+    if (replaySessionId === null) {
+      void reload();
+    }
+  }, [replaySessionId, reload]);
+
+  return (
+    <section style={sectionStyle}>
+      <header style={headerStyle}>
+        <History size={12} aria-hidden="true" style={{ marginRight: 4 }} />
+        History
+      </header>
+
+      <div style={listStyle}>
+        {loading && sessions.length === 0 ? <div style={emptyStyle}>加载中…</div> : null}
+        {error ? <div style={{ ...emptyStyle, color: "#b91c1c" }}>加载失败:{error}</div> : null}
+        {!loading && !error && sessions.length === 0 ? (
+          <div style={emptyStyle}>暂无历史会话</div>
+        ) : null}
+
+        {sessions.map((s) => {
+          const isSelected = s.id === replaySessionId;
+          return (
+            <button
+              key={s.id}
+              type="button"
+              onClick={() => resumeSession(s.id)}
+              style={{
+                ...itemStyle,
+                background: isSelected ? "#dbeafe" : "transparent",
+                borderLeft: isSelected ? "3px solid #2563eb" : "3px solid transparent",
+              }}
+              title={s.title}
+            >
+              <div
+                style={{
+                  fontSize: "0.8rem",
+                  color: isSelected ? "#1e3a8a" : "#1f2937",
+                  whiteSpace: "nowrap",
+                  overflow: "hidden",
+                  textOverflow: "ellipsis",
+                }}
+              >
+                {s.title}
+              </div>
+              <div
+                style={{
+                  fontSize: "0.7rem",
+                  color: "#94a3b8",
+                  marginTop: "0.15rem",
+                  display: "flex",
+                  justifyContent: "space-between",
+                }}
+              >
+                <span>{s.skillId ?? "—"}</span>
+                <span>{relativeTime(s.updatedAt)}</span>
+              </div>
+            </button>
+          );
+        })}
+      </div>
+    </section>
+  );
+}
+
+function relativeTime(ts: number): string {
+  const diffMs = Date.now() - ts;
+  const sec = Math.floor(diffMs / 1000);
+  if (sec < 60) return "刚刚";
+  const min = Math.floor(sec / 60);
+  if (min < 60) return `${min} 分钟前`;
+  const hr = Math.floor(min / 60);
+  if (hr < 24) return `${hr} 小时前`;
+  const day = Math.floor(hr / 24);
+  if (day < 7) return `${day} 天前`;
+  // 超过 7 天显示 YYYY-MM-DD
+  const d = new Date(ts);
+  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}-${String(d.getDate()).padStart(2, "0")}`;
+}
+
+const sectionStyle: React.CSSProperties = {
+  borderTop: "1px solid #e5e7eb",
+  background: "#f8fafc",
+  display: "flex",
+  flexDirection: "column",
+  flex: 1,
+  minHeight: 0, // 允许 flex 子项 overflow scroll
+};
+
+const headerStyle: React.CSSProperties = {
+  padding: "0.6rem 1rem",
+  fontSize: "0.7rem",
+  fontWeight: 600,
+  color: "#475569",
+  textTransform: "uppercase",
+  letterSpacing: "0.05em",
+  borderBottom: "1px solid #e5e7eb",
+  display: "flex",
+  alignItems: "center",
+};
+
+const listStyle: React.CSSProperties = {
+  flex: 1,
+  overflowY: "auto",
+  padding: "0.4rem 0",
+};
+
+const emptyStyle: React.CSSProperties = {
+  padding: "1rem",
+  color: "#94a3b8",
+  fontSize: "0.8rem",
+  textAlign: "center",
+};
+
+const itemStyle: React.CSSProperties = {
+  display: "block",
+  width: "100%",
+  textAlign: "left",
+  padding: "0.5rem 0.85rem",
+  border: "none",
+  cursor: "pointer",
+  fontFamily: "inherit",
+  background: "transparent",
+};

--- a/apps/desktop/src/renderer/components/layout/LeftSidebar.tsx
+++ b/apps/desktop/src/renderer/components/layout/LeftSidebar.tsx
@@ -1,0 +1,28 @@
+// LeftSidebar(M1 #29 12b):左栏组合 SkillPicker(顶)+ HistoryList(底)。
+// SkillPicker flex 1.2 / HistoryList flex 1(skill 优先,history 副)。
+
+import type { ReactElement } from "react";
+import { HistoryList } from "./HistoryList";
+import { SkillPicker } from "./SkillPicker";
+
+export function LeftSidebar(): ReactElement {
+  return (
+    <aside style={containerStyle}>
+      <div style={{ flex: 1.2, display: "flex", minHeight: 0 }}>
+        <SkillPicker />
+      </div>
+      <div style={{ flex: 1, display: "flex", minHeight: 0 }}>
+        <HistoryList />
+      </div>
+    </aside>
+  );
+}
+
+const containerStyle: React.CSSProperties = {
+  flex: 1,
+  display: "flex",
+  flexDirection: "column",
+  background: "#f8fafc",
+  borderRight: "1px solid #e5e7eb",
+  overflow: "hidden",
+};

--- a/apps/desktop/src/renderer/components/layout/SkillPicker.tsx
+++ b/apps/desktop/src/renderer/components/layout/SkillPicker.tsx
@@ -8,8 +8,6 @@
 import { type ReactElement, useEffect } from "react";
 import { useSkillStore } from "../../stores/skill";
 
-const PICKER_WIDTH = 220;
-
 export function SkillPicker(): ReactElement {
   const { skills, selectedId, loading, error, loadSkills, selectSkill } = useSkillStore();
 
@@ -20,12 +18,10 @@ export function SkillPicker(): ReactElement {
   return (
     <aside
       style={{
-        width: PICKER_WIDTH,
-        flexShrink: 0,
-        borderRight: "1px solid #e5e7eb",
-        background: "#f8fafc",
+        flex: 1,
         display: "flex",
         flexDirection: "column",
+        minHeight: 0,
       }}
     >
       <header

--- a/apps/desktop/src/renderer/features/layout/MainLayout.tsx
+++ b/apps/desktop/src/renderer/features/layout/MainLayout.tsx
@@ -13,7 +13,7 @@
 
 import { type ReactElement, useEffect, useRef, useState } from "react";
 import { Group, type Layout, Panel, Separator } from "react-resizable-panels";
-import { SkillPicker } from "../../components/layout/SkillPicker";
+import { LeftSidebar } from "../../components/layout/LeftSidebar";
 import { SkillWorkArea } from "../skills/SkillWorkArea";
 
 const LAYOUT_KEY = "ui.layoutWidths";
@@ -82,7 +82,7 @@ export function MainLayout(): ReactElement | null {
     >
       <Panel id="left" minSize={15} maxSize={40}>
         <div style={paneStyle}>
-          <SkillPicker />
+          <LeftSidebar />
         </div>
       </Panel>
       <Separator id="sep-left" style={resizeHandleStyle} />

--- a/apps/desktop/src/renderer/features/layout/MainLayout.tsx
+++ b/apps/desktop/src/renderer/features/layout/MainLayout.tsx
@@ -1,0 +1,131 @@
+// MainLayout(M1 #29 12a):三栏可拖拽布局。
+//
+// react-resizable-panels:Panel(defaultSize / minSize)+ PanelResizeHandle 拖拽条。
+// onLayout debounce 500ms → settings 表持久化(通报点 4 持久化要求)。
+//
+// 三栏:
+// - 左:SkillPicker(20% / min 15)
+// - 中:SkillWorkArea(60% / min 30)
+// - 右:placeholder "右栏(M2 浏览器预览)"(20% / min 0,可拖到隐藏)
+//
+// **D9-1 决策**:不用 PanelGroup 的 storage prop(它是 sync API 跟 settings async
+// IPC 冲突),改用 onLayout + 启动时 settings.get 异步加载 default sizes 模式。
+
+import { type ReactElement, useEffect, useRef, useState } from "react";
+import { Group, type Layout, Panel, Separator } from "react-resizable-panels";
+import { SkillPicker } from "../../components/layout/SkillPicker";
+import { SkillWorkArea } from "../skills/SkillWorkArea";
+
+const LAYOUT_KEY = "ui.layoutWidths";
+// v4 Layout 形态:{ [panelId]: sizePercent }。三栏 panelId:left / center / right。
+const DEFAULT_LAYOUT: Layout = { left: 20, center: 60, right: 20 };
+const DEBOUNCE_MS = 500;
+const GROUP_ID = "main-layout";
+
+export function MainLayout(): ReactElement | null {
+  const [layout, setLayout] = useState<Layout | null>(null);
+  const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  // 启动时异步加载持久化布局
+  useEffect(() => {
+    let cancelled = false;
+    void window.api.settings
+      .get(LAYOUT_KEY)
+      .then((v) => {
+        if (cancelled) return;
+        if (typeof v === "string") {
+          try {
+            const parsed = JSON.parse(v);
+            // 形态校验:object,所有 value 是 number
+            if (
+              parsed &&
+              typeof parsed === "object" &&
+              !Array.isArray(parsed) &&
+              Object.values(parsed).every((n) => typeof n === "number")
+            ) {
+              setLayout(parsed as Layout);
+              return;
+            }
+          } catch {}
+        }
+        setLayout(DEFAULT_LAYOUT);
+      })
+      .catch(() => {
+        if (!cancelled) setLayout(DEFAULT_LAYOUT);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const handleLayoutChange = (newLayout: Layout): void => {
+    if (debounceRef.current) clearTimeout(debounceRef.current);
+    debounceRef.current = setTimeout(() => {
+      void window.api.settings
+        .set(LAYOUT_KEY, JSON.stringify(newLayout))
+        .catch((err) => console.error("[main-layout] persist failed", err));
+    }, DEBOUNCE_MS);
+  };
+
+  // 加载中:占位空白(避免 Group 用错 defaultLayout)
+  if (!layout) {
+    return <div style={{ flex: 1, display: "flex" }} />;
+  }
+
+  return (
+    <Group
+      orientation="horizontal"
+      id={GROUP_ID}
+      defaultLayout={layout}
+      onLayoutChange={handleLayoutChange}
+      style={{ flex: 1, display: "flex" }}
+    >
+      <Panel id="left" minSize={15} maxSize={40}>
+        <div style={paneStyle}>
+          <SkillPicker />
+        </div>
+      </Panel>
+      <Separator id="sep-left" style={resizeHandleStyle} />
+      <Panel id="center" minSize={30}>
+        <div style={paneStyle}>
+          <SkillWorkArea />
+        </div>
+      </Panel>
+      <Separator id="sep-right" style={resizeHandleStyle} />
+      <Panel id="right" minSize={0}>
+        <div style={{ ...paneStyle, ...rightPaneStyle }}>
+          <div style={rightPaneInnerStyle}>
+            <h3 style={{ margin: "0 0 0.5rem", fontSize: "0.9rem", color: "#475569" }}>右栏</h3>
+            <p style={{ margin: 0, fontSize: "0.8rem", color: "#94a3b8" }}>
+              M2 浏览器预览(可拖窄到隐藏)
+            </p>
+          </div>
+        </div>
+      </Panel>
+    </Group>
+  );
+}
+
+const paneStyle: React.CSSProperties = {
+  height: "100%",
+  display: "flex",
+  flexDirection: "column",
+  overflow: "hidden",
+};
+
+const rightPaneStyle: React.CSSProperties = {
+  background: "#f8fafc",
+  borderLeft: "1px solid #e5e7eb",
+};
+
+const rightPaneInnerStyle: React.CSSProperties = {
+  padding: "1rem",
+  color: "#475569",
+};
+
+const resizeHandleStyle: React.CSSProperties = {
+  width: 4,
+  background: "#e5e7eb",
+  cursor: "col-resize",
+  transition: "background 0.15s",
+};

--- a/apps/desktop/src/renderer/features/settings/SettingsOverlay.tsx
+++ b/apps/desktop/src/renderer/features/settings/SettingsOverlay.tsx
@@ -1,32 +1,35 @@
-// SettingsRiskOverlay(M1 #28 阶段 4):/settings/risk 子页 modal-style。
+// SettingsOverlay(M1 #29 12b 重构):多 tab 设置 modal-style。
+// 历史:M1 #28 阶段 4 是 SettingsRiskOverlay(只 risk),M1 #29 升级为 5 tabs。
 //
 // **D9-1 决策**:M1 不引入 router 框架(react-router 等大依赖),用全屏 modal 等价
 // 实现 "settings 子页"。M2 真做 settings 框架时把 modal 改路由,接口契约不变。
 //
-// 两个 Tab:
+// 5 Tabs:
+// - General:语言切换(M1 显示但 i18n 完整支持留 follow-up)+ 主题(M2)
+// - CC:CC 版本 / 登录状态 / 安装路径 / "重新检测"按钮
 // - Rules:risk_rules 表所有规则,每条带"删除"按钮
 // - Audit:audit_log 全表分页(50/页),按 timestamp DESC
+// - About:版本号 / GitHub / AGPL-3.0
 //
 // 触发:Header 齿轮图标 → setOpen(true)。关闭:右上角 ✕ / 按 ESC / 点击 overlay 背景。
 
-import type { AuditLogRow, RiskRuleRow } from "@opentrad/shared";
+import type { AuditLogRow, CCStatus, RiskRuleRow } from "@opentrad/shared";
 import { Settings, Trash2, X } from "lucide-react";
 import { type ReactElement, useCallback, useEffect, useState } from "react";
 
 const PAGE_SIZE = 50;
+const APP_VERSION = "0.0.0"; // M1 hardcoded;M2 从 package.json runtime 读
+const REPO_URL = "https://github.com/open-trad/opentrad";
 
-export interface SettingsRiskOverlayProps {
+export interface SettingsOverlayProps {
   open: boolean;
   onClose: () => void;
 }
 
-type Tab = "rules" | "audit";
+type Tab = "general" | "cc" | "rules" | "audit" | "about";
 
-export function SettingsRiskOverlay({
-  open,
-  onClose,
-}: SettingsRiskOverlayProps): ReactElement | null {
-  const [tab, setTab] = useState<Tab>("rules");
+export function SettingsOverlay({ open, onClose }: SettingsOverlayProps): ReactElement | null {
+  const [tab, setTab] = useState<Tab>("general");
 
   // ESC 关闭
   useEffect(() => {
@@ -53,7 +56,7 @@ export function SettingsRiskOverlay({
         <header style={headerStyle}>
           <div style={{ display: "flex", alignItems: "center", gap: "0.5rem" }}>
             <Settings size={18} aria-hidden="true" />
-            <h2 style={{ margin: 0, fontSize: "1.05rem" }}>Risk 设置</h2>
+            <h2 style={{ margin: 0, fontSize: "1.05rem" }}>设置</h2>
           </div>
           <button type="button" onClick={onClose} style={closeBtnStyle} aria-label="关闭">
             <X size={18} />
@@ -61,19 +64,221 @@ export function SettingsRiskOverlay({
         </header>
 
         <div style={tabBarStyle}>
+          <TabButton active={tab === "general"} onClick={() => setTab("general")}>
+            通用
+          </TabButton>
+          <TabButton active={tab === "cc"} onClick={() => setTab("cc")}>
+            Claude Code
+          </TabButton>
           <TabButton active={tab === "rules"} onClick={() => setTab("rules")}>
-            规则({/* count loaded after */})
+            规则
           </TabButton>
           <TabButton active={tab === "audit"} onClick={() => setTab("audit")}>
             审计日志
           </TabButton>
+          <TabButton active={tab === "about"} onClick={() => setTab("about")}>
+            关于
+          </TabButton>
         </div>
 
-        <div style={tabContentStyle}>{tab === "rules" ? <RulesTab /> : <AuditTab />}</div>
+        <div style={tabContentStyle}>
+          {tab === "general" && <GeneralTab />}
+          {tab === "cc" && <CcTab />}
+          {tab === "rules" && <RulesTab />}
+          {tab === "audit" && <AuditTab />}
+          {tab === "about" && <AboutTab />}
+        </div>
       </div>
     </div>
   );
 }
+
+// ----- General Tab -----
+// M1:语言切换 UI 占位(完整 i18n 全 UI 文案 follow-up issue);
+// 主题 UI 占位 disabled(M2 dark mode)。
+
+function GeneralTab(): ReactElement {
+  const [lang, setLang] = useState<"zh-CN" | "en">("zh-CN");
+
+  // M1 实际不做 i18n.changeLanguage(全 UI 文案改 t() 是 follow-up issue,
+  // 工作量超 12b 一个 commit 范围)。本 select 仅展示设计意图,选 en 后无视觉变化。
+  // M2 完整 i18n 落地后此 onChange 真实生效。
+  return (
+    <div>
+      <SettingItem label="语言" hint="界面文案语言(完整 i18n 在 follow-up issue 落地)">
+        <select
+          value={lang}
+          onChange={(e) => setLang(e.target.value as "zh-CN" | "en")}
+          style={selectStyle}
+        >
+          <option value="zh-CN">简体中文</option>
+          <option value="en">English</option>
+        </select>
+      </SettingItem>
+
+      <SettingItem label="主题" hint="M2 dark mode 落地后启用">
+        <select disabled style={{ ...selectStyle, opacity: 0.5, cursor: "not-allowed" }}>
+          <option>跟随系统(M2)</option>
+        </select>
+      </SettingItem>
+    </div>
+  );
+}
+
+// ----- CC Tab -----
+
+function CcTab(): ReactElement {
+  const [status, setStatus] = useState<CCStatus | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  const reload = useCallback(async (): Promise<void> => {
+    setLoading(true);
+    try {
+      const s = await window.api.cc.status();
+      setStatus(s);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void reload();
+  }, [reload]);
+
+  return (
+    <div>
+      <SettingItem label="安装状态">
+        <span>
+          {loading ? "检测中…" : status?.installed ? `✓ 已安装 v${status.version}` : "× 未安装"}
+        </span>
+      </SettingItem>
+      <SettingItem label="登录状态">
+        <span>
+          {!status?.installed
+            ? "—"
+            : status.loggedIn
+              ? `✓ ${status.email ?? "(已登录)"} (${status.authMethod === "subscription" ? "订阅" : "API"})`
+              : "× 未登录"}
+        </span>
+      </SettingItem>
+      <SettingItem
+        label="安装路径"
+        hint="M1 仅显示 binary 名;实际路径由 PATH 解析(M2 显示 which 结果)"
+      >
+        <code style={codeStyle}>claude</code>
+      </SettingItem>
+      <button type="button" onClick={() => void reload()} style={primaryBtnStyle}>
+        重新检测
+      </button>
+    </div>
+  );
+}
+
+// ----- About Tab -----
+
+function AboutTab(): ReactElement {
+  const handleOpenRepo = async (): Promise<void> => {
+    try {
+      await window.api.shell.openExternal({ url: REPO_URL });
+    } catch (err) {
+      console.error("[about] openExternal failed", err);
+    }
+  };
+
+  return (
+    <div>
+      <h3 style={{ margin: "0 0 0.5rem", fontSize: "1.1rem", color: "#111827" }}>OpenTrad</h3>
+      <p style={{ margin: "0 0 1rem", color: "#6b7280", fontSize: "0.9rem" }}>
+        基于 Claude Code 的外贸 AI 工作台
+      </p>
+
+      <SettingItem label="版本">
+        <code style={codeStyle}>v{APP_VERSION}</code>
+      </SettingItem>
+      <SettingItem label="GitHub">
+        <button
+          type="button"
+          onClick={() => void handleOpenRepo()}
+          style={{
+            background: "none",
+            border: "none",
+            padding: 0,
+            color: "#2563eb",
+            textDecoration: "underline",
+            cursor: "pointer",
+            fontSize: "0.9rem",
+            fontFamily: "inherit",
+          }}
+        >
+          {REPO_URL.replace("https://", "")}
+        </button>
+      </SettingItem>
+      <SettingItem label="License">
+        <span style={{ fontSize: "0.85rem", color: "#374151" }}>AGPL-3.0</span>
+      </SettingItem>
+    </div>
+  );
+}
+
+// 通用 SettingItem
+function SettingItem({
+  label,
+  hint,
+  children,
+}: {
+  label: string;
+  hint?: string;
+  children: React.ReactNode;
+}): ReactElement {
+  return (
+    <div style={{ marginBottom: "1.25rem" }}>
+      <div
+        style={{
+          display: "flex",
+          justifyContent: "space-between",
+          alignItems: "center",
+          gap: "1rem",
+        }}
+      >
+        <span
+          style={{
+            fontSize: "0.85rem",
+            color: "#374151",
+            fontWeight: 500,
+          }}
+        >
+          {label}
+        </span>
+        <div>{children}</div>
+      </div>
+      {hint ? (
+        <p style={{ margin: "0.3rem 0 0", fontSize: "0.75rem", color: "#94a3b8" }}>{hint}</p>
+      ) : null}
+    </div>
+  );
+}
+
+const selectStyle: React.CSSProperties = {
+  padding: "0.4rem 0.6rem",
+  fontSize: "0.85rem",
+  border: "1px solid #d1d5db",
+  borderRadius: 6,
+  background: "white",
+  fontFamily: "inherit",
+  minWidth: 160,
+};
+
+const primaryBtnStyle: React.CSSProperties = {
+  background: "#2563eb",
+  color: "white",
+  border: "none",
+  padding: "0.5rem 1rem",
+  borderRadius: 6,
+  cursor: "pointer",
+  fontSize: "0.85rem",
+  fontFamily: "inherit",
+  marginTop: "0.5rem",
+};
 
 // ----- Rules Tab -----
 

--- a/apps/desktop/src/renderer/features/skills/SkillWorkArea.tsx
+++ b/apps/desktop/src/renderer/features/skills/SkillWorkArea.tsx
@@ -29,16 +29,83 @@ type WorkPhase =
       events: CCEvent[];
       finished: boolean;
       success?: boolean;
+    }
+  // M1 #29 12b D-M1-7:历史回放,read-only 渲染 events 表数据,**不重启 CC 子进程**。
+  | {
+      kind: "replay";
+      sessionId: string;
+      title: string;
+      skillId: string | null;
+      events: CCEvent[];
+      loading: boolean;
+      error?: string;
     };
 
 export function SkillWorkArea(): ReactElement {
-  const { selectedId, skills } = useSkillStore();
+  const selectedId = useSkillStore((s) => s.selectedId);
+  const skills = useSkillStore((s) => s.skills);
+  const replaySessionId = useSkillStore((s) => s.replaySessionId);
   const selectedSkill = skills.find((s) => s.id === selectedId);
 
   const [phase, setPhase] = useState<WorkPhase>({ kind: "empty" });
 
-  // selectedSkill 变化时重置 phase 为 form(若有 skill)或 empty
+  // replaySessionId 变化:进入 replay phase + 异步 fetch events
   useEffect(() => {
+    if (!replaySessionId) return;
+    setPhase({
+      kind: "replay",
+      sessionId: replaySessionId,
+      title: "加载中…",
+      skillId: null,
+      events: [],
+      loading: true,
+    });
+    let cancelled = false;
+    void window.api.session
+      .resume({ sessionId: replaySessionId })
+      .then((result) => {
+        if (cancelled) return;
+        if (!result) {
+          setPhase({
+            kind: "replay",
+            sessionId: replaySessionId,
+            title: "(会话不存在)",
+            skillId: null,
+            events: [],
+            loading: false,
+            error: "session not found",
+          });
+          return;
+        }
+        setPhase({
+          kind: "replay",
+          sessionId: replaySessionId,
+          title: result.session.title,
+          skillId: result.session.skillId,
+          events: result.events,
+          loading: false,
+        });
+      })
+      .catch((err) => {
+        if (cancelled) return;
+        setPhase({
+          kind: "replay",
+          sessionId: replaySessionId,
+          title: "(加载失败)",
+          skillId: null,
+          events: [],
+          loading: false,
+          error: err instanceof Error ? err.message : String(err),
+        });
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [replaySessionId]);
+
+  // selectedSkill 变化时重置 phase 为 form(若有 skill 且非 replay 中)或 empty
+  useEffect(() => {
+    if (replaySessionId) return; // replay 中,不被 skill 切换打断;skill 选了才会 selectSkill 清 replay
     if (selectedSkill) {
       setPhase((prev) => {
         // 同一 skill 已在 chat 中,不重置
@@ -48,7 +115,7 @@ export function SkillWorkArea(): ReactElement {
     } else {
       setPhase({ kind: "empty" });
     }
-  }, [selectedSkill]);
+  }, [selectedSkill, replaySessionId]);
 
   // 订阅 cc:event 流(chat 阶段)
   useEffect(() => {
@@ -116,6 +183,57 @@ export function SkillWorkArea(): ReactElement {
         <div style={contentStyle}>
           <SkillHeader skill={phase.skill} />
           <SkillInputForm skill={phase.skill} onSubmit={(i) => void handleSubmit(phase.skill, i)} />
+        </div>
+      </main>
+    );
+  }
+
+  // replay(M1 #29 12b 历史回放)
+  if (phase.kind === "replay") {
+    return (
+      <main style={mainStyle}>
+        <div style={contentStyle}>
+          <header
+            style={{
+              display: "flex",
+              justifyContent: "space-between",
+              alignItems: "flex-start",
+              marginBottom: "1.25rem",
+              paddingBottom: "1rem",
+              borderBottom: "1px solid #e5e7eb",
+            }}
+          >
+            <div>
+              <h2 style={{ margin: 0, fontSize: "1.25rem", color: "#111827" }}>{phase.title}</h2>
+              <p style={{ margin: "0.25rem 0 0", fontSize: "0.85rem", color: "#6b7280" }}>
+                历史回放(read-only) {phase.skillId ? `· skill: ${phase.skillId}` : ""}
+              </p>
+            </div>
+            <span
+              style={{
+                fontSize: "0.75rem",
+                color: "#94a3b8",
+                background: "#f3f4f6",
+                padding: "0.2rem 0.5rem",
+                borderRadius: 4,
+              }}
+            >
+              session: {phase.sessionId.slice(0, 8)}…
+            </span>
+          </header>
+          {phase.loading ? (
+            <div style={{ color: "#9ca3af", padding: "2rem 0", fontSize: "0.9rem" }}>
+              加载历史事件…
+            </div>
+          ) : phase.error ? (
+            <div style={{ color: "#b91c1c", padding: "1rem 0" }}>{phase.error}</div>
+          ) : phase.events.length === 0 ? (
+            <div style={{ color: "#9ca3af", padding: "2rem 0", fontSize: "0.9rem" }}>
+              该会话无事件记录
+            </div>
+          ) : (
+            <EventStream events={phase.events} />
+          )}
         </div>
       </main>
     );

--- a/apps/desktop/src/renderer/features/skills/SkillWorkArea.tsx
+++ b/apps/desktop/src/renderer/features/skills/SkillWorkArea.tsx
@@ -13,6 +13,9 @@
 
 import type { CCEvent, SkillManifest } from "@opentrad/shared";
 import { type ReactElement, useEffect, useState } from "react";
+import { MessageBubble } from "../../components/chat/MessageBubble";
+import { ToolCallCard } from "../../components/chat/ToolCallCard";
+import { ToolResultCard } from "../../components/chat/ToolResultCard";
 import { useSkillStore } from "../../stores/skill";
 import { SkillInputForm } from "./SkillInputForm";
 
@@ -212,45 +215,40 @@ function EventStream({ events }: { events: CCEvent[] }): ReactElement {
   );
 }
 
-function EventCard({ evt }: { evt: CCEvent }): ReactElement {
-  const baseStyle: React.CSSProperties = {
-    padding: "0.6rem 0.9rem",
-    borderRadius: 6,
-    fontSize: "0.85rem",
-    background: "#f8fafc",
-    color: "#475569",
-    border: "1px solid #e2e8f0",
-  };
-
+function EventCard({ evt }: { evt: CCEvent }): ReactElement | null {
+  // M1 #29 12a:升级 EventCard 用 MessageBubble / ToolCallCard / ToolResultCard。
+  // M0 简版的 inline 渲染替换为专用组件,markdown / 代码块 / 表格 / 工具卡片完整支持。
   if (evt.type === "assistant_text") {
-    return (
-      <div
-        style={{
-          ...baseStyle,
-          background: "#dbeafe",
-          color: "#1e3a8a",
-          border: "1px solid #93c5fd",
-        }}
-      >
-        {evt.text}
-      </div>
-    );
+    return <MessageBubble kind="text" content={evt.text} />;
   }
   if (evt.type === "assistant_thinking") {
-    return (
-      <details style={{ ...baseStyle, background: "#f3f4f6" }}>
-        <summary style={{ cursor: "pointer", fontSize: "0.8rem", color: "#6b7280" }}>
-          思考中…
-        </summary>
-        <div style={{ marginTop: "0.4rem", whiteSpace: "pre-wrap" }}>{evt.thinking}</div>
-      </details>
-    );
+    return <MessageBubble kind="thinking" content={evt.thinking} />;
+  }
+  if (evt.type === "assistant_tool_use") {
+    return <ToolCallCard toolName={evt.name} toolUseId={evt.toolUseId} input={evt.input} />;
+  }
+  if (evt.type === "tool_result") {
+    return <ToolResultCard toolUseId={evt.toolUseId} content={evt.content} isError={evt.isError} />;
   }
   if (evt.type === "result") {
-    return null as unknown as ReactElement; // result 在外层 finished 标显示
+    return null; // result 在外层 finished 标显示
   }
-  // system / rate_limit / assistant_tool_use / tool_result / unknown 用最简渲染
-  return <div style={{ ...baseStyle, fontSize: "0.75rem" }}>{evt.type}</div>;
+  // system / rate_limit_event / unknown:最简标 type(信息密度低)
+  return (
+    <div
+      style={{
+        padding: "0.4rem 0.7rem",
+        borderRadius: 6,
+        fontSize: "0.7rem",
+        background: "#f8fafc",
+        color: "#94a3b8",
+        border: "1px solid #e2e8f0",
+        fontFamily: '"SF Mono", Menlo, Monaco, monospace',
+      }}
+    >
+      {evt.type}
+    </div>
+  );
 }
 
 const mainStyle: React.CSSProperties = {

--- a/apps/desktop/src/renderer/stores/skill.ts
+++ b/apps/desktop/src/renderer/stores/skill.ts
@@ -12,10 +12,14 @@ import { create } from "zustand";
 interface SkillStoreState {
   skills: SkillManifest[];
   selectedId: string | null;
+  // M1 #29 12b:历史回放选中的 sessionId(null = chat 当前;string = 回放历史)。
+  // selectSkill 时清空,回到 form/chat;resumeSession 时设置,SkillWorkArea 进 replay。
+  replaySessionId: string | null;
   loading: boolean;
   error: string | null;
   loadSkills: () => Promise<void>;
   selectSkill: (id: string | null) => void;
+  resumeSession: (sessionId: string | null) => void;
   // 选中 skill 的 manifest(派生 getter)
   selectedSkill: () => SkillManifest | undefined;
 }
@@ -23,6 +27,7 @@ interface SkillStoreState {
 export const useSkillStore = create<SkillStoreState>((set, get) => ({
   skills: [],
   selectedId: null,
+  replaySessionId: null,
   loading: false,
   error: null,
   loadSkills: async () => {
@@ -41,7 +46,8 @@ export const useSkillStore = create<SkillStoreState>((set, get) => ({
       });
     }
   },
-  selectSkill: (id) => set({ selectedId: id }),
+  selectSkill: (id) => set({ selectedId: id, replaySessionId: null }),
+  resumeSession: (sessionId) => set({ replaySessionId: sessionId }),
   selectedSkill: () => {
     const { skills, selectedId } = get();
     return skills.find((s) => s.id === selectedId);

--- a/packages/shared/src/types/ipc.ts
+++ b/packages/shared/src/types/ipc.ts
@@ -105,12 +105,25 @@ export const SessionDeleteRequestSchema = z.object({
 export type SessionDeleteRequest = z.infer<typeof SessionDeleteRequestSchema>;
 
 // -------- session:resume（Renderer → Main） --------
+// M1 #29 D-M1-7:M1 只查看不重启 CC,response 含 SessionMeta + 完整 events 数组。
+// events 是 CCEvent[](payload 已 normalize 后 union),不在本 schema 内重复 zod 校验
+// (CCEvent discriminated union 复杂,renderer 信任 main 端 normalize 输出)。
+// 不存在的 sessionId → null。
 
 export const SessionResumeRequestSchema = z.object({
   sessionId: z.string(),
 });
 
 export type SessionResumeRequest = z.infer<typeof SessionResumeRequestSchema>;
+
+// 注:CCEvent 类型在 cc-event.ts;本 interface 直接 import 引用,不走 zod schema
+// (避免 union 序列化复杂度,M1 实测层 wire 校验已在 stream-parser 完成)。
+import type { CCEvent } from "./cc-event";
+
+export interface SessionResumeResponse {
+  session: SessionMeta;
+  events: CCEvent[];
+}
 
 // -------- risk-gate:confirm（Main → Renderer push） --------
 // payload 是 RiskGateRequest（见 risk-gate.ts）。

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -77,6 +77,18 @@ importers:
       react-dom:
         specifier: ^19.2.5
         version: 19.2.5(react@19.2.5)
+      react-markdown:
+        specifier: ^10.1.0
+        version: 10.1.0(@types/react@19.2.14)(react@19.2.5)
+      react-resizable-panels:
+        specifier: ^4.10.0
+        version: 4.10.0(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      react-syntax-highlighter:
+        specifier: ^16.1.1
+        version: 16.1.1(react@19.2.5)
+      remark-gfm:
+        specifier: ^4.0.1
+        version: 4.0.1
       zod:
         specifier: ^4.3.6
         version: 4.3.6
@@ -99,6 +111,9 @@ importers:
       '@types/react-dom':
         specifier: ^19.2.3
         version: 19.2.3(@types/react@19.2.14)
+      '@types/react-syntax-highlighter':
+        specifier: ^15.5.13
+        version: 15.5.13
       '@vitejs/plugin-react':
         specifier: ^6.0.1
         version: 6.0.1(vite@8.0.10(@types/node@25.6.0)(esbuild@0.27.7)(tsx@4.21.0))
@@ -236,6 +251,10 @@ packages:
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
+
+  '@babel/runtime@7.29.2':
+    resolution: {integrity: sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==}
+    engines: {node: '>=6.9.0'}
 
   '@babel/template@7.28.6':
     resolution: {integrity: sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==}
@@ -799,11 +818,20 @@ packages:
   '@types/chai@5.2.3':
     resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
 
+  '@types/debug@4.1.13':
+    resolution: {integrity: sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw==}
+
   '@types/deep-eql@4.0.2':
     resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
 
+  '@types/estree-jsx@1.0.5':
+    resolution: {integrity: sha512-52CcUVNFyfb1A2ALocQw/Dd1BQFNmSdkuC3BkZ6iqhdMfQz7JWOFRuJFloOzjk+6WijU56m9oKXFAXc7o3Towg==}
+
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
+
+  '@types/hast@3.0.4':
+    resolution: {integrity: sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==}
 
   '@types/http-cache-semantics@4.2.0':
     resolution: {integrity: sha512-L3LgimLHXtGkWikKnsPg0/VFx9OGZaC+eN1u4r+OB1XRqH3meBIAVC2zr1WdMH+RHmnRkqliQAOHNJ/E0j/e0Q==}
@@ -814,16 +842,28 @@ packages:
   '@types/keyv@3.1.4':
     resolution: {integrity: sha512-BQ5aZNSCpj7D6K2ksrRCTmKRLEpnPvWDiLPfoGyhZ++8YtiK9d/3DBKPJgry359X/P1PfruyYwvnvwFjuEiEIg==}
 
+  '@types/mdast@4.0.4':
+    resolution: {integrity: sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==}
+
+  '@types/ms@2.1.0':
+    resolution: {integrity: sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==}
+
   '@types/node@24.12.2':
     resolution: {integrity: sha512-A1sre26ke7HDIuY/M23nd9gfB+nrmhtYyMINbjI1zHJxYteKR6qSMX56FsmjMcDb3SMcjJg5BiRRgOCC/yBD0g==}
 
   '@types/node@25.6.0':
     resolution: {integrity: sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==}
 
+  '@types/prismjs@1.26.6':
+    resolution: {integrity: sha512-vqlvI7qlMvcCBbVe0AKAb4f97//Hy0EBTaiW8AalRnG/xAN5zOiWWyrNqNXeq8+KAuvRewjCVY1+IPxk4RdNYw==}
+
   '@types/react-dom@19.2.3':
     resolution: {integrity: sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==}
     peerDependencies:
       '@types/react': ^19.2.0
+
+  '@types/react-syntax-highlighter@15.5.13':
+    resolution: {integrity: sha512-uLGJ87j6Sz8UaBAooU0T6lWJ0dBmjZgN1PZTrj05TNql2/XpC6+4HhMT5syIdFUUt+FASfCeLLv4kBygNU+8qA==}
 
   '@types/react@19.2.14':
     resolution: {integrity: sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==}
@@ -831,8 +871,17 @@ packages:
   '@types/responselike@1.0.3':
     resolution: {integrity: sha512-H/+L+UkTV33uf49PH5pCAUBVPNj2nDBXTN+qS1dOwyyg24l3CcicicCA7ca+HMvJBZcFgl5r8e+RR6elsb4Lyw==}
 
+  '@types/unist@2.0.11':
+    resolution: {integrity: sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==}
+
+  '@types/unist@3.0.3':
+    resolution: {integrity: sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==}
+
   '@types/yauzl@2.10.3':
     resolution: {integrity: sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q==}
+
+  '@ungap/structured-clone@1.3.0':
+    resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
 
   '@vitejs/plugin-react@6.0.1':
     resolution: {integrity: sha512-l9X/E3cDb+xY3SWzlG1MOGt2usfEHGMNIaegaUGFsLkb3RCn/k8/TOXBcab+OndDI4TBtktT8/9BwwW8Vi9KUQ==}
@@ -911,6 +960,9 @@ packages:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
     engines: {node: '>=12'}
 
+  bail@2.0.2:
+    resolution: {integrity: sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==}
+
   base64-js@1.5.1:
     resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
 
@@ -975,9 +1027,24 @@ packages:
   caniuse-lite@1.0.30001790:
     resolution: {integrity: sha512-bOoxfJPyYo+ds6W0YfptaCWbFnJYjh2Y1Eow5lRv+vI2u8ganPZqNm1JwNh0t2ELQCqIWg4B3dWEusgAmsoyOw==}
 
+  ccount@2.0.1:
+    resolution: {integrity: sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==}
+
   chai@6.2.2:
     resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
     engines: {node: '>=18'}
+
+  character-entities-html4@2.1.0:
+    resolution: {integrity: sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA==}
+
+  character-entities-legacy@3.0.0:
+    resolution: {integrity: sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ==}
+
+  character-entities@2.0.2:
+    resolution: {integrity: sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ==}
+
+  character-reference-invalid@2.0.1:
+    resolution: {integrity: sha512-iBZ4F4wRbyORVsu0jPV7gXkOsGYjGHPmAyv+HiHG8gi5PtC9KI2j1+v8/tlibRvjoWX027ypmG/n0HtO5t7unw==}
 
   chownr@1.1.4:
     resolution: {integrity: sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==}
@@ -988,6 +1055,9 @@ packages:
 
   clone-response@1.0.3:
     resolution: {integrity: sha512-ROoL94jJH2dUVML2Y/5PEDNaSHgeOdSDicUyS7izcF63G6sTc/FTjLub4b8Il9S8S0beOfYt0TaA5qvFK+w0wA==}
+
+  comma-separated-tokens@2.0.3:
+    resolution: {integrity: sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==}
 
   content-disposition@1.1.0:
     resolution: {integrity: sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==}
@@ -1028,6 +1098,9 @@ packages:
       supports-color:
         optional: true
 
+  decode-named-character-reference@1.3.0:
+    resolution: {integrity: sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q==}
+
   decompress-response@6.0.0:
     resolution: {integrity: sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==}
     engines: {node: '>=10'}
@@ -1052,12 +1125,19 @@ packages:
     resolution: {integrity: sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==}
     engines: {node: '>= 0.8'}
 
+  dequal@2.0.3:
+    resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
+    engines: {node: '>=6'}
+
   detect-libc@2.1.2:
     resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
     engines: {node: '>=8'}
 
   detect-node@2.1.0:
     resolution: {integrity: sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g==}
+
+  devlop@1.1.0:
+    resolution: {integrity: sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==}
 
   dunder-proto@1.0.1:
     resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
@@ -1135,6 +1215,13 @@ packages:
     resolution: {integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==}
     engines: {node: '>=10'}
 
+  escape-string-regexp@5.0.0:
+    resolution: {integrity: sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==}
+    engines: {node: '>=12'}
+
+  estree-util-is-identifier-name@3.0.0:
+    resolution: {integrity: sha512-hFtqIDZTIUZ9BXLb8y4pYGyk6+wekIivNVTcmvk8NoOh+VeRn5y6cEHzbURrWbfp1fIqdVipilzj+lfaadNZmg==}
+
   estree-walker@3.0.3:
     resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
 
@@ -1171,6 +1258,9 @@ packages:
     resolution: {integrity: sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==}
     engines: {node: '>= 18'}
 
+  extend@3.0.2:
+    resolution: {integrity: sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==}
+
   extract-zip@2.0.1:
     resolution: {integrity: sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==}
     engines: {node: '>= 10.17.0'}
@@ -1181,6 +1271,9 @@ packages:
 
   fast-uri@3.1.0:
     resolution: {integrity: sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==}
+
+  fault@1.0.4:
+    resolution: {integrity: sha512-CJ0HCB5tL5fYTEA7ToAq5+kTwd++Borf1/bifxd9iT70QcXr4MRrO3Llf8Ifs70q+SJcGHFtnIE/Nw6giCtECA==}
 
   fd-slicer@1.1.0:
     resolution: {integrity: sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==}
@@ -1200,6 +1293,10 @@ packages:
   finalhandler@2.1.1:
     resolution: {integrity: sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==}
     engines: {node: '>= 18.0.0'}
+
+  format@0.2.2:
+    resolution: {integrity: sha512-wzsgA6WOq+09wrU1tsJ09udeR/YZRaeArL9e1wPbFg3GG2yDnC2ldKpxs4xunpFF9DgqCqOIra3bc1HWrJ37Ww==}
+    engines: {node: '>=0.4.x'}
 
   forwarded@0.2.0:
     resolution: {integrity: sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==}
@@ -1281,9 +1378,30 @@ packages:
     resolution: {integrity: sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==}
     engines: {node: '>= 0.4'}
 
+  hast-util-parse-selector@4.0.0:
+    resolution: {integrity: sha512-wkQCkSYoOGCRKERFWcxMVMOcYE2K1AaNLU8DXS9arxnLOUEWbOXKXiJUNzEpqZ3JOKpnha3jkFrumEjVliDe7A==}
+
+  hast-util-to-jsx-runtime@2.3.6:
+    resolution: {integrity: sha512-zl6s8LwNyo1P9uw+XJGvZtdFF1GdAkOg8ujOw+4Pyb76874fLps4ueHXDhXWdk6YHQ6OgUtinliG7RsYvCbbBg==}
+
+  hast-util-whitespace@3.0.0:
+    resolution: {integrity: sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==}
+
+  hastscript@9.0.1:
+    resolution: {integrity: sha512-g7df9rMFX/SPi34tyGCyUBREQoKkapwdY/T04Qn9TDWfHhAYt4/I0gMVirzK5wEzeUqIjEB+LXC/ypb7Aqno5w==}
+
+  highlight.js@10.7.3:
+    resolution: {integrity: sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A==}
+
+  highlightjs-vue@1.0.0:
+    resolution: {integrity: sha512-PDEfEF102G23vHmPhLyPboFCD+BkMGu+GuJe2d9/eH4FsCwvgBpnc9n0pGE+ffKdph38s6foEZiEjdgHdzp+IA==}
+
   hono@4.12.15:
     resolution: {integrity: sha512-qM0jDhFEaCBb4TxoW7f53Qrpv9RBiayUHo0S52JudprkhvpjIrGoU1mnnr29Fvd1U335ZFPZQY1wlkqgfGXyLg==}
     engines: {node: '>=16.9.0'}
+
+  html-url-attributes@3.0.1:
+    resolution: {integrity: sha512-ol6UPyBWqsrO6EJySPz2O7ZSr856WDrEzM5zMqp+FJJLGMW35cLYmmZnl0vztAZxRUoNZJFTCohfjuIJ8I4QBQ==}
 
   http-cache-semantics@4.2.0:
     resolution: {integrity: sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ==}
@@ -1309,6 +1427,9 @@ packages:
   ini@1.3.8:
     resolution: {integrity: sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==}
 
+  inline-style-parser@0.2.7:
+    resolution: {integrity: sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA==}
+
   ip-address@10.1.0:
     resolution: {integrity: sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==}
     engines: {node: '>= 12'}
@@ -1316,6 +1437,22 @@ packages:
   ipaddr.js@1.9.1:
     resolution: {integrity: sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==}
     engines: {node: '>= 0.10'}
+
+  is-alphabetical@2.0.1:
+    resolution: {integrity: sha512-FWyyY60MeTNyeSRpkM2Iry0G9hpr7/9kD40mD/cGQEuilcZYS4okz8SN2Q6rLCJ8gbCt6fN+rC+6tMGS99LaxQ==}
+
+  is-alphanumerical@2.0.1:
+    resolution: {integrity: sha512-hmbYhX/9MUMF5uh7tOXyK/n0ZvWpad5caBA17GsC6vyuCqaWliRG5K1qS9inmUhEMaOBIW7/whAnSwveW/LtZw==}
+
+  is-decimal@2.0.1:
+    resolution: {integrity: sha512-AAB9hiomQs5DXWcRB1rqsxGUstbRroFOPPVAomNk/3XHR5JyEZChOyTWe2oayKnsSsr/kcGqF+z6yuH6HHpN0A==}
+
+  is-hexadecimal@2.0.1:
+    resolution: {integrity: sha512-DgZQp241c8oO6cA1SbTEWiXeoxV42vlcJxgH+B3hi1AiqqKruZR3ZGF8In3fj4+/y/7rHvlOZLZtgJ/4ttYGZg==}
+
+  is-plain-obj@4.1.0:
+    resolution: {integrity: sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==}
+    engines: {node: '>=12'}
 
   is-promise@4.0.0:
     resolution: {integrity: sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==}
@@ -1435,9 +1572,15 @@ packages:
     resolution: {integrity: sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==}
     engines: {node: '>= 12.0.0'}
 
+  longest-streak@3.1.0:
+    resolution: {integrity: sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==}
+
   lowercase-keys@2.0.0:
     resolution: {integrity: sha512-tqNXrS78oMOE73NMxK4EMLQsQowWf8jKooH9g7xPavRT706R6bkQJ6DY2Te7QukaZsulxa30wQ7bk0pm4XiHmA==}
     engines: {node: '>=8'}
+
+  lowlight@1.20.0:
+    resolution: {integrity: sha512-8Ktj+prEb1RoCPkEOrPMYUN/nCggB7qAWe3a7OpMjWQkh3l2RD5wKRQ+o8Q8YuI9RG/xs95waaI/E6ym/7NsTw==}
 
   lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
@@ -1450,6 +1593,9 @@ packages:
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
 
+  markdown-table@3.0.4:
+    resolution: {integrity: sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw==}
+
   matcher@3.0.0:
     resolution: {integrity: sha512-OkeDaAZ/bQCxeFAozM55PKcKU0yJMPGifLwV4Qgjitu+5MoAfSQN4lsLJeXZ1b8w0x+/Emda6MZgXS1jvsapng==}
     engines: {node: '>=10'}
@@ -1458,6 +1604,51 @@ packages:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
     engines: {node: '>= 0.4'}
 
+  mdast-util-find-and-replace@3.0.2:
+    resolution: {integrity: sha512-Tmd1Vg/m3Xz43afeNxDIhWRtFZgM2VLyaf4vSTYwudTyeuTneoL3qtWMA5jeLyz/O1vDJmmV4QuScFCA2tBPwg==}
+
+  mdast-util-from-markdown@2.0.3:
+    resolution: {integrity: sha512-W4mAWTvSlKvf8L6J+VN9yLSqQ9AOAAvHuoDAmPkz4dHf553m5gVj2ejadHJhoJmcmxEnOv6Pa8XJhpxE93kb8Q==}
+
+  mdast-util-gfm-autolink-literal@2.0.1:
+    resolution: {integrity: sha512-5HVP2MKaP6L+G6YaxPNjuL0BPrq9orG3TsrZ9YXbA3vDw/ACI4MEsnoDpn6ZNm7GnZgtAcONJyPhOP8tNJQavQ==}
+
+  mdast-util-gfm-footnote@2.1.0:
+    resolution: {integrity: sha512-sqpDWlsHn7Ac9GNZQMeUzPQSMzR6Wv0WKRNvQRg0KqHh02fpTz69Qc1QSseNX29bhz1ROIyNyxExfawVKTm1GQ==}
+
+  mdast-util-gfm-strikethrough@2.0.0:
+    resolution: {integrity: sha512-mKKb915TF+OC5ptj5bJ7WFRPdYtuHv0yTRxK2tJvi+BDqbkiG7h7u/9SI89nRAYcmap2xHQL9D+QG/6wSrTtXg==}
+
+  mdast-util-gfm-table@2.0.0:
+    resolution: {integrity: sha512-78UEvebzz/rJIxLvE7ZtDd/vIQ0RHv+3Mh5DR96p7cS7HsBhYIICDBCu8csTNWNO6tBWfqXPWekRuj2FNOGOZg==}
+
+  mdast-util-gfm-task-list-item@2.0.0:
+    resolution: {integrity: sha512-IrtvNvjxC1o06taBAVJznEnkiHxLFTzgonUdy8hzFVeDun0uTjxxrRGVaNFqkU1wJR3RBPEfsxmU6jDWPofrTQ==}
+
+  mdast-util-gfm@3.1.0:
+    resolution: {integrity: sha512-0ulfdQOM3ysHhCJ1p06l0b0VKlhU0wuQs3thxZQagjcjPrlFRqY215uZGHHJan9GEAXd9MbfPjFJz+qMkVR6zQ==}
+
+  mdast-util-mdx-expression@2.0.1:
+    resolution: {integrity: sha512-J6f+9hUp+ldTZqKRSg7Vw5V6MqjATc+3E4gf3CFNcuZNWD8XdyI6zQ8GqH7f8169MM6P7hMBRDVGnn7oHB9kXQ==}
+
+  mdast-util-mdx-jsx@3.2.0:
+    resolution: {integrity: sha512-lj/z8v0r6ZtsN/cGNNtemmmfoLAFZnjMbNyLzBafjzikOM+glrjNHPlf6lQDOTccj9n5b0PPihEBbhneMyGs1Q==}
+
+  mdast-util-mdxjs-esm@2.0.1:
+    resolution: {integrity: sha512-EcmOpxsZ96CvlP03NghtH1EsLtr0n9Tm4lPUJUBccV9RwUOneqSycg19n5HGzCf+10LozMRSObtVr3ee1WoHtg==}
+
+  mdast-util-phrasing@4.1.0:
+    resolution: {integrity: sha512-TqICwyvJJpBwvGAMZjj4J2n0X8QWp21b9l0o7eXyVJ25YNWYbJDVIyD1bZXE6WtV6RmKJVYmQAKWa0zWOABz2w==}
+
+  mdast-util-to-hast@13.2.1:
+    resolution: {integrity: sha512-cctsq2wp5vTsLIcaymblUriiTcZd0CwWtCbLvrOzYCDZoWyMNV8sZ7krj09FSnsiJi3WVsHLM4k6Dq/yaPyCXA==}
+
+  mdast-util-to-markdown@2.1.2:
+    resolution: {integrity: sha512-xj68wMTvGXVOKonmog6LwyJKrYXZPvlwabaryTjLh9LuvovB/KAH+kvi8Gjj+7rJjsFi23nkUxRQv1KqSroMqA==}
+
+  mdast-util-to-string@4.0.0:
+    resolution: {integrity: sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg==}
+
   media-typer@1.1.0:
     resolution: {integrity: sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==}
     engines: {node: '>= 0.8'}
@@ -1465,6 +1656,90 @@ packages:
   merge-descriptors@2.0.0:
     resolution: {integrity: sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==}
     engines: {node: '>=18'}
+
+  micromark-core-commonmark@2.0.3:
+    resolution: {integrity: sha512-RDBrHEMSxVFLg6xvnXmb1Ayr2WzLAWjeSATAoxwKYJV94TeNavgoIdA0a9ytzDSVzBy2YKFK+emCPOEibLeCrg==}
+
+  micromark-extension-gfm-autolink-literal@2.1.0:
+    resolution: {integrity: sha512-oOg7knzhicgQ3t4QCjCWgTmfNhvQbDDnJeVu9v81r7NltNCVmhPy1fJRX27pISafdjL+SVc4d3l48Gb6pbRypw==}
+
+  micromark-extension-gfm-footnote@2.1.0:
+    resolution: {integrity: sha512-/yPhxI1ntnDNsiHtzLKYnE3vf9JZ6cAisqVDauhp4CEHxlb4uoOTxOCJ+9s51bIB8U1N1FJ1RXOKTIlD5B/gqw==}
+
+  micromark-extension-gfm-strikethrough@2.1.0:
+    resolution: {integrity: sha512-ADVjpOOkjz1hhkZLlBiYA9cR2Anf8F4HqZUO6e5eDcPQd0Txw5fxLzzxnEkSkfnD0wziSGiv7sYhk/ktvbf1uw==}
+
+  micromark-extension-gfm-table@2.1.1:
+    resolution: {integrity: sha512-t2OU/dXXioARrC6yWfJ4hqB7rct14e8f7m0cbI5hUmDyyIlwv5vEtooptH8INkbLzOatzKuVbQmAYcbWoyz6Dg==}
+
+  micromark-extension-gfm-tagfilter@2.0.0:
+    resolution: {integrity: sha512-xHlTOmuCSotIA8TW1mDIM6X2O1SiX5P9IuDtqGonFhEK0qgRI4yeC6vMxEV2dgyr2TiD+2PQ10o+cOhdVAcwfg==}
+
+  micromark-extension-gfm-task-list-item@2.1.0:
+    resolution: {integrity: sha512-qIBZhqxqI6fjLDYFTBIa4eivDMnP+OZqsNwmQ3xNLE4Cxwc+zfQEfbs6tzAo2Hjq+bh6q5F+Z8/cksrLFYWQQw==}
+
+  micromark-extension-gfm@3.0.0:
+    resolution: {integrity: sha512-vsKArQsicm7t0z2GugkCKtZehqUm31oeGBV/KVSorWSy8ZlNAv7ytjFhvaryUiCUJYqs+NoE6AFhpQvBTM6Q4w==}
+
+  micromark-factory-destination@2.0.1:
+    resolution: {integrity: sha512-Xe6rDdJlkmbFRExpTOmRj9N3MaWmbAgdpSrBQvCFqhezUn4AHqJHbaEnfbVYYiexVSs//tqOdY/DxhjdCiJnIA==}
+
+  micromark-factory-label@2.0.1:
+    resolution: {integrity: sha512-VFMekyQExqIW7xIChcXn4ok29YE3rnuyveW3wZQWWqF4Nv9Wk5rgJ99KzPvHjkmPXF93FXIbBp6YdW3t71/7Vg==}
+
+  micromark-factory-space@2.0.1:
+    resolution: {integrity: sha512-zRkxjtBxxLd2Sc0d+fbnEunsTj46SWXgXciZmHq0kDYGnck/ZSGj9/wULTV95uoeYiK5hRXP2mJ98Uo4cq/LQg==}
+
+  micromark-factory-title@2.0.1:
+    resolution: {integrity: sha512-5bZ+3CjhAd9eChYTHsjy6TGxpOFSKgKKJPJxr293jTbfry2KDoWkhBb6TcPVB4NmzaPhMs1Frm9AZH7OD4Cjzw==}
+
+  micromark-factory-whitespace@2.0.1:
+    resolution: {integrity: sha512-Ob0nuZ3PKt/n0hORHyvoD9uZhr+Za8sFoP+OnMcnWK5lngSzALgQYKMr9RJVOWLqQYuyn6ulqGWSXdwf6F80lQ==}
+
+  micromark-util-character@2.1.1:
+    resolution: {integrity: sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q==}
+
+  micromark-util-chunked@2.0.1:
+    resolution: {integrity: sha512-QUNFEOPELfmvv+4xiNg2sRYeS/P84pTW0TCgP5zc9FpXetHY0ab7SxKyAQCNCc1eK0459uoLI1y5oO5Vc1dbhA==}
+
+  micromark-util-classify-character@2.0.1:
+    resolution: {integrity: sha512-K0kHzM6afW/MbeWYWLjoHQv1sgg2Q9EccHEDzSkxiP/EaagNzCm7T/WMKZ3rjMbvIpvBiZgwR3dKMygtA4mG1Q==}
+
+  micromark-util-combine-extensions@2.0.1:
+    resolution: {integrity: sha512-OnAnH8Ujmy59JcyZw8JSbK9cGpdVY44NKgSM7E9Eh7DiLS2E9RNQf0dONaGDzEG9yjEl5hcqeIsj4hfRkLH/Bg==}
+
+  micromark-util-decode-numeric-character-reference@2.0.2:
+    resolution: {integrity: sha512-ccUbYk6CwVdkmCQMyr64dXz42EfHGkPQlBj5p7YVGzq8I7CtjXZJrubAYezf7Rp+bjPseiROqe7G6foFd+lEuw==}
+
+  micromark-util-decode-string@2.0.1:
+    resolution: {integrity: sha512-nDV/77Fj6eH1ynwscYTOsbK7rR//Uj0bZXBwJZRfaLEJ1iGBR6kIfNmlNqaqJf649EP0F3NWNdeJi03elllNUQ==}
+
+  micromark-util-encode@2.0.1:
+    resolution: {integrity: sha512-c3cVx2y4KqUnwopcO9b/SCdo2O67LwJJ/UyqGfbigahfegL9myoEFoDYZgkT7f36T0bLrM9hZTAaAyH+PCAXjw==}
+
+  micromark-util-html-tag-name@2.0.1:
+    resolution: {integrity: sha512-2cNEiYDhCWKI+Gs9T0Tiysk136SnR13hhO8yW6BGNyhOC4qYFnwF1nKfD3HFAIXA5c45RrIG1ub11GiXeYd1xA==}
+
+  micromark-util-normalize-identifier@2.0.1:
+    resolution: {integrity: sha512-sxPqmo70LyARJs0w2UclACPUUEqltCkJ6PhKdMIDuJ3gSf/Q+/GIe3WKl0Ijb/GyH9lOpUkRAO2wp0GVkLvS9Q==}
+
+  micromark-util-resolve-all@2.0.1:
+    resolution: {integrity: sha512-VdQyxFWFT2/FGJgwQnJYbe1jjQoNTS4RjglmSjTUlpUMa95Htx9NHeYW4rGDJzbjvCsl9eLjMQwGeElsqmzcHg==}
+
+  micromark-util-sanitize-uri@2.0.1:
+    resolution: {integrity: sha512-9N9IomZ/YuGGZZmQec1MbgxtlgougxTodVwDzzEouPKo3qFWvymFHWcnDi2vzV1ff6kas9ucW+o3yzJK9YB1AQ==}
+
+  micromark-util-subtokenize@2.1.0:
+    resolution: {integrity: sha512-XQLu552iSctvnEcgXw6+Sx75GflAPNED1qx7eBJ+wydBb2KCbRZe+NwvIEEMM83uml1+2WSXpBAcp9IUCgCYWA==}
+
+  micromark-util-symbol@2.0.1:
+    resolution: {integrity: sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q==}
+
+  micromark-util-types@2.0.2:
+    resolution: {integrity: sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA==}
+
+  micromark@4.0.2:
+    resolution: {integrity: sha512-zpe98Q6kvavpCr1NPVSCMebCKfD7CA2NqZ+rykeNhONIJBpc1tFKt9hucLGwha3jNTNI8lHpctWJWoimVF4PfA==}
 
   mime-db@1.54.0:
     resolution: {integrity: sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==}
@@ -1571,6 +1846,9 @@ packages:
     resolution: {integrity: sha512-BZOr3nRQHOntUjTrH8+Lh54smKHoHyur8We1V8DSMVrl5A2malOOwuJRnKRDjSnkoeBh4at6BwEnb5I7Jl31wg==}
     engines: {node: '>=8'}
 
+  parse-entities@4.0.2:
+    resolution: {integrity: sha512-GG2AQYWoLgL877gQIKeRPGO1xF9+eG1ujIb5soS5gPvLQ1y2o8FL90w2QWNdf9I361Mpp7726c+lj3U0qK1uGw==}
+
   parseurl@1.3.3:
     resolution: {integrity: sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==}
     engines: {node: '>= 0.8'}
@@ -1619,6 +1897,10 @@ packages:
     deprecated: No longer maintained. Please contact the author of the relevant native addon; alternatives are available.
     hasBin: true
 
+  prismjs@1.30.0:
+    resolution: {integrity: sha512-DEvV2ZF2r2/63V+tK8hQvrR2ZGn10srHbXviTlcv7Kpzw8jWiNTqbVgjO3IY8RxrrOUF8VPMQQFysYYYv0YZxw==}
+    engines: {node: '>=6'}
+
   proc-log@6.1.0:
     resolution: {integrity: sha512-iG+GYldRf2BQ0UDUAd6JQ/RwzaQy6mXmsk/IzlYyal4A4SNFw54MeH4/tLkF4I5WoWG9SQwuqWzS99jaFQHBuQ==}
     engines: {node: ^20.17.0 || >=22.9.0}
@@ -1626,6 +1908,9 @@ packages:
   progress@2.0.3:
     resolution: {integrity: sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==}
     engines: {node: '>=0.4.0'}
+
+  property-information@7.1.0:
+    resolution: {integrity: sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ==}
 
   proxy-addr@2.0.7:
     resolution: {integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==}
@@ -1659,6 +1944,24 @@ packages:
     peerDependencies:
       react: ^19.2.5
 
+  react-markdown@10.1.0:
+    resolution: {integrity: sha512-qKxVopLT/TyA6BX3Ue5NwabOsAzm0Q7kAPwq6L+wWDwisYs7R8vZ0nRXqq6rkueboxpkjvLGU9fWifiX/ZZFxQ==}
+    peerDependencies:
+      '@types/react': '>=18'
+      react: '>=18'
+
+  react-resizable-panels@4.10.0:
+    resolution: {integrity: sha512-frjewRQt7TCv/vCH1pJfjZ7RxAhr5pKuqVQtVgzFq/vherxBFOWyC3xMbryx5Ti2wylViGUFc93Etg4rB3E0UA==}
+    peerDependencies:
+      react: ^18.0.0 || ^19.0.0
+      react-dom: ^18.0.0 || ^19.0.0
+
+  react-syntax-highlighter@16.1.1:
+    resolution: {integrity: sha512-PjVawBGy80C6YbC5DDZJeUjBmC7skaoEUdvfFQediQHgCL7aKyVHe57SaJGfQsloGDac+gCpTfRdtxzWWKmCXA==}
+    engines: {node: '>= 16.20.2'}
+    peerDependencies:
+      react: '>= 0.14.0'
+
   react@19.2.5:
     resolution: {integrity: sha512-llUJLzz1zTUBrskt2pwZgLq59AemifIftw4aB7JxOqf1HY2FDaGDxgwpAPVzHU1kdWabH7FauP4i1oEeer2WCA==}
     engines: {node: '>=0.10.0'}
@@ -1670,6 +1973,21 @@ packages:
   readable-stream@3.6.2:
     resolution: {integrity: sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==}
     engines: {node: '>= 6'}
+
+  refractor@5.0.0:
+    resolution: {integrity: sha512-QXOrHQF5jOpjjLfiNk5GFnWhRXvxjUVnlFxkeDmewR5sXkr3iM46Zo+CnRR8B+MDVqkULW4EcLVcRBNOPXHosw==}
+
+  remark-gfm@4.0.1:
+    resolution: {integrity: sha512-1quofZ2RQ9EWdeN34S79+KExV1764+wCUGop5CPL1WGdD0ocPpu91lzPGbwWMECpEpd42kJGQwzRfyov9j4yNg==}
+
+  remark-parse@11.0.0:
+    resolution: {integrity: sha512-FCxlKLNGknS5ba/1lmpYijMUzX2esxW5xQqjWxw2eHFfS2MSdaHVINFmhjo+qN1WhZhNimq0dZATN9pH0IDrpA==}
+
+  remark-rehype@11.1.2:
+    resolution: {integrity: sha512-Dh7l57ianaEoIpzbp0PC9UKAdCSVklD8E5Rpw7ETfbTl3FqcOOgq5q2LVDhgGCkaBv7p24JXikPdvhhmHvKMsw==}
+
+  remark-stringify@11.0.0:
+    resolution: {integrity: sha512-1OSmLd3awB/t8qdoEOMazZkNsfVTeY4fTsgzcQFdXNq8ToTN4ZGwrMnlda4K6smTFKD+GRV6O48i6Z4iKgPPpw==}
 
   require-from-string@2.0.2:
     resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
@@ -1770,6 +2088,9 @@ packages:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
     engines: {node: '>=0.10.0'}
 
+  space-separated-tokens@2.0.2:
+    resolution: {integrity: sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==}
+
   sprintf-js@1.1.3:
     resolution: {integrity: sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==}
 
@@ -1786,9 +2107,18 @@ packages:
   string_decoder@1.3.0:
     resolution: {integrity: sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==}
 
+  stringify-entities@4.0.4:
+    resolution: {integrity: sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==}
+
   strip-json-comments@2.0.1:
     resolution: {integrity: sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==}
     engines: {node: '>=0.10.0'}
+
+  style-to-js@1.1.21:
+    resolution: {integrity: sha512-RjQetxJrrUJLQPHbLku6U/ocGtzyjbJMP9lCNK7Ag0CNh690nSH8woqWH9u16nMjYBAok+i7JO1NP2pOy8IsPQ==}
+
+  style-to-object@1.0.14:
+    resolution: {integrity: sha512-LIN7rULI0jBscWQYaSswptyderlarFkjQ+t79nzty8tcIAceVomEVlLzH5VP4Cmsv6MtKhs7qaAiwlcp+Mgaxw==}
 
   sumchecker@3.0.1:
     resolution: {integrity: sha512-MvjXzkz/BOfyVDkG0oFOtBxHX2u3gKbMHIF/dXblZsgD3BWOFLmHovIpZY7BykJdAjcqRCBi1WYBNdEC9yI7vg==}
@@ -1824,6 +2154,12 @@ packages:
     resolution: {integrity: sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==}
     engines: {node: '>=0.6'}
 
+  trim-lines@3.0.1:
+    resolution: {integrity: sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==}
+
+  trough@2.2.0:
+    resolution: {integrity: sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw==}
+
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
 
@@ -1858,6 +2194,24 @@ packages:
     resolution: {integrity: sha512-ZgpWDC5gmNiuY9CnLVXEH8rl50xhRCuLNA97fAUnKi8RRuV4E6KG31pDTsLVUKnohJE0I3XDrTeEydAXRw47xg==}
     engines: {node: '>=18.17'}
 
+  unified@11.0.5:
+    resolution: {integrity: sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==}
+
+  unist-util-is@6.0.1:
+    resolution: {integrity: sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g==}
+
+  unist-util-position@5.0.0:
+    resolution: {integrity: sha512-fucsC7HjXvkB5R3kTCO7kUjRdrS0BJt3M/FPxmHMBOm8JQi2BsHAHFsy27E0EolP8rp0NzXsJ+jNPyDWvOJZPA==}
+
+  unist-util-stringify-position@4.0.0:
+    resolution: {integrity: sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==}
+
+  unist-util-visit-parents@6.0.2:
+    resolution: {integrity: sha512-goh1s1TBrqSqukSc8wrjwWhL0hiJxgA8m4kFxGlQ+8FYQ3C/m11FcTs4YYem7V664AhHVvgoQLk890Ssdsr2IQ==}
+
+  unist-util-visit@5.1.0:
+    resolution: {integrity: sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg==}
+
   universalify@0.1.2:
     resolution: {integrity: sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==}
     engines: {node: '>= 4.0.0'}
@@ -1878,6 +2232,12 @@ packages:
   vary@1.1.2:
     resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
     engines: {node: '>= 0.8'}
+
+  vfile-message@4.0.3:
+    resolution: {integrity: sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw==}
+
+  vfile@6.0.3:
+    resolution: {integrity: sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==}
 
   vite@8.0.10:
     resolution: {integrity: sha512-rZuUu9j6J5uotLDs+cAA4O5H4K1SfPliUlQwqa6YEwSrWDZzP4rhm00oJR5snMewjxF5V/K3D4kctsUTsIU9Mw==}
@@ -2017,6 +2377,9 @@ packages:
       use-sync-external-store:
         optional: true
 
+  zwitch@2.0.4:
+    resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
+
 snapshots:
 
   '@babel/code-frame@7.29.0':
@@ -2102,6 +2465,8 @@ snapshots:
     dependencies:
       '@babel/core': 7.29.0
       '@babel/helper-plugin-utils': 7.28.6
+
+  '@babel/runtime@7.29.2': {}
 
   '@babel/template@7.28.6':
     dependencies:
@@ -2502,9 +2867,21 @@ snapshots:
       '@types/deep-eql': 4.0.2
       assertion-error: 2.0.1
 
+  '@types/debug@4.1.13':
+    dependencies:
+      '@types/ms': 2.1.0
+
   '@types/deep-eql@4.0.2': {}
 
+  '@types/estree-jsx@1.0.5':
+    dependencies:
+      '@types/estree': 1.0.8
+
   '@types/estree@1.0.8': {}
+
+  '@types/hast@3.0.4':
+    dependencies:
+      '@types/unist': 3.0.3
 
   '@types/http-cache-semantics@4.2.0': {}
 
@@ -2514,6 +2891,12 @@ snapshots:
     dependencies:
       '@types/node': 25.6.0
 
+  '@types/mdast@4.0.4':
+    dependencies:
+      '@types/unist': 3.0.3
+
+  '@types/ms@2.1.0': {}
+
   '@types/node@24.12.2':
     dependencies:
       undici-types: 7.16.0
@@ -2522,7 +2905,13 @@ snapshots:
     dependencies:
       undici-types: 7.19.2
 
+  '@types/prismjs@1.26.6': {}
+
   '@types/react-dom@19.2.3(@types/react@19.2.14)':
+    dependencies:
+      '@types/react': 19.2.14
+
+  '@types/react-syntax-highlighter@15.5.13':
     dependencies:
       '@types/react': 19.2.14
 
@@ -2534,10 +2923,16 @@ snapshots:
     dependencies:
       '@types/node': 25.6.0
 
+  '@types/unist@2.0.11': {}
+
+  '@types/unist@3.0.3': {}
+
   '@types/yauzl@2.10.3':
     dependencies:
       '@types/node': 25.6.0
     optional: true
+
+  '@ungap/structured-clone@1.3.0': {}
 
   '@vitejs/plugin-react@6.0.1(vite@8.0.10(@types/node@25.6.0)(esbuild@0.27.7)(tsx@4.21.0))':
     dependencies:
@@ -2612,6 +3007,8 @@ snapshots:
   argparse@2.0.1: {}
 
   assertion-error@2.0.1: {}
+
+  bail@2.0.2: {}
 
   base64-js@1.5.1: {}
 
@@ -2692,7 +3089,17 @@ snapshots:
 
   caniuse-lite@1.0.30001790: {}
 
+  ccount@2.0.1: {}
+
   chai@6.2.2: {}
+
+  character-entities-html4@2.1.0: {}
+
+  character-entities-legacy@3.0.0: {}
+
+  character-entities@2.0.2: {}
+
+  character-reference-invalid@2.0.1: {}
 
   chownr@1.1.4: {}
 
@@ -2701,6 +3108,8 @@ snapshots:
   clone-response@1.0.3:
     dependencies:
       mimic-response: 1.0.1
+
+  comma-separated-tokens@2.0.3: {}
 
   content-disposition@1.1.0: {}
 
@@ -2729,6 +3138,10 @@ snapshots:
     dependencies:
       ms: 2.1.3
 
+  decode-named-character-reference@1.3.0:
+    dependencies:
+      character-entities: 2.0.2
+
   decompress-response@6.0.0:
     dependencies:
       mimic-response: 3.1.0
@@ -2753,10 +3166,16 @@ snapshots:
 
   depd@2.0.0: {}
 
+  dequal@2.0.3: {}
+
   detect-libc@2.1.2: {}
 
   detect-node@2.1.0:
     optional: true
+
+  devlop@1.1.0:
+    dependencies:
+      dequal: 2.0.3
 
   dunder-proto@1.0.1:
     dependencies:
@@ -2874,6 +3293,10 @@ snapshots:
   escape-string-regexp@4.0.0:
     optional: true
 
+  escape-string-regexp@5.0.0: {}
+
+  estree-util-is-identifier-name@3.0.0: {}
+
   estree-walker@3.0.3:
     dependencies:
       '@types/estree': 1.0.8
@@ -2930,6 +3353,8 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  extend@3.0.2: {}
+
   extract-zip@2.0.1:
     dependencies:
       debug: 4.4.3
@@ -2943,6 +3368,10 @@ snapshots:
   fast-deep-equal@3.1.3: {}
 
   fast-uri@3.1.0: {}
+
+  fault@1.0.4:
+    dependencies:
+      format: 0.2.2
 
   fd-slicer@1.1.0:
     dependencies:
@@ -2964,6 +3393,8 @@ snapshots:
       statuses: 2.0.2
     transitivePeerDependencies:
       - supports-color
+
+  format@0.2.2: {}
 
   forwarded@0.2.0: {}
 
@@ -3060,7 +3491,49 @@ snapshots:
     dependencies:
       function-bind: 1.1.2
 
+  hast-util-parse-selector@4.0.0:
+    dependencies:
+      '@types/hast': 3.0.4
+
+  hast-util-to-jsx-runtime@2.3.6:
+    dependencies:
+      '@types/estree': 1.0.8
+      '@types/hast': 3.0.4
+      '@types/unist': 3.0.3
+      comma-separated-tokens: 2.0.3
+      devlop: 1.1.0
+      estree-util-is-identifier-name: 3.0.0
+      hast-util-whitespace: 3.0.0
+      mdast-util-mdx-expression: 2.0.1
+      mdast-util-mdx-jsx: 3.2.0
+      mdast-util-mdxjs-esm: 2.0.1
+      property-information: 7.1.0
+      space-separated-tokens: 2.0.2
+      style-to-js: 1.1.21
+      unist-util-position: 5.0.0
+      vfile-message: 4.0.3
+    transitivePeerDependencies:
+      - supports-color
+
+  hast-util-whitespace@3.0.0:
+    dependencies:
+      '@types/hast': 3.0.4
+
+  hastscript@9.0.1:
+    dependencies:
+      '@types/hast': 3.0.4
+      comma-separated-tokens: 2.0.3
+      hast-util-parse-selector: 4.0.0
+      property-information: 7.1.0
+      space-separated-tokens: 2.0.2
+
+  highlight.js@10.7.3: {}
+
+  highlightjs-vue@1.0.0: {}
+
   hono@4.12.15: {}
+
+  html-url-attributes@3.0.1: {}
 
   http-cache-semantics@4.2.0: {}
 
@@ -3087,9 +3560,24 @@ snapshots:
 
   ini@1.3.8: {}
 
+  inline-style-parser@0.2.7: {}
+
   ip-address@10.1.0: {}
 
   ipaddr.js@1.9.1: {}
+
+  is-alphabetical@2.0.1: {}
+
+  is-alphanumerical@2.0.1:
+    dependencies:
+      is-alphabetical: 2.0.1
+      is-decimal: 2.0.1
+
+  is-decimal@2.0.1: {}
+
+  is-hexadecimal@2.0.1: {}
+
+  is-plain-obj@4.1.0: {}
 
   is-promise@4.0.0: {}
 
@@ -3175,7 +3663,14 @@ snapshots:
       lightningcss-win32-arm64-msvc: 1.32.0
       lightningcss-win32-x64-msvc: 1.32.0
 
+  longest-streak@3.1.0: {}
+
   lowercase-keys@2.0.0: {}
+
+  lowlight@1.20.0:
+    dependencies:
+      fault: 1.0.4
+      highlight.js: 10.7.3
 
   lru-cache@5.1.1:
     dependencies:
@@ -3189,6 +3684,8 @@ snapshots:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
 
+  markdown-table@3.0.4: {}
+
   matcher@3.0.0:
     dependencies:
       escape-string-regexp: 4.0.0
@@ -3196,9 +3693,353 @@ snapshots:
 
   math-intrinsics@1.1.0: {}
 
+  mdast-util-find-and-replace@3.0.2:
+    dependencies:
+      '@types/mdast': 4.0.4
+      escape-string-regexp: 5.0.0
+      unist-util-is: 6.0.1
+      unist-util-visit-parents: 6.0.2
+
+  mdast-util-from-markdown@2.0.3:
+    dependencies:
+      '@types/mdast': 4.0.4
+      '@types/unist': 3.0.3
+      decode-named-character-reference: 1.3.0
+      devlop: 1.1.0
+      mdast-util-to-string: 4.0.0
+      micromark: 4.0.2
+      micromark-util-decode-numeric-character-reference: 2.0.2
+      micromark-util-decode-string: 2.0.1
+      micromark-util-normalize-identifier: 2.0.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+      unist-util-stringify-position: 4.0.0
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-gfm-autolink-literal@2.0.1:
+    dependencies:
+      '@types/mdast': 4.0.4
+      ccount: 2.0.1
+      devlop: 1.1.0
+      mdast-util-find-and-replace: 3.0.2
+      micromark-util-character: 2.1.1
+
+  mdast-util-gfm-footnote@2.1.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      devlop: 1.1.0
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-to-markdown: 2.1.2
+      micromark-util-normalize-identifier: 2.0.1
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-gfm-strikethrough@2.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-to-markdown: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-gfm-table@2.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      devlop: 1.1.0
+      markdown-table: 3.0.4
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-to-markdown: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-gfm-task-list-item@2.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      devlop: 1.1.0
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-to-markdown: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-gfm@3.1.0:
+    dependencies:
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-gfm-autolink-literal: 2.0.1
+      mdast-util-gfm-footnote: 2.1.0
+      mdast-util-gfm-strikethrough: 2.0.0
+      mdast-util-gfm-table: 2.0.0
+      mdast-util-gfm-task-list-item: 2.0.0
+      mdast-util-to-markdown: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-mdx-expression@2.0.1:
+    dependencies:
+      '@types/estree-jsx': 1.0.5
+      '@types/hast': 3.0.4
+      '@types/mdast': 4.0.4
+      devlop: 1.1.0
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-to-markdown: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-mdx-jsx@3.2.0:
+    dependencies:
+      '@types/estree-jsx': 1.0.5
+      '@types/hast': 3.0.4
+      '@types/mdast': 4.0.4
+      '@types/unist': 3.0.3
+      ccount: 2.0.1
+      devlop: 1.1.0
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-to-markdown: 2.1.2
+      parse-entities: 4.0.2
+      stringify-entities: 4.0.4
+      unist-util-stringify-position: 4.0.0
+      vfile-message: 4.0.3
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-mdxjs-esm@2.0.1:
+    dependencies:
+      '@types/estree-jsx': 1.0.5
+      '@types/hast': 3.0.4
+      '@types/mdast': 4.0.4
+      devlop: 1.1.0
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-to-markdown: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-phrasing@4.1.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      unist-util-is: 6.0.1
+
+  mdast-util-to-hast@13.2.1:
+    dependencies:
+      '@types/hast': 3.0.4
+      '@types/mdast': 4.0.4
+      '@ungap/structured-clone': 1.3.0
+      devlop: 1.1.0
+      micromark-util-sanitize-uri: 2.0.1
+      trim-lines: 3.0.1
+      unist-util-position: 5.0.0
+      unist-util-visit: 5.1.0
+      vfile: 6.0.3
+
+  mdast-util-to-markdown@2.1.2:
+    dependencies:
+      '@types/mdast': 4.0.4
+      '@types/unist': 3.0.3
+      longest-streak: 3.1.0
+      mdast-util-phrasing: 4.1.0
+      mdast-util-to-string: 4.0.0
+      micromark-util-classify-character: 2.0.1
+      micromark-util-decode-string: 2.0.1
+      unist-util-visit: 5.1.0
+      zwitch: 2.0.4
+
+  mdast-util-to-string@4.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+
   media-typer@1.1.0: {}
 
   merge-descriptors@2.0.0: {}
+
+  micromark-core-commonmark@2.0.3:
+    dependencies:
+      decode-named-character-reference: 1.3.0
+      devlop: 1.1.0
+      micromark-factory-destination: 2.0.1
+      micromark-factory-label: 2.0.1
+      micromark-factory-space: 2.0.1
+      micromark-factory-title: 2.0.1
+      micromark-factory-whitespace: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-chunked: 2.0.1
+      micromark-util-classify-character: 2.0.1
+      micromark-util-html-tag-name: 2.0.1
+      micromark-util-normalize-identifier: 2.0.1
+      micromark-util-resolve-all: 2.0.1
+      micromark-util-subtokenize: 2.1.0
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm-autolink-literal@2.1.0:
+    dependencies:
+      micromark-util-character: 2.1.1
+      micromark-util-sanitize-uri: 2.0.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm-footnote@2.1.0:
+    dependencies:
+      devlop: 1.1.0
+      micromark-core-commonmark: 2.0.3
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-normalize-identifier: 2.0.1
+      micromark-util-sanitize-uri: 2.0.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm-strikethrough@2.1.0:
+    dependencies:
+      devlop: 1.1.0
+      micromark-util-chunked: 2.0.1
+      micromark-util-classify-character: 2.0.1
+      micromark-util-resolve-all: 2.0.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm-table@2.1.1:
+    dependencies:
+      devlop: 1.1.0
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm-tagfilter@2.0.0:
+    dependencies:
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm-task-list-item@2.1.0:
+    dependencies:
+      devlop: 1.1.0
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm@3.0.0:
+    dependencies:
+      micromark-extension-gfm-autolink-literal: 2.1.0
+      micromark-extension-gfm-footnote: 2.1.0
+      micromark-extension-gfm-strikethrough: 2.1.0
+      micromark-extension-gfm-table: 2.1.1
+      micromark-extension-gfm-tagfilter: 2.0.0
+      micromark-extension-gfm-task-list-item: 2.1.0
+      micromark-util-combine-extensions: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-factory-destination@2.0.1:
+    dependencies:
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-factory-label@2.0.1:
+    dependencies:
+      devlop: 1.1.0
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-factory-space@2.0.1:
+    dependencies:
+      micromark-util-character: 2.1.1
+      micromark-util-types: 2.0.2
+
+  micromark-factory-title@2.0.1:
+    dependencies:
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-factory-whitespace@2.0.1:
+    dependencies:
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-util-character@2.1.1:
+    dependencies:
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-util-chunked@2.0.1:
+    dependencies:
+      micromark-util-symbol: 2.0.1
+
+  micromark-util-classify-character@2.0.1:
+    dependencies:
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-util-combine-extensions@2.0.1:
+    dependencies:
+      micromark-util-chunked: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-util-decode-numeric-character-reference@2.0.2:
+    dependencies:
+      micromark-util-symbol: 2.0.1
+
+  micromark-util-decode-string@2.0.1:
+    dependencies:
+      decode-named-character-reference: 1.3.0
+      micromark-util-character: 2.1.1
+      micromark-util-decode-numeric-character-reference: 2.0.2
+      micromark-util-symbol: 2.0.1
+
+  micromark-util-encode@2.0.1: {}
+
+  micromark-util-html-tag-name@2.0.1: {}
+
+  micromark-util-normalize-identifier@2.0.1:
+    dependencies:
+      micromark-util-symbol: 2.0.1
+
+  micromark-util-resolve-all@2.0.1:
+    dependencies:
+      micromark-util-types: 2.0.2
+
+  micromark-util-sanitize-uri@2.0.1:
+    dependencies:
+      micromark-util-character: 2.1.1
+      micromark-util-encode: 2.0.1
+      micromark-util-symbol: 2.0.1
+
+  micromark-util-subtokenize@2.1.0:
+    dependencies:
+      devlop: 1.1.0
+      micromark-util-chunked: 2.0.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-util-symbol@2.0.1: {}
+
+  micromark-util-types@2.0.2: {}
+
+  micromark@4.0.2:
+    dependencies:
+      '@types/debug': 4.1.13
+      debug: 4.4.3
+      decode-named-character-reference: 1.3.0
+      devlop: 1.1.0
+      micromark-core-commonmark: 2.0.3
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-chunked: 2.0.1
+      micromark-util-combine-extensions: 2.0.1
+      micromark-util-decode-numeric-character-reference: 2.0.2
+      micromark-util-encode: 2.0.1
+      micromark-util-normalize-identifier: 2.0.1
+      micromark-util-resolve-all: 2.0.1
+      micromark-util-sanitize-uri: 2.0.1
+      micromark-util-subtokenize: 2.1.0
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+    transitivePeerDependencies:
+      - supports-color
 
   mime-db@1.54.0: {}
 
@@ -3286,6 +4127,16 @@ snapshots:
 
   p-cancelable@2.1.1: {}
 
+  parse-entities@4.0.2:
+    dependencies:
+      '@types/unist': 2.0.11
+      character-entities-legacy: 3.0.0
+      character-reference-invalid: 2.0.1
+      decode-named-character-reference: 1.3.0
+      is-alphanumerical: 2.0.1
+      is-decimal: 2.0.1
+      is-hexadecimal: 2.0.1
+
   parseurl@1.3.3: {}
 
   path-key@3.1.1: {}
@@ -3331,9 +4182,13 @@ snapshots:
       tar-fs: 2.1.4
       tunnel-agent: 0.6.0
 
+  prismjs@1.30.0: {}
+
   proc-log@6.1.0: {}
 
   progress@2.0.3: {}
+
+  property-information@7.1.0: {}
 
   proxy-addr@2.0.7:
     dependencies:
@@ -3372,6 +4227,39 @@ snapshots:
       react: 19.2.5
       scheduler: 0.27.0
 
+  react-markdown@10.1.0(@types/react@19.2.14)(react@19.2.5):
+    dependencies:
+      '@types/hast': 3.0.4
+      '@types/mdast': 4.0.4
+      '@types/react': 19.2.14
+      devlop: 1.1.0
+      hast-util-to-jsx-runtime: 2.3.6
+      html-url-attributes: 3.0.1
+      mdast-util-to-hast: 13.2.1
+      react: 19.2.5
+      remark-parse: 11.0.0
+      remark-rehype: 11.1.2
+      unified: 11.0.5
+      unist-util-visit: 5.1.0
+      vfile: 6.0.3
+    transitivePeerDependencies:
+      - supports-color
+
+  react-resizable-panels@4.10.0(react-dom@19.2.5(react@19.2.5))(react@19.2.5):
+    dependencies:
+      react: 19.2.5
+      react-dom: 19.2.5(react@19.2.5)
+
+  react-syntax-highlighter@16.1.1(react@19.2.5):
+    dependencies:
+      '@babel/runtime': 7.29.2
+      highlight.js: 10.7.3
+      highlightjs-vue: 1.0.0
+      lowlight: 1.20.0
+      prismjs: 1.30.0
+      react: 19.2.5
+      refractor: 5.0.0
+
   react@19.2.5: {}
 
   read-binary-file-arch@1.0.6:
@@ -3385,6 +4273,47 @@ snapshots:
       inherits: 2.0.4
       string_decoder: 1.3.0
       util-deprecate: 1.0.2
+
+  refractor@5.0.0:
+    dependencies:
+      '@types/hast': 3.0.4
+      '@types/prismjs': 1.26.6
+      hastscript: 9.0.1
+      parse-entities: 4.0.2
+
+  remark-gfm@4.0.1:
+    dependencies:
+      '@types/mdast': 4.0.4
+      mdast-util-gfm: 3.1.0
+      micromark-extension-gfm: 3.0.0
+      remark-parse: 11.0.0
+      remark-stringify: 11.0.0
+      unified: 11.0.5
+    transitivePeerDependencies:
+      - supports-color
+
+  remark-parse@11.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      mdast-util-from-markdown: 2.0.3
+      micromark-util-types: 2.0.2
+      unified: 11.0.5
+    transitivePeerDependencies:
+      - supports-color
+
+  remark-rehype@11.1.2:
+    dependencies:
+      '@types/hast': 3.0.4
+      '@types/mdast': 4.0.4
+      mdast-util-to-hast: 13.2.1
+      unified: 11.0.5
+      vfile: 6.0.3
+
+  remark-stringify@11.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      mdast-util-to-markdown: 2.1.2
+      unified: 11.0.5
 
   require-from-string@2.0.2: {}
 
@@ -3528,6 +4457,8 @@ snapshots:
 
   source-map-js@1.2.1: {}
 
+  space-separated-tokens@2.0.2: {}
+
   sprintf-js@1.1.3:
     optional: true
 
@@ -3541,7 +4472,20 @@ snapshots:
     dependencies:
       safe-buffer: 5.2.1
 
+  stringify-entities@4.0.4:
+    dependencies:
+      character-entities-html4: 2.1.0
+      character-entities-legacy: 3.0.0
+
   strip-json-comments@2.0.1: {}
+
+  style-to-js@1.1.21:
+    dependencies:
+      style-to-object: 1.0.14
+
+  style-to-object@1.0.14:
+    dependencies:
+      inline-style-parser: 0.2.7
 
   sumchecker@3.0.1:
     dependencies:
@@ -3585,6 +4529,10 @@ snapshots:
 
   toidentifier@1.0.1: {}
 
+  trim-lines@3.0.1: {}
+
+  trough@2.2.0: {}
+
   tslib@2.8.1:
     optional: true
 
@@ -3616,6 +4564,39 @@ snapshots:
 
   undici@6.25.0: {}
 
+  unified@11.0.5:
+    dependencies:
+      '@types/unist': 3.0.3
+      bail: 2.0.2
+      devlop: 1.1.0
+      extend: 3.0.2
+      is-plain-obj: 4.1.0
+      trough: 2.2.0
+      vfile: 6.0.3
+
+  unist-util-is@6.0.1:
+    dependencies:
+      '@types/unist': 3.0.3
+
+  unist-util-position@5.0.0:
+    dependencies:
+      '@types/unist': 3.0.3
+
+  unist-util-stringify-position@4.0.0:
+    dependencies:
+      '@types/unist': 3.0.3
+
+  unist-util-visit-parents@6.0.2:
+    dependencies:
+      '@types/unist': 3.0.3
+      unist-util-is: 6.0.1
+
+  unist-util-visit@5.1.0:
+    dependencies:
+      '@types/unist': 3.0.3
+      unist-util-is: 6.0.1
+      unist-util-visit-parents: 6.0.2
+
   universalify@0.1.2: {}
 
   unpipe@1.0.0: {}
@@ -3629,6 +4610,16 @@ snapshots:
   util-deprecate@1.0.2: {}
 
   vary@1.1.2: {}
+
+  vfile-message@4.0.3:
+    dependencies:
+      '@types/unist': 3.0.3
+      unist-util-stringify-position: 4.0.0
+
+  vfile@6.0.3:
+    dependencies:
+      '@types/unist': 3.0.3
+      vfile-message: 4.0.3
 
   vite@8.0.10(@types/node@25.6.0)(esbuild@0.27.7)(tsx@4.21.0):
     dependencies:
@@ -3704,3 +4695,5 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.14
       react: 19.2.5
+
+  zwitch@2.0.4: {}


### PR DESCRIPTION
## Summary

按 02 F2.3 + F6.4 + F6.5 + F6.6 + 03 §六组件树,M0 简版 Hello World UI 升级到完整 Chat UI + 三栏可拖拽 + 历史回放 + 多 tab Settings。3 阶段拆分实施(发起人 #29 issue body 允许 12a / 12b),整合单 PR。

详见 commit messages:
- 5e72352 (12a) — MessageBubble + ToolCards + 三栏可拖拽 + 持久化
- e4720f5 (12b) — HistoryList + 历史回放 + SettingsOverlay 5 tabs

## D9-1 决策(5 条,详见 commit messages)

1. 不用 PanelGroup storage prop(sync vs async IPC 冲突)
2. react-resizable-panels v4 适配(Group / Separator / Layout 字典)
3. **InputBox 推后到 M2**(D-M1-7 不续聊)
4. **ExportButton + 完整 i18n 推后到 follow-up issue**
5. events.payload 解析失败 graceful degrade

## 通报点(无 GUI 截图,文字描述代替;Mac mini 真机统一校 #21+#22+#24+#28+#29)

详见 commit message 12b 段。简版:

- **通报 1**:MessageBubble 蓝底圆角 + markdown(代码块复制 + GFM 表格 + 链接 shell.openExternal);ToolCallCard / ToolResultCard 紫色,长文本折叠
- **通报 2 行为级**:HistoryList 左栏点击 → 中栏 SkillWorkArea phase 'replay' read-only 渲染 events 流
- **通报 3 i18n**:D9-1 推后,只 General tab 占位 select(动态文案 ack 不翻译)
- **通报 4 三栏拖拽**:react-resizable-panels v4,onLayoutChange debounce 500ms → settings.ui.layoutWidths;`sqlite3 ... WHERE key='ui.layoutWidths'` 验证

## 数字

- 19 文件 / +2,217 / -66
- desktop test 15/90 全过 / typecheck 0 / lint 0
- renderer 960 KB → 2.49 MB(+1.5 MB markdown stack 合理)

## Test plan

- [x] typecheck / lint / test / build 全过
- [x] CI 三平台待跑
- [ ] dev e2e Mac mini 真机统一校

## 工时 self-report(retrospective followup #4)

12a ~110 min + 12b ~75 min ≈ 3h。issue 估 3-4 天。

Closes #29

🤖 Generated with [Claude Code](https://claude.com/claude-code)