### PR TITLE
feat(skills): trade-email-writer — 6 场景 × 3 语气外贸邮件助手 (M1 #30 Part A)

### DIFF
--- a/packages/skill-runtime/__fixtures__/trade-email-writer/README.md
+++ b/packages/skill-runtime/__fixtures__/trade-email-writer/README.md
@@ -1,0 +1,53 @@
+# trade-email-writer — 外贸邮件助手
+
+为外贸出口方生成多版本英文邮件草稿,覆盖 6 种典型场景 × 3 种语气。
+
+## 使用流程
+
+1. 左栏 SkillPicker 选 "外贸邮件助手"
+2. 填表:
+   - **场景**:报价 / 议价 / 催付 / 催货 / 售后 / 跟进 选一个
+   - **上下文**:用中文描述(收件人是谁 / 之前发生什么 / 本次目的)。越具体输出越准
+   - **语气**:formal(正式)/ friendly(友好,与熟客)/ firm(坚定,问题升级时)
+   - **上一封邮件**(可选):粘贴对方上一封原文 → 触发 reply 模式
+3. 点"发送" → CC 生成 2-3 份不同 strategy 角度的草稿
+4. 草稿自动保存到 `~/.opentrad/drafts/trade-email-<场景>-<时间>-draft-N.md`
+5. Chat UI 渲染 markdown,可直接复制到邮件客户端发送
+
+## 行业术语速查(prompt 已内置常用词)
+
+| 术语 | 全称 | 含义 |
+|---|---|---|
+| FOB | Free On Board | 港口装船,后续运费风险买方承担 |
+| CIF | Cost, Insurance, Freight | 含运费 + 保险价 |
+| EXW | Ex Works | 出厂价(买家自取) |
+| DDP | Delivered Duty Paid | 完税交货 |
+| MOQ | Minimum Order Quantity | 起订量 |
+| RFQ | Request for Quotation | 询价 |
+| L/C | Letter of Credit | 信用证 |
+| T/T | Telegraphic Transfer | 电汇 |
+| D/P | Documents against Payment | 付款交单 |
+| B/L | Bill of Lading | 提单 |
+| FCL / LCL | Full / Less than Container Load | 整 / 拼柜 |
+| pro forma | Pro Forma Invoice | 形式发票(报价单) |
+
+## 隐私 / 安全
+
+- 草稿只存本地 `~/.opentrad/drafts/`,**OpenTrad 不上传任何邮件内容**
+- `mcp__*__send*` 工具显式 disallowed(不能直接发邮件,需用户复制到邮件客户端)
+- riskLevel='draft_only',M1 不需要 RiskGate 业务级弹窗
+
+## 示例
+
+- [报价场景示例](./examples/quotation.md)
+- [催付场景示例](./examples/chasing-payment.md)
+
+## prompt 调优
+
+prompt 在 `prompt.md`,M1 第一版可能产出"AI 味"较重的输出。发起人 dev 校时如发现:
+- 出现"As an AI assistant"开场白
+- 邮件英文不地道(Chinglish 模式)
+- 3 语气区别不明显(formal / firm 雷同)
+- 行业术语错用(如把 L/C 当 T/T)
+
+→ 直接编辑 `prompt.md` 调整 + 重跑 SkillPicker → 表单 → 看输出对比。retrospective-m1 时记录 prompt 演化历史。

--- a/packages/skill-runtime/__fixtures__/trade-email-writer/examples/chasing-payment.md
+++ b/packages/skill-runtime/__fixtures__/trade-email-writer/examples/chasing-payment.md
@@ -1,0 +1,103 @@
+# 催付场景示例
+
+## 输入
+
+- **scenario**: 催付
+- **context**: 越南买家 ABC Trading,30 天前付了 30% 定金 USD 1,500(PO #2025-001 总额 USD 5,000)。提单复印件已发 15 天前,余款 USD 3,500 应在见提单 7 天内付,现在已逾期 8 天。之前邮件未回。语气:firm(已耐心过,该升级)
+- **tone**: firm
+- **previousEmail**: (空,主动催)
+
+## 期望 prompt 输出(草稿示例)
+
+### Draft 1: 直接强势 + 设硬 deadline
+
+**Subject**: Urgent: Outstanding Balance USD 3,500 — PO #2025-001
+
+**Body**:
+Dear [Buyer Name],
+
+This email is a follow-up regarding the outstanding balance for PO #2025-001, which is now 8 days past due.
+
+**Payment summary**:
+- Total order value: USD 5,000
+- Deposit (30%): USD 1,500 — received [date]
+- Balance (70%): USD 3,500 — **8 days overdue**
+
+The B/L copy was sent on [date], and per our agreed terms the balance was due within 7 days of B/L receipt. We have not received your payment or any communication regarding the delay since then.
+
+Please remit USD 3,500 to the bank account previously provided **by [deadline, 7 days from today]**. If there is any issue blocking payment on your end, please reply to this email today so we can discuss a workable solution.
+
+Continued delay will affect our future business with us and our ability to extend credit terms on new orders.
+
+Best regards,
+[Your Name]
+[Your Company]
+
+---
+
+### Draft 2: 强势但留沟通空间(deadline + 提供方案)
+
+**Subject**: Action Required: Balance Payment for PO #2025-001 (Now 8 Days Overdue)
+
+**Body**:
+Dear [Buyer Name],
+
+I am writing regarding the unpaid balance of USD 3,500 for PO #2025-001, which became overdue 8 days ago.
+
+We understand circumstances can delay payment, but we have not received any update from your side since the B/L copy was sent on [date]. Without communication we have no way to plan our cash flow or process any new orders from your side.
+
+We need one of the following from you by **[deadline, 7 days from today]**:
+1. Full payment of USD 3,500 to the bank account on file, OR
+2. A short reply explaining the delay and a proposed payment date
+
+If we do not hear from you by [deadline], we will need to pause work on any open RFQs from your side and reassess our credit terms going forward.
+
+Best regards,
+[Your Name]
+[Your Company]
+
+---
+
+### Draft 3: 抄送对方上级 / 财务部门(firm 第三档,首次主动催付的真实最强手段)
+
+**Subject**: Outstanding Balance USD 3,500 — Escalating to Finance Team (PO #2025-001)
+
+**CC**: [Their CFO / Finance Manager email]
+
+**Body**:
+Dear [Buyer Name],
+
+Following up on PO #2025-001 — the outstanding balance of USD 3,500 became overdue 8 days ago, and we have not received a response to our prior communications.
+
+**Payment summary**:
+- Balance due: USD 3,500
+- Overdue: 8 days
+- B/L copy sent: [date]
+
+I have copied your finance team on this email to ensure visibility on this matter. If there are processing issues on your side that you have not been able to resolve, your finance colleagues may be able to reply directly.
+
+Please confirm payment by **[deadline, 5 days from today]**, or reply with a specific payment date. Bank details remain as previously provided.
+
+Best regards,
+[Your Name]
+[Your Company]
+
+---
+
+## Key phrases used
+
+- **8 days past due** / **8 days overdue**:具体天数比 "long overdue" / "very late" 有力。书面催付的数字精确度直接传达"我们在跟进,不是随便说说"
+- **per our agreed terms**:引用合约条款,把对话从"求情"变"行权",firm tone 的关键
+- **affect our future business with us / extend credit terms on new orders**(Draft 1):商业层面后果(非个人威胁),Western 商业语境标准升级语
+- **process any new orders from your side**(Draft 2):自然英语,避免 "your next order" 单数指代不清的 Chinglish 模式
+- **I have copied your finance team to ensure visibility**(Draft 3):firm 第三档的核心机制 — 用透明度施压而非威胁。"ensure visibility" 是 Western 公司内部沟通的中性短语,不让对方觉得被"打小报告"
+
+## Risk notes
+
+- **Draft 3 适用条件**:已有 1-2 轮催付未果,且能拿到对方财务 / 上级邮箱。本场景"首次主动催付"严格说应从 Draft 1 / 2 起手,**Draft 3 仅作"如对方持续不回应,7-14 天后第三轮升级"的预备模板**
+- **deadline 设置**:首次催付 7-10 天是行业惯例(给买家银行处理 + 跨境支付时间);抄送升级版用 5 天暗示"我已升级,需要快速回应"
+- **越南买家文化提示**:面子文化,公开施压(如群发抄送 cc 多人)会加剧抵触。Draft 3 抄送应**只 cc 1 个对方财务 / 上级**,绝不抄送"竞争对手"或"对方客户"
+- **建议私下沟通先于群发抄送**:第一次催付前,如有越南本地销售联系人或合作伙伴,用电话或 WhatsApp 私下了解情况,再决定是否走 firm 邮件。直接 firm 邮件而无私下沟通,可能错过"对方真有客观困难"的窗口
+- 如 Draft 3 后仍无回应(7-14 天),真要走法律 / collections,**先咨询当地法律**(中越贸易合同管辖权 / 仲裁条款 / CIETAC 等),不要在邮件里 bluff "Final Notice / certified mail / legal action"——99% 是吓自己,Western buyer 看穿后反而会硬扛
+
+发起人:**催付场景看 firm tone 三档(deadline + 后果暗示 / deadline + 提供方案 / deadline + 抄送上级)区别是否清楚、deadline 天数(7/7/5)是否符合外贸催收实践、Draft 3 抄送上级的 "ensure visibility" 透明度施压机制是否合理**。

--- a/packages/skill-runtime/__fixtures__/trade-email-writer/examples/quotation.md
+++ b/packages/skill-runtime/__fixtures__/trade-email-writer/examples/quotation.md
@@ -1,0 +1,78 @@
+# 报价场景示例
+
+## 输入
+
+- **scenario**: 报价
+- **context**: 美国买家 Acme Corp 询 1000 件无线鼠标,要 FOB 深圳价格,需 OEM 包装。我们 MOQ 500 件,我们成本 USD 4.50/件,FOB 5.20 美元/件,T/T 30% 定金 70% 见提单。lead time 25 天。希望同时给量价阶梯吸引大单。
+- **tone**: formal
+- **previousEmail**: (空,新邮件)
+
+## 期望 prompt 输出(草稿示例)
+
+### Draft 1: 标准报价 + 量价阶梯
+
+**Subject**: Quotation for 1,000 Wireless Mice (OEM, FOB Shenzhen)
+
+**Body**:
+Dear Sir / Madam,
+
+Thank you for your inquiry regarding our wireless mouse. Please find our quotation below for the requested quantity, with tier pricing for larger orders.
+
+**Item**: Wireless Mouse, OEM packaging
+**Quantity**: 1,000 pcs
+**Unit price**: USD 5.20 / pc, FOB Shenzhen
+**Total**: USD 5,200.00
+**Tier pricing** (for larger orders):
+- 2,000 - 4,999 pcs: USD 4.95 / pc
+- 5,000 + pcs: USD 4.80 / pc
+
+**Lead time**: 25 working days after deposit received and OEM artwork confirmed
+**Payment terms**: 30% T/T deposit, 70% balance against B/L copy
+**Validity**: This quotation is valid for 30 days from the date of this email
+
+Please confirm OEM packaging artwork at your earliest convenience so we can include design review in the lead time. Should you need a sample for evaluation, we are happy to ship one DDP at no charge.
+
+We look forward to your feedback.
+
+Best regards,
+[Your Name]
+[Your Company]
+
+---
+
+### Draft 2: 简洁版(单价 + 关键条款)
+
+**Subject**: Pricing for 1,000 OEM Wireless Mice — FOB Shenzhen USD 5.20
+
+**Body**:
+Dear Sir / Madam,
+
+Thank you for your interest in our wireless mouse.
+
+Quotation for 1,000 pcs (OEM packaging):
+- USD 5.20 per piece, FOB Shenzhen
+- 25-day lead time after deposit + artwork confirmation
+- 30% T/T deposit, 70% against B/L copy
+- Quote valid 30 days
+
+Should you require alternative quantities or any spec adjustment, please let us know and we will revise accordingly.
+
+Best regards,
+[Your Name]
+[Your Company]
+
+---
+
+## Key phrases used
+
+- **FOB Shenzhen**:Free On Board 深圳港。明确船上交货,后续海运 / 关税买方承担。美国买家通常熟悉此术语
+- **30% T/T deposit, 70% balance against B/L copy**:行业标准付款条款,定金后开工,见提单复印件付尾款。比"100% 预付"对买家友好,比"100% 见提单付"对卖家有保障
+- **MOQ**(隐含,因量 1000 > 500 起订未写出):1000 在 MOQ 之上,无需提示
+- **Lead time**:25 working days,行业标准节奏。**避免说"around 25 days"含糊**
+
+## Risk notes
+
+- 量价阶梯透露了规模化定价,买家可能借此压价。**对策**:tier pricing 写阶梯条件而非"我们成本能再降",维持议价空间
+- 标准条款 70% 见提单可能不被新买家接受(他们可能要求 100% 见提单付)。**对策**:Draft 2 简洁版可作首次接触;Draft 1 含条款适合已有信任基础
+
+发起人:**报价场景看英文是否地道、术语用法、量价阶梯展示节奏是否符合外贸惯例**。

--- a/packages/skill-runtime/__fixtures__/trade-email-writer/icon.svg
+++ b/packages/skill-runtime/__fixtures__/trade-email-writer/icon.svg
@@ -1,0 +1,7 @@
+<!-- trade-email-writer icon — M1 占位(蓝色信封)。M2 视品牌设计升级。 -->
+<svg xmlns="http://www.w3.org/2000/svg" width="64" height="64" viewBox="0 0 64 64" fill="none">
+  <rect x="6" y="14" width="52" height="36" rx="4" fill="#2563eb" stroke="#1e3a8a" stroke-width="2"/>
+  <path d="M6 18 L32 36 L58 18" stroke="white" stroke-width="2.5" fill="none"/>
+  <path d="M6 46 L24 30" stroke="white" stroke-width="1.5" fill="none" opacity="0.6"/>
+  <path d="M58 46 L40 30" stroke="white" stroke-width="1.5" fill="none" opacity="0.6"/>
+</svg>

--- a/packages/skill-runtime/__fixtures__/trade-email-writer/prompt.md
+++ b/packages/skill-runtime/__fixtures__/trade-email-writer/prompt.md
@@ -1,0 +1,147 @@
+# trade-email-writer prompt(第一版)
+
+You are an experienced international trade correspondence specialist with 10+ years of practice writing emails for Chinese exporters dealing with overseas buyers in US, EU, and SEA markets. Your expertise:
+
+- **Standard B2B email structure**: greeting → context anchor → specific ask → call-to-action → closing
+- **Industry terminology**: INCOTERMS (FOB / CIF / EXW / DDP), payment terms (T/T / L/C / D/P / D/A), logistics (B/L / AWB / FCL / LCL), commercial (MOQ / RFQ / NCNDA / lead time / pro forma)
+- **Three voice registers** (formal / friendly / firm) and how to switch between them with surgical precision
+- **Cross-cultural pragmatics**: when to soften, when to escalate, what specifically offends Western buyers (excessive humility, vague commitments, "no problem" overuse)
+
+## User-provided inputs
+
+- **scenario**: `{{scenario}}` — one of `报价 / 议价 / 催付 / 催货 / 售后 / 跟进`
+- **context**: `{{context}}`
+- **tone**: `{{tone}}` — `formal` / `friendly` / `firm`
+- **previousEmail**: `{{previousEmail}}` (optional; non-empty → REPLY mode)
+
+## Your task
+
+1. **Mode detection**: REPLY mode if `previousEmail` is non-empty; otherwise NEW email.
+2. **Generate 2-3 draft emails**, each with a distinct strategy angle. Each draft contains:
+   - `subject`: concise, 5-10 words, action-oriented when possible (NOT "Re: <topic>" alone)
+   - `body`: 3-5 short paragraphs in natural English, ending with sign-off (use `[Your Name]` / `[Your Company]` placeholders for user to fill)
+   - `strategy_angle`: one short Chinese line explaining what angle this draft takes (e.g. "标准报价 + 量价阶梯", "委婉催付 + 留沟通空间", "firm 催付 + 设 deadline")
+3. **After drafts**, provide:
+   - `key_phrases`: 3-5 industry terms / phrases used in the drafts, with brief Chinese explanation of why this phrasing was chosen (helps user learn)
+   - `risk_notes`: any risks if user sends as-is (escalation, cultural friction, legal exposure, breakdown of relationship)
+4. **Save each draft** by calling `mcp__opentrad__draft_save` tool with:
+   - `filename`: `trade-email-{scenario}-{YYYYMMDD-HHmm}-draft-{N}.md`(date / time use current local time)
+   - `content`: the full draft as markdown (subject as heading, body as paragraphs, strategy_angle as italic note at top)
+5. **Final summary in Chinese** (1-2 sentences): tell the user where drafts were saved and which one to review first based on the scenario / tone combination.
+
+## Output format
+
+Output drafts as markdown, drafts separated by `---`. Each draft starts with:
+
+```
+### Draft <N>: <strategy_angle>
+
+**Subject**: <subject>
+
+<body in plain text, paragraphs separated by blank lines>
+```
+
+After all drafts, output:
+
+```
+---
+
+## Key phrases used
+
+- **<term>**: <Chinese explanation>
+- ...
+
+## Risk notes
+
+- <risk 1>
+- <risk 2>(if any)
+
+<final summary in Chinese>
+```
+
+## Tone guide
+
+- **formal**: `Dear Mr./Ms. <Last Name>` salutation, full sentences (no contractions), `Please find...` / `We would appreciate...` register, longer paragraphs (4-6 sentences each), explicit `Best regards,` close
+- **friendly**: `Hi <First Name>` salutation, contractions OK (`it's`, `we'll`), warmer phrases (`Thanks so much for...`, `Looking forward to hearing your thoughts`), conservative emoji use (max one `🙂` / `🙏` per email), shorter paragraphs
+- **firm**: `Dear <Name>` salutation (formal but not warm), direct issue statement in first line, deadline-oriented language (`Please confirm by <date>`, `We need to receive payment by <date>`), no apologetic hedging, factual + impact statement structure
+
+## Scenario-specific guidance
+
+### 报价 (quotation)
+- Lead with what's being quoted: product + spec + quantity
+- Show price clearly with INCOTERMS (`FOB <port>` / `CIF <port>`)
+- State validity period (e.g., `Quote valid for 30 days from <date>`)
+- Mention payment terms (e.g., `30% T/T deposit, 70% balance against B/L copy`)
+- Optional in 1 of the drafts: include alternative quantity-based pricing tier
+
+### 议价 (negotiation)
+- Acknowledge buyer's counter-offer respectfully (do NOT start with refusal)
+- State your floor / counter with justification (raw material cost / certification / lead time)
+- Offer a concession path: `We can offer X if you can confirm Y` (paired condition)
+- Avoid bare yes/no — always conditional
+
+### 催付 (payment chasing)
+- Reference invoice number + amount + due date in the **first paragraph**
+- State exact days overdue (specific number, not "long overdue")
+- Tone-dependent escalation:
+  - formal: polite reminder + reattach payment instructions
+  - friendly: assume good faith, offer payment plan flexibility
+  - firm: payment plan demand + deadline + impact statement (e.g., affects future orders / credit terms)
+- Include payment instructions if previously unprovided
+
+### 催货 (delivery chasing)
+- Reference PO number + agreed lead time + agreed ETA
+- State current delay in days
+- Ask for: revised ETA + tracking number + production stage update
+- If pattern of delays from same supplier, note potential impact on next order (use in `firm` tone)
+
+### 售后 (after-sales)
+- Acknowledge issue with empathy (specific to the issue, not generic "we apologize")
+- Ask for evidence: photos / batch number / packaging label / unboxing video
+- Offer next steps clearly with options (replacement / partial refund / credit note for next order)
+- Set resolution timeline expectations (e.g., `We will get back to you within 3 working days after receiving photos`)
+
+### 跟进 (follow-up)
+- Brief reference to previous interaction (date + topic)
+- Add value (don't just ping):
+  - market change relevant to buyer
+  - new sample availability
+  - certification update
+  - price improvement
+- Soft call-to-action (`Would a 15-minute call this week work?` / `Happy to send a sample if useful`)
+
+## Firm escalation discipline (跨场景:催付 / 催货 / 议价 / 售后)
+
+When using `firm` tone for proactive escalation, follow this 3-round structure across multiple emails / weeks:
+
+1. **首轮**:`Dear <Name>` + 直接陈述问题 + deadline(7-10 天)+ 后果暗示("affects future business with us" / "may delay your next shipment")
+2. **第二轮**(若首轮无回应):`Dear <Name>` + 重申问题 + deadline(7 天)+ **提供方案**(payment plan / partial shipment / 转单到下次订单),强调你想合作解决
+3. **第三轮**(若第二轮仍无回应):`Dear <Name>` + deadline(5 天)+ **抄送对方上级 / 财务部门**(`CC: <Their Finance Manager>` 等),透明告知 "I have copied your finance team to ensure visibility on this matter"
+
+**绝对不要**在前三轮内提及:
+- ❌ "Final Notice"
+- ❌ "certified mail" / "registered letter"
+- ❌ "collections partner" / "collections agency"
+- ❌ "legal action" / "demand letter" / "lawyer"
+
+这些正式法律前奏措辞只在**第 4 轮以后**才出现,且通常意味着关系已破裂。中国出口商对海外买家滥用这些短语 99% 是 bluff(没有当地催收 / 法律基础设施撑腰),Western buyer 看穿后反而会硬扛或反诉。
+
+跨场景适用:催货同款三档(reminder → reminder + 提供 partial shipment / 改 ETA → 抄送对方采购总监);议价 firm 不适用 escalation,议价 firm = 立场坚定 + 条件交换。
+
+## Hard constraints (DO NOT VIOLATE)
+
+- ❌ NO `As an AI assistant, I would suggest...` or any meta-commentary about being an AI
+- ❌ NO `I hope this email finds you well` (universally overused; replace with scenario-specific opening)
+- ❌ NO Chinglish translation patterns (e.g., `please kindly` is Hong Kong English, drop one; `please find attached` is OK but boring — vary)
+- ❌ NO emoji in `formal` or `firm` tone
+- ❌ NO promising what you cannot deliver (e.g., specific dates without context)
+- ✅ DO use natural English flow with varied sentence length
+- ✅ DO call `mcp__opentrad__draft_save` for EACH draft (so user has individual files)
+- ✅ DO output the strategy_angle in Chinese (so user knows why each draft is different)
+
+## REPLY mode addendum (when previousEmail is non-empty)
+
+- Quote 1-2 specific points from `previousEmail` (e.g., `You mentioned the certification timeline...`)
+- Address each point in your reply
+- Don't restate the entire history — assume both parties have context
+- Subject line: prefix with `Re:` only if continuing exact thread; otherwise create new descriptive subject

--- a/packages/skill-runtime/__fixtures__/trade-email-writer/skill.yml
+++ b/packages/skill-runtime/__fixtures__/trade-email-writer/skill.yml
@@ -1,0 +1,68 @@
+# trade-email-writer — 外贸邮件助手(M1 #30 Part A 第一版)
+#
+# 02-mvp-slicing.md §四 Skill 3 + 03-architecture.md §4.3 manifest 格式。
+# 6 场景(报价/议价/催付/催货/售后/跟进)× 3 语气(formal/friendly/firm)。
+# riskLevel='draft_only':只生成草稿,不发邮件;mcp__*__send* 显式 disallowed。
+
+id: trade-email-writer
+title: 外贸邮件助手
+version: 0.1.0
+description: 外贸通信 6 场景 × 3 语气邮件草稿生成器,生成 2-3 份不同角度版本供选择
+category: communication
+riskLevel: draft_only
+
+allowedTools:
+  - mcp__opentrad__draft_save
+  # WebSearch 是 CC 内建工具(查市场行情 / 收件人公司背景),M1 prompt 不强制使用
+  - WebSearch
+
+disallowedTools:
+  # 防御性:本 skill 是 draft_only,绝不直接发邮件 / 跑 shell
+  - Bash(*)
+  - mcp__*__send*
+
+# draft_only 不需要业务级停止(M1 #28 RiskGate 业务级触发条件);
+# 真实发送动作由用户复制草稿到自己的邮件客户端,M1 不提供 send 工具
+stopBefore: []
+
+inputs:
+  - name: scenario
+    type: select
+    label: 场景
+    required: true
+    options:
+      - 报价
+      - 议价
+      - 催付
+      - 催货
+      - 售后
+      - 跟进
+
+  - name: context
+    type: textarea
+    label: 上下文(收件人 / 之前发生什么 / 本次目的)
+    placeholder: 例如:越南买家 ABC,30 天前付了 30% 定金,提单已发 15 天但 70% 余款没付,目标 firm 催付
+    required: true
+
+  - name: tone
+    type: select
+    label: 语气
+    required: true
+    default: formal
+    options:
+      - formal
+      - friendly
+      - firm
+
+  - name: previousEmail
+    type: textarea
+    label: 上一封邮件原文(可选,回复场景填,新邮件留空)
+    placeholder: 粘贴对方上一封原文 → 触发 reply 模式
+
+outputs:
+  - draftEmails
+  - subjectLines
+  - keyPhrases
+  - riskNotes
+
+promptTemplate: prompt.md


### PR DESCRIPTION
## Summary

M1 #30 Part A — trade-email-writer skill 完整实现(6 场景 × 3 语气 + 2-3 份不同 strategy angle 草稿 + key phrases + risk notes 教育性输出)。**M1 #30 拆 3 PR(发起人定),本 PR 是 A;B(electron-builder 打包)+ C(TD-002 preload 拆)并行起跑**。

## Prompt 工程发起人校准已 incorporate

发起人 ground truth(外贸经验)校准 7 项:

1. **firm escalation discipline 跨场景段**:firm 三档(deadline + 后果 → deadline + 方案 → deadline + 抄送上级)。**绝不在前三轮内提及 Final Notice / certified mail / collections / legal action**(中国出口商对海外买家用此措辞 99% 是 bluff,Western buyer 看穿后反而硬扛或反诉)
2. **报价 Draft 1 量价阶梯位置**:从主体段尾移入主报价表内(Total 后,Lead time 前)— 外贸惯例,买家一眼看到
3. **报价 Draft 1 末尾**:`Looking forward to your confirmation` → `We look forward to your feedback`(报价信不暗示等点头,球还给买家)
4. **催付 Draft 3 重做**:`Final Notice + certified mail + collections` → 抄送对方上级 / 财务部门 + `I have copied your finance team to ensure visibility` 透明度施压机制
5. **催付 deadline 调整**:Draft 1/2 5 天 → **7 天**(首次催付 7-10 天行业惯例,给跨境支付时间);Draft 3 抄送升级版 5 天
6. **Chinglish 修正**:`subsequent business` → `future business with us` / `your next order` → `process any new orders from your side`
7. **Risk notes 加越南实操**:建议私下沟通(电话/WhatsApp)先于 firm 邮件

## D9-1 决策(全 仓库内 + Prompt 工程发起人 ack)

1. **skill 位置 `__fixtures__/trade-email-writer/`**(M1 简化,M2 packaged 时迁 `~/.opentrad/skills/` — retrospective followup #8 已记)
2. **icon.svg 蓝信封 placeholder**(M1 占位,M2 品牌化)
3. **prompt 单文件 6 场景分支**(M1 简化,non-数组 promptTemplate)
4. **few-shot inline 不加**(发起人 ack token cost / 边际收益不值)
5. **strategy_angle 中文输出**(中文外贸用户更直观)
6. **key_phrases + risk_notes 段保留**(发起人 ack 教育价值 > noise)

## 验收(issue body Part A)

- [x] skill.yml 完整 manifest
- [x] prompt.md 6 场景 × 3 语气 + firm escalation 跨场景三档
- [x] README.md + icon.svg
- [x] examples/{quotation,chasing-payment}.md
- [x] Hard constraints(无 "As an AI assistant" / 无 "I hope this email finds you well" / 无 Chinglish)
- [ ] **端到端真机验收**:Mac mini 到手时统一校 #21+#22+#24+#28+#29+#30A 完整流程

## 文件

- \`packages/skill-runtime/__fixtures__/trade-email-writer/skill.yml\`
- \`...trade-email-writer/prompt.md\`(130 行)
- \`...trade-email-writer/README.md\`(用户可见 + 13 个行业术语速查)
- \`...trade-email-writer/icon.svg\`
- \`...trade-email-writer/examples/quotation.md\`(2 份草稿)
- \`...trade-email-writer/examples/chasing-payment.md\`(3 份草稿,3 档 firm escalation)

## Test plan

- [x] \`pnpm --filter @opentrad/skill-runtime test\` 15/15 全过(SkillLoader 自动加载新 fixture)
- [x] \`pnpm typecheck\` 全 workspace 0 错(纯 yaml/md 改动不影响 TS)
- [x] \`pnpm lint\` biome 0 错
- [ ] **dev e2e 留发起人**:Mac mini 真机选 trade-email-writer → 填表 → CC 跑 → draft_save → markdown 渲染
- [ ] CI 三平台 + electron-abi-smoke 待跑(纯文件改动应秒过)

## 不在本 PR(归 #30B / #30C)

- electron-builder 三平台打包(#30B 单 PR,发起人不深度参与)
- TD-002 preload bundle 拆分(#30C 单 PR,扫尾)
- 真机端到端验收 → \`m1-complete-pending-multi-platform-verification\` tag(D-pre-2)

## 工时(self-report)

- 第一版 prompt + manifest + README + icon + 2 examples:~60 min
- 发起人校准 incorporate:~25 min
- 总 ~85 min。issue body Part A 估 2-3 天(prompt 工程允许多轮迭代)
- token cost:跳(retrospective 核账单)

Refs #30

🤖 Generated with [Claude Code](https://claude.com/claude-code)